### PR TITLE
feat(frontend): disable save button in settings when no changes are made

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -17,6 +17,7 @@
     "@omnicraft/sse-events": "workspace:^",
     "@tailwindcss/vite": "^4.2.2",
     "clsx": "^2.1.1",
+    "dequal": "^2.0.3",
     "highlight.js": "^11.11.1",
     "http-status-codes": "^2.3.0",
     "lucide-react": "^0.577.0",

--- a/apps/frontend/src/pages/settings/components/SettingSection/SettingSection.tsx
+++ b/apps/frontend/src/pages/settings/components/SettingSection/SettingSection.tsx
@@ -14,8 +14,15 @@ interface SettingSectionProps {
 }
 
 export function SettingSection({title, fields, children}: SettingSectionProps) {
-  const {values, updateValue, isLoading, loadError, reload} =
-    useSettingValues(fields);
+  const {
+    values,
+    updateValue,
+    isLoading,
+    loadError,
+    isDirty,
+    markSaved,
+    reload,
+  } = useSettingValues(fields);
   const {validationErrors, validate, clearError} = useSettingValidation(fields);
   const {isSaving, save} = useSettingSave(fields);
 
@@ -32,8 +39,11 @@ export function SettingSection({title, fields, children}: SettingSectionProps) {
       toast.danger('Please fix the errors before saving');
       return;
     }
-    await save(values);
-  }, [validate, save, values]);
+    const success = await save(values);
+    if (success) {
+      markSaved(values);
+    }
+  }, [validate, save, values, markSaved]);
 
   const isDisabled = isLoading || isSaving;
 
@@ -43,6 +53,7 @@ export function SettingSection({title, fields, children}: SettingSectionProps) {
       isLoading={isLoading}
       loadError={loadError}
       isSaving={isSaving}
+      isDirty={isDirty}
       onSave={() => {
         void handleSave();
       }}

--- a/apps/frontend/src/pages/settings/components/SettingSection/SettingSection.tsx
+++ b/apps/frontend/src/pages/settings/components/SettingSection/SettingSection.tsx
@@ -41,7 +41,7 @@ export function SettingSection({title, fields, children}: SettingSectionProps) {
     }
     const success = await save(values);
     if (success) {
-      markSaved(values);
+      markSaved();
     }
   }, [validate, save, values, markSaved]);
 

--- a/apps/frontend/src/pages/settings/components/SettingSection/SettingSectionView.tsx
+++ b/apps/frontend/src/pages/settings/components/SettingSection/SettingSectionView.tsx
@@ -12,6 +12,7 @@ interface SettingSectionViewProps {
   isLoading: boolean;
   loadError: boolean;
   isSaving: boolean;
+  isDirty: boolean;
   onSave: () => void;
   onRetry: () => void;
 }
@@ -22,6 +23,7 @@ export function SettingSectionView({
   isLoading,
   loadError,
   isSaving,
+  isDirty,
   onSave,
   onRetry,
 }: SettingSectionViewProps) {
@@ -35,7 +37,11 @@ export function SettingSectionView({
       ) : (
         <>
           <div className={styles.fields}>{children}</div>
-          <Button isPending={isSaving} isDisabled={isSaving} onPress={onSave}>
+          <Button
+            isPending={isSaving}
+            isDisabled={!isDirty || isSaving}
+            onPress={onSave}
+          >
             {({isPending}) => (
               <>
                 {isPending && <Spinner color='current' size='sm' />}

--- a/apps/frontend/src/pages/settings/components/SettingSection/hooks/useSettingSave.ts
+++ b/apps/frontend/src/pages/settings/components/SettingSection/hooks/useSettingSave.ts
@@ -15,8 +15,10 @@ export function useSettingSave(fields: FieldConfig[]) {
         const entries = fields.map(({path}) => ({path, value: values[path]}));
         await putSettingValues(entries);
         toast.success('Settings saved');
+        return true;
       } catch {
         toast.danger('Failed to save settings');
+        return false;
       } finally {
         setIsSaving(false);
       }

--- a/apps/frontend/src/pages/settings/components/SettingSection/hooks/useSettingValues.ts
+++ b/apps/frontend/src/pages/settings/components/SettingSection/hooks/useSettingValues.ts
@@ -39,9 +39,9 @@ export function useSettingValues(fields: FieldConfig[]) {
     setValues((prev) => ({...prev, [fieldPath]: value}));
   }, []);
 
-  const markSaved = useCallback((vals: SettingFieldValues) => {
-    setSavedValues({...vals});
-  }, []);
+  const markSaved = useCallback(() => {
+    setSavedValues(values);
+  }, [values]);
 
   const isDirty = !dequal(values, savedValues);
 

--- a/apps/frontend/src/pages/settings/components/SettingSection/hooks/useSettingValues.ts
+++ b/apps/frontend/src/pages/settings/components/SettingSection/hooks/useSettingValues.ts
@@ -1,3 +1,4 @@
+import {dequal} from 'dequal';
 import {useCallback, useEffect, useState} from 'react';
 
 import {getSettingValue} from '@/api/settings/index.js';
@@ -42,9 +43,7 @@ export function useSettingValues(fields: FieldConfig[]) {
     setSavedValues({...vals});
   }, []);
 
-  const isDirty = Object.keys(savedValues).some(
-    (key) => values[key] !== savedValues[key],
-  );
+  const isDirty = !dequal(values, savedValues);
 
   return {
     values,

--- a/apps/frontend/src/pages/settings/components/SettingSection/hooks/useSettingValues.ts
+++ b/apps/frontend/src/pages/settings/components/SettingSection/hooks/useSettingValues.ts
@@ -6,6 +6,7 @@ import type {FieldConfig, SettingFieldValues} from '../types.js';
 
 export function useSettingValues(fields: FieldConfig[]) {
   const [values, setValues] = useState<SettingFieldValues>({});
+  const [savedValues, setSavedValues] = useState<SettingFieldValues>({});
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
 
@@ -19,7 +20,9 @@ export function useSettingValues(fields: FieldConfig[]) {
           return [path, value] as const;
         }),
       );
-      setValues(Object.fromEntries(results));
+      const loaded = Object.fromEntries(results);
+      setValues(loaded);
+      setSavedValues(loaded);
     } catch {
       setLoadError(true);
     } finally {
@@ -35,5 +38,21 @@ export function useSettingValues(fields: FieldConfig[]) {
     setValues((prev) => ({...prev, [fieldPath]: value}));
   }, []);
 
-  return {values, updateValue, isLoading, loadError, reload: load};
+  const markSaved = useCallback((vals: SettingFieldValues) => {
+    setSavedValues({...vals});
+  }, []);
+
+  const isDirty = Object.keys(savedValues).some(
+    (key) => values[key] !== savedValues[key],
+  );
+
+  return {
+    values,
+    updateValue,
+    isLoading,
+    loadError,
+    isDirty,
+    markSaved,
+    reload: load,
+  };
 }

--- a/apps/frontend/src/pages/settings/sections/file-access/FileAccessSection.tsx
+++ b/apps/frontend/src/pages/settings/sections/file-access/FileAccessSection.tsx
@@ -12,6 +12,7 @@ export function FileAccessSection() {
     isSaving,
     saveError,
     invalidPaths,
+    isDirty,
     save,
     addPath,
     removePath,
@@ -35,6 +36,7 @@ export function FileAccessSection() {
       isSaving={isSaving}
       saveError={saveError}
       invalidPaths={invalidPaths}
+      isDirty={isDirty}
       onAdd={addPath}
       onRemove={removePath}
       onSave={() => {

--- a/apps/frontend/src/pages/settings/sections/file-access/FileAccessSectionView.tsx
+++ b/apps/frontend/src/pages/settings/sections/file-access/FileAccessSectionView.tsx
@@ -16,6 +16,7 @@ interface FileAccessSectionViewProps {
   isSaving: boolean;
   saveError: string | null;
   invalidPaths: InvalidPathEntry[];
+  isDirty: boolean;
   onAdd: (entry: AllowedPathEntry) => void;
   onRemove: (index: number) => void;
   onSave: () => void;
@@ -29,6 +30,7 @@ export function FileAccessSectionView({
   isSaving,
   saveError,
   invalidPaths,
+  isDirty,
   onAdd,
   onRemove,
   onSave,
@@ -66,6 +68,7 @@ export function FileAccessSectionView({
           <SaveFooter
             isSaving={isSaving}
             saveError={saveError}
+            isDirty={isDirty}
             onSave={onSave}
           />
         </>

--- a/apps/frontend/src/pages/settings/sections/file-access/components/SaveFooter/SaveFooter.tsx
+++ b/apps/frontend/src/pages/settings/sections/file-access/components/SaveFooter/SaveFooter.tsx
@@ -5,14 +5,24 @@ import styles from './styles.module.css';
 interface SaveFooterProps {
   isSaving: boolean;
   saveError: string | null;
+  isDirty: boolean;
   onSave: () => void;
 }
 
-export function SaveFooter({isSaving, saveError, onSave}: SaveFooterProps) {
+export function SaveFooter({
+  isSaving,
+  saveError,
+  isDirty,
+  onSave,
+}: SaveFooterProps) {
   return (
     <div className={styles.container}>
       {saveError !== null && <p className={styles.saveError}>{saveError}</p>}
-      <Button isPending={isSaving} isDisabled={isSaving} onPress={onSave}>
+      <Button
+        isPending={isSaving}
+        isDisabled={!isDirty || isSaving}
+        onPress={onSave}
+      >
         {({isPending}) => (
           <>
             {isPending && <Spinner color='current' size='sm' />}

--- a/apps/frontend/src/pages/settings/sections/file-access/hooks/useAllowedPaths.ts
+++ b/apps/frontend/src/pages/settings/sections/file-access/hooks/useAllowedPaths.ts
@@ -10,6 +10,7 @@ import {
 
 export function useAllowedPaths() {
   const [paths, setPaths] = useState<AllowedPathEntry[]>([]);
+  const [savedPaths, setSavedPaths] = useState<AllowedPathEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -22,6 +23,7 @@ export function useAllowedPaths() {
     try {
       const data = await getAllowedPaths();
       setPaths(data);
+      setSavedPaths(data);
     } catch (e) {
       setLoadError(e instanceof Error ? e.message : 'Failed to load');
     } finally {
@@ -66,6 +68,8 @@ export function useAllowedPaths() {
     setInvalidPaths([]);
   }, []);
 
+  const isDirty = JSON.stringify(paths) !== JSON.stringify(savedPaths);
+
   return {
     paths,
     isLoading,
@@ -73,6 +77,7 @@ export function useAllowedPaths() {
     isSaving,
     saveError,
     invalidPaths,
+    isDirty,
     save,
     addPath,
     removePath,

--- a/apps/frontend/src/pages/settings/sections/file-access/hooks/useAllowedPaths.ts
+++ b/apps/frontend/src/pages/settings/sections/file-access/hooks/useAllowedPaths.ts
@@ -1,4 +1,5 @@
 import type {AllowedPathEntry} from '@omnicraft/settings-schema';
+import {dequal} from 'dequal';
 import {useCallback, useEffect, useState} from 'react';
 
 import {
@@ -68,7 +69,7 @@ export function useAllowedPaths() {
     setInvalidPaths([]);
   }, []);
 
-  const isDirty = JSON.stringify(paths) !== JSON.stringify(savedPaths);
+  const isDirty = !dequal(paths, savedPaths);
 
   return {
     paths,

--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,7 @@
         "@omnicraft/sse-events": "workspace:^",
         "@tailwindcss/vite": "^4.2.2",
         "clsx": "^2.1.1",
+        "dequal": "^2.0.3",
         "highlight.js": "^11.11.1",
         "http-status-codes": "^2.3.0",
         "lucide-react": "^0.577.0",


### PR DESCRIPTION
## Summary

- Track dirty state by comparing current form values against last-saved values across all settings pages (LLM, Agent, Search, File Access)
- Save button is disabled by default and only enabled when the user modifies a field
- Button re-disables after successful save or when changes are reverted to match saved state

Closes #68

## Test plan

- [ ] Open Settings > LLM, verify Save button is disabled on load
- [ ] Change a field value, verify Save button becomes enabled
- [ ] Revert the field to its original value, verify Save button disables again
- [ ] Save changes, verify Save button disables after success
- [ ] Repeat for Agent and Search sections
- [ ] Open Settings > File Access, verify Save button is disabled on load
- [ ] Add a path, verify Save button becomes enabled
- [ ] Remove the added path, verify Save button disables again
- [ ] Save changes, verify Save button disables after success

🤖 Generated with [Claude Code](https://claude.com/claude-code)