### PR TITLE
chore(frontend): upgrade HeroUI from v3 RC to v3 stable

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -11,8 +11,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@heroui/react": "^3.0.0-rc.1",
-    "@heroui/styles": "^3.0.0-rc.1",
+    "@heroui/react": "^3.0.1",
+    "@heroui/styles": "^3.0.1",
     "@omnicraft/settings-schema": "workspace:^",
     "@omnicraft/sse-events": "workspace:^",
     "@tailwindcss/vite": "^4.2.2",

--- a/bun.lock
+++ b/bun.lock
@@ -47,8 +47,8 @@
       "name": "@omnicraft/frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@heroui/react": "^3.0.0-rc.1",
-        "@heroui/styles": "^3.0.0-rc.1",
+        "@heroui/react": "^3.0.1",
+        "@heroui/styles": "^3.0.1",
         "@omnicraft/settings-schema": "workspace:^",
         "@omnicraft/sse-events": "workspace:^",
         "@tailwindcss/vite": "^4.2.2",
@@ -261,9 +261,9 @@
 
     "@hapi/bourne": ["@hapi/bourne@3.0.0", "https://registry.npmmirror.com/@hapi/bourne/-/bourne-3.0.0.tgz", {}, "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w=="],
 
-    "@heroui/react": ["@heroui/react@3.0.0-rc.1", "https://registry.npmmirror.com/@heroui/react/-/react-3.0.0-rc.1.tgz", { "dependencies": { "@heroui/styles": "3.0.0-rc.1", "@radix-ui/react-avatar": "1.1.11", "@react-aria/i18n": "3.12.16", "@react-aria/ssr": "3.9.10", "@react-aria/utils": "3.33.1", "@react-stately/utils": "3.11.0", "@react-types/color": "3.1.4", "@react-types/shared": "3.33.1", "input-otp": "1.4.2", "react-aria-components": "1.16.0", "tailwind-merge": "3.4.0", "tailwind-variants": "3.2.2" }, "peerDependencies": { "react": ">=19.0.0", "react-dom": ">=19.0.0", "tailwindcss": ">=4.0.0" } }, "sha512-Fzhk7FhYBzx6qESlAqYxIUzfPaLwARZWOeGiURlSWYyvWfkNOx0o/tZOgveFtt/QKdaCbTeV5WxB30rMLzntEA=="],
+    "@heroui/react": ["@heroui/react@3.0.1", "https://registry.npmmirror.com/@heroui/react/-/react-3.0.1.tgz", { "dependencies": { "@heroui/styles": "3.0.1", "@radix-ui/react-avatar": "1.1.11", "@react-aria/i18n": "3.12.16", "@react-aria/ssr": "3.9.10", "@react-aria/utils": "3.33.1", "@react-stately/utils": "3.11.0", "@react-types/color": "3.1.4", "@react-types/shared": "3.33.1", "input-otp": "1.4.2", "react-aria-components": "1.16.0", "tailwind-merge": "3.4.0", "tailwind-variants": "3.2.2" }, "peerDependencies": { "react": ">=19.0.0", "react-dom": ">=19.0.0", "tailwindcss": ">=4.0.0" } }, "sha512-Dx5oku2LPgK1+Uy1KIyVcfqgYTkVCXEII9OuwoKIJe7GW9Lf1xdHpSTwsdDZoNrUl8IvkDjav1ud92OGY/maRA=="],
 
-    "@heroui/styles": ["@heroui/styles@3.0.0-rc.1", "https://registry.npmmirror.com/@heroui/styles/-/styles-3.0.0-rc.1.tgz", { "dependencies": { "tailwind-variants": "3.2.2", "tw-animate-css": "1.4.0" }, "peerDependencies": { "tailwindcss": ">=4.0.0" } }, "sha512-2TJbP5nYhHoOo6GVN83FuTV6K2JiHKLfnrmvNVDagovLM3h4A1D2hr0t8a/PIgDz2oue0shnPwExsUbuPsH+GA=="],
+    "@heroui/styles": ["@heroui/styles@3.0.1", "https://registry.npmmirror.com/@heroui/styles/-/styles-3.0.1.tgz", { "dependencies": { "tailwind-variants": "3.2.2", "tw-animate-css": "1.4.0" }, "peerDependencies": { "tailwindcss": ">=4.0.0" } }, "sha512-ZGXz6nse8713f3uZMNapa8STkiyERgE7P5qOJlWTGnO8qHC+OHCB9TRJOdz1JR+daAhxu68pBO1qdWlzvud1cw=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "https://registry.npmmirror.com/@humanfs/core/-/core-0.19.1.tgz", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 


### PR DESCRIPTION
## Summary

- Upgrade `@heroui/react` and `@heroui/styles` from `3.0.0-rc.1` to `3.0.1` (stable)
- No API changes — all existing component usage is compatible
- TypeScript build and Vite production build verified clean

## Verification

- [x] `tsc -b` passes
- [x] `vite build` succeeds
- [x] All components (Alert, Button, TextArea, Tabs, Skeleton, Spinner, TextField, Select, ToggleButton, ToggleButtonGroup, Toast, CloseButton) use the same v3 compound API

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)