### PR TITLE
feat(frontend): adaptive streaming text speed based on buffer size

### DIFF
--- a/apps/frontend/src/pages/chat/components/MessageList/components/MessageBubble/hooks/useStreamingText.ts
+++ b/apps/frontend/src/pages/chat/components/MessageList/components/MessageBubble/hooks/useStreamingText.ts
@@ -1,6 +1,10 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 
-const CHARS_PER_FRAME = 1;
+/**
+ * Number of frames over which the animation should catch up to the target.
+ * At 60 fps this is roughly 0.5 seconds.
+ */
+const FRAMES_TO_CATCH_UP = 30;
 
 interface UseStreamingTextResult {
   displayedContent: string;
@@ -30,7 +34,12 @@ export function useStreamingText(fullContent: string): UseStreamingTextResult {
 
     const tick = () => {
       setDisplayedLength((prev) => {
-        const next = Math.min(prev + CHARS_PER_FRAME, targetLengthRef.current);
+        const buffer = targetLengthRef.current - prev;
+        const charsThisFrame = Math.max(
+          1,
+          Math.ceil(buffer / FRAMES_TO_CATCH_UP),
+        );
+        const next = Math.min(prev + charsThisFrame, targetLengthRef.current);
         displayedLengthRef.current = next;
         return next;
       });


### PR DESCRIPTION
## Summary
- Replace fixed 1-char-per-frame streaming animation with adaptive speed based on buffer size
- When UI falls behind the LLM output, each frame renders more characters to catch up smoothly
- Formula: `charsPerFrame = max(1, ceil(buffer / 30))` — catches up within ~0.5s at 60fps
- Minimum speed remains 1 character per frame (no change to normal-speed streaming)

## Test Plan
- [x] Send a message and observe streaming — should look similar to before for normal-speed responses
- [x] Send a message that triggers a long response — UI should not fall far behind, catching up smoothly
- [x] Verify no visual "jumps" or jarring transitions during catch-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)