### PR TITLE
feat(backend): add unique id and timestamp to LlmMessage

### DIFF
--- a/apps/backend/src/agent-core/llm-api/types.ts
+++ b/apps/backend/src/agent-core/llm-api/types.ts
@@ -9,21 +9,27 @@ export interface LlmToolCall {
   arguments: string;
 }
 
+/** Common fields shared by all LLM messages. */
+interface LlmMessageBase {
+  id: string;
+  createdAt: number;
+}
+
 /** A message from the user. */
-export interface LlmUserMessage {
+export interface LlmUserMessage extends LlmMessageBase {
   role: 'user';
   content: string;
 }
 
 /** A message from the assistant, optionally containing tool calls. */
-export interface LlmAssistantMessage {
+export interface LlmAssistantMessage extends LlmMessageBase {
   role: 'assistant';
   content: string;
   toolCalls: LlmToolCall[];
 }
 
 /** A tool execution result, linked to a specific tool call. */
-export interface LlmToolResultMessage {
+export interface LlmToolResultMessage extends LlmMessageBase {
   role: 'tool';
   callId: string;
   content: string;

--- a/apps/backend/src/agent-core/llm-api/types.ts
+++ b/apps/backend/src/agent-core/llm-api/types.ts
@@ -13,18 +13,17 @@ export interface LlmToolCall {
 interface LlmMessageBase {
   id: string;
   createdAt: number;
+  content: string;
 }
 
 /** A message from the user. */
 export interface LlmUserMessage extends LlmMessageBase {
   role: 'user';
-  content: string;
 }
 
 /** A message from the assistant, optionally containing tool calls. */
 export interface LlmAssistantMessage extends LlmMessageBase {
   role: 'assistant';
-  content: string;
   toolCalls: LlmToolCall[];
 }
 
@@ -32,7 +31,6 @@ export interface LlmAssistantMessage extends LlmMessageBase {
 export interface LlmToolResultMessage extends LlmMessageBase {
   role: 'tool';
   callId: string;
-  content: string;
 }
 
 /** A single message in the LLM conversation context. */

--- a/apps/backend/src/agent-core/llm-session/llm-session.ts
+++ b/apps/backend/src/agent-core/llm-session/llm-session.ts
@@ -73,7 +73,7 @@ export class LlmSession {
     signal?: AbortSignal,
   ): LlmSessionEventStream {
     yield* this.sendMessages(
-      [{role: 'user', content}],
+      [{id: crypto.randomUUID(), createdAt: Date.now(), role: 'user', content}],
       tools,
       systemPrompt,
       signal,
@@ -94,6 +94,8 @@ export class LlmSession {
     signal?: AbortSignal,
   ): LlmSessionEventStream {
     const toolMessages: LlmMessage[] = results.map((result) => ({
+      id: crypto.randomUUID(),
+      createdAt: Date.now(),
       role: 'tool' as const,
       callId: result.callId,
       content: result.content,
@@ -162,6 +164,7 @@ export class LlmSession {
     });
 
     let textContent = '';
+    let assistantCreatedAt = 0;
     const toolCalls: LlmToolCall[] = [];
     const pendingToolCalls = new Map<string, LlmToolCall>();
 
@@ -208,6 +211,7 @@ export class LlmSession {
           };
           break;
         case 'message-start':
+          assistantCreatedAt = Date.now();
           break;
       }
     }
@@ -217,6 +221,8 @@ export class LlmSession {
     }
 
     const assistantMessage: LlmAssistantMessage = {
+      id: crypto.randomUUID(),
+      createdAt: assistantCreatedAt,
       role: 'assistant',
       content: textContent,
       toolCalls,

--- a/apps/backend/src/services/chat/helpers.ts
+++ b/apps/backend/src/services/chat/helpers.ts
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto';
+
 import type {LlmConfig} from '@/agent-core/llm-api/index.js';
 import {llmApi} from '@/agent-core/llm-api/index.js';
 import {settingsService} from '@/services/settings/index.js';
@@ -28,6 +30,8 @@ export async function generateTitleFromLlm(
     config,
     messages: [
       {
+        id: crypto.randomUUID(),
+        createdAt: Date.now(),
         role: 'user',
         content: [
           'Generate a short title (under 20 characters) for this conversation.',


### PR DESCRIPTION
## Summary
- Add `id` (`crypto.randomUUID()`) and `createdAt` (`Date.now()`) fields to all `LlmMessage` sub-types via a shared `LlmMessageBase` interface
- Generate values at all message creation points in `LlmSession` and `helpers.ts`
- Assistant message timestamp is captured at the `message-start` streaming event to reflect when the LLM began responding

## Test plan
- [x] TypeScript type check passes (`bun run typecheck`)
- [x] ESLint passes (`bun run lint`)
- [x] Verify messages in session snapshots include `id` and `createdAt`
- [x] Verify LLM adapters still work correctly (extra fields are ignored during conversion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)