### PR TITLE
chore: upgrade TypeScript from 5.9 to 6.0

### DIFF
--- a/apps/frontend/tsconfig.app.json
+++ b/apps/frontend/tsconfig.app.json
@@ -25,7 +25,6 @@
     "noUncheckedSideEffectImports": true,
 
     /* Path aliases */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/bun.lock
+++ b/bun.lock
@@ -133,7 +133,7 @@
   },
   "catalog": {
     "eslint": "^10.0.2",
-    "typescript": "~5.9.3",
+    "typescript": "^6.0.2",
     "zod": "^4.3.6",
   },
   "packages": {
@@ -1437,7 +1437,7 @@
 
     "type-is": ["type-is@2.0.1", "https://registry.npmmirror.com/type-is/-/type-is-2.0.1.tgz", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "typescript": ["typescript@5.9.3", "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.2", "https://registry.npmmirror.com/typescript/-/typescript-6.0.2.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "typescript-eslint": ["typescript-eslint@8.57.1", "https://registry.npmmirror.com/typescript-eslint/-/typescript-eslint-8.57.1.tgz", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.57.1", "@typescript-eslint/parser": "8.57.1", "@typescript-eslint/typescript-estree": "8.57.1", "@typescript-eslint/utils": "8.57.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "catalog": {
     "eslint": "^10.0.2",
-    "typescript": "~5.9.3",
+    "typescript": "^6.0.2",
     "zod": "^4.3.6"
   }
 }


### PR DESCRIPTION
## Summary
- Upgrade TypeScript from `~5.9.3` to `^6.0.2` in the workspace catalog
- Remove deprecated `baseUrl` option from `apps/frontend/tsconfig.app.json` (deprecated in TS 6.0, will be removed in 7.0). Path aliases continue to work since `paths` resolves relative to the tsconfig location by default.

## Test plan
- [x] `@omnicraft/frontend` build passes
- [x] `@omnicraft/backend` typecheck passes
- [x] `@omnicraft/settings-schema` typecheck passes
- [x] `@omnicraft/sse-events` typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)