### PR TITLE
fix(backend): mock SettingsManager in webSearchTool test

### DIFF
--- a/apps/backend/src/agent/tools/web/web-search.test.ts
+++ b/apps/backend/src/agent/tools/web/web-search.test.ts
@@ -1,31 +1,18 @@
-import crypto from 'node:crypto';
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-
-import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 
 import {createMockContext} from '@/agent-core/tool/testing.js';
-import {SettingsManager} from '@/models/settings-manager/index.js';
 
-import {webSearchTool} from './web-search.js';
+vi.mock('@/models/settings-manager/index.js', () => ({
+  SettingsManager: {
+    getInstance: () => ({
+      getAll: () => Promise.resolve({search: {tavilyApiKey: ''}}),
+    }),
+  },
+}));
+
+const {webSearchTool} = await import('./web-search.js');
 
 describe('webSearchTool', () => {
-  let tmpDir: string;
-
-  beforeEach(async () => {
-    tmpDir = path.join(os.tmpdir(), crypto.randomUUID());
-    fs.mkdirSync(tmpDir, {recursive: true});
-    await SettingsManager.create(path.join(tmpDir, 'settings.json'));
-  });
-
-  afterEach(() => {
-    SettingsManager.resetInstanceForTesting();
-    if (fs.existsSync(tmpDir)) {
-      fs.rmSync(tmpDir, {recursive: true, force: true});
-    }
-  });
-
   it('has the correct name', () => {
     expect(webSearchTool.name).toBe('web_search');
   });


### PR DESCRIPTION
## Summary
- Mock `SettingsManager.getInstance()` in `webSearchTool` test instead of using the real `SettingsManager` with the actual settings schema
- Removes tight coupling to `@omnicraft/settings-schema` structure and eliminates unnecessary filesystem setup/teardown

Closes #67

## Test plan
- [x] `webSearchTool` tests pass
- [x] Full backend test suite passes (395 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)