### PR TITLE
fix(frontend): use inherited color for markdown links in chat bubbles

### DIFF
--- a/apps/frontend/src/components/MarkdownRenderer/styles.module.css
+++ b/apps/frontend/src/components/MarkdownRenderer/styles.module.css
@@ -122,7 +122,7 @@
 
 /* Links */
 .markdown :global(a) {
-  color: var(--accent);
+  color: inherit;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## Summary
- Fix invisible hyperlinks in chat message bubbles (#32)
- Changed link color from `var(--accent)` to `inherit` in `MarkdownRenderer/styles.module.css`
- Links now inherit the bubble's text color (white on user bubbles, foreground on assistant bubbles) and are distinguished by underline

## Test plan
- [x] Send a URL in a chat message and verify the link is visible in the user bubble (blue background)
- [x] Have the assistant respond with a link and verify it's visible in the assistant bubble
- [x] Test in both light and dark mode

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)