### PR TITLE
feat(frontend): add thinking level selector to chat input

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: dev-server
+description: Use when user asks to start the dev server, run the app locally, or test changes in the browser
+---
+
+# Dev Server
+
+## Prerequisites
+
+Backend requires `apps/backend/.env`. If missing, copy from `.env.example`:
+
+```bash
+cp apps/backend/.env.example apps/backend/.env
+```
+
+## Start
+
+Run from the repo root to start both frontend and backend:
+
+```bash
+bun run dev
+```
+
+- Frontend: http://localhost:5173/
+- Backend: http://localhost:3000/
+
+## Notes
+
+- The root `dev` script runs `bun run --filter './apps/*' dev`, starting all apps in parallel.
+- Frontend dev server (Vite) proxies API requests to the backend.
+- Do not start frontend alone unless explicitly asked — always use the root command.

--- a/apps/frontend/src/pages/chat/ChatPage.tsx
+++ b/apps/frontend/src/pages/chat/ChatPage.tsx
@@ -101,8 +101,8 @@ function ChatPageContent() {
       maxRoundsReached={maxRoundsReached}
       scrollRef={scrollRef}
       sessionId={sessionId}
-      onSend={(content) => {
-        void sendMessage(content);
+      onSend={(content, thinkingLevel) => {
+        void sendMessage(content, thinkingLevel);
         requestAnimationFrame(() => {
           scrollToBottom();
         });

--- a/apps/frontend/src/pages/chat/ChatPageView.tsx
+++ b/apps/frontend/src/pages/chat/ChatPageView.tsx
@@ -1,4 +1,5 @@
 import {ScrollShadow} from '@heroui/react';
+import type {ThinkingLevel} from '@omnicraft/api-schema';
 import type {RefObject} from 'react';
 
 import {ChatAlert} from './components/ChatAlert/index.js';
@@ -18,7 +19,7 @@ interface ChatPageViewProps {
   maxRoundsReached: boolean;
   scrollRef: RefObject<HTMLDivElement | null>;
   sessionId: string | null;
-  onSend: (content: string) => void;
+  onSend: (content: string, thinkingLevel: ThinkingLevel) => void;
   onStop: () => void;
   onNewSession: () => void;
   newSessionDisabled: boolean;

--- a/apps/frontend/src/pages/chat/components/ChatInput/ChatInput.tsx
+++ b/apps/frontend/src/pages/chat/components/ChatInput/ChatInput.tsx
@@ -1,21 +1,24 @@
+import type {ThinkingLevel} from '@omnicraft/api-schema';
 import {useCallback, useState} from 'react';
 
 import {ChatInputView} from './ChatInputView.js';
+import {useThinkingLevel} from './hooks/useThinkingLevel.js';
 
 interface ChatInputProps {
   isStreaming: boolean;
-  onSend: (content: string) => void;
+  onSend: (content: string, thinkingLevel: ThinkingLevel) => void;
   onStop: () => void;
 }
 
 export function ChatInput({isStreaming, onSend, onStop}: ChatInputProps) {
   const [input, setInput] = useState('');
+  const {thinkingLevel, setThinkingLevel} = useThinkingLevel();
 
   const handleSend = useCallback(() => {
     if (!input.trim()) return;
-    onSend(input);
+    onSend(input, thinkingLevel);
     setInput('');
-  }, [input, onSend]);
+  }, [input, thinkingLevel, onSend]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -31,10 +34,12 @@ export function ChatInput({isStreaming, onSend, onStop}: ChatInputProps) {
     <ChatInputView
       input={input}
       isStreaming={isStreaming}
+      thinkingLevel={thinkingLevel}
       onInputChange={setInput}
       onKeyDown={handleKeyDown}
       onSend={handleSend}
       onStop={onStop}
+      onThinkingLevelChange={setThinkingLevel}
     />
   );
 }

--- a/apps/frontend/src/pages/chat/components/ChatInput/ChatInputView.tsx
+++ b/apps/frontend/src/pages/chat/components/ChatInput/ChatInputView.tsx
@@ -1,23 +1,29 @@
 import {Button, TextArea} from '@heroui/react';
+import type {ThinkingLevel} from '@omnicraft/api-schema';
 
+import {ThinkingLevelSelect} from './components/ThinkingLevelSelect/index.js';
 import styles from './styles.module.css';
 
 interface ChatInputViewProps {
   input: string;
   isStreaming: boolean;
+  thinkingLevel: ThinkingLevel;
   onInputChange: (value: string) => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
   onSend: () => void;
   onStop: () => void;
+  onThinkingLevelChange: (level: ThinkingLevel) => void;
 }
 
 export function ChatInputView({
   input,
   isStreaming,
+  thinkingLevel,
   onInputChange,
   onKeyDown,
   onSend,
   onStop,
+  onThinkingLevelChange,
 }: ChatInputViewProps) {
   return (
     <div className={styles.container}>
@@ -32,6 +38,11 @@ export function ChatInputView({
           onInputChange(e.target.value);
         }}
         onKeyDown={onKeyDown}
+      />
+      <ThinkingLevelSelect
+        value={thinkingLevel}
+        isDisabled={isStreaming}
+        onChange={onThinkingLevelChange}
       />
       {isStreaming ? (
         <Button aria-label='Stop generation' variant='danger' onPress={onStop}>

--- a/apps/frontend/src/pages/chat/components/ChatInput/components/ThinkingLevelSelect/ThinkingLevelSelect.tsx
+++ b/apps/frontend/src/pages/chat/components/ChatInput/components/ThinkingLevelSelect/ThinkingLevelSelect.tsx
@@ -1,0 +1,69 @@
+import {ListBox, Select} from '@heroui/react';
+import type {ThinkingLevel} from '@omnicraft/api-schema';
+import {Lightbulb} from 'lucide-react';
+
+import styles from './styles.module.css';
+
+const THINKING_LEVEL_OPTIONS: readonly {
+  id: ThinkingLevel;
+  label: string;
+}[] = [
+  {id: 'none', label: 'None'},
+  {id: 'low', label: 'Low'},
+  {id: 'medium', label: 'Medium'},
+  {id: 'high', label: 'High'},
+];
+
+function getLabel(id: ThinkingLevel): string {
+  return THINKING_LEVEL_OPTIONS.find((o) => o.id === id)?.label ?? 'None';
+}
+
+interface ThinkingLevelSelectProps {
+  value: ThinkingLevel;
+  isDisabled: boolean;
+  onChange: (value: ThinkingLevel) => void;
+}
+
+export function ThinkingLevelSelect({
+  value,
+  isDisabled,
+  onChange,
+}: ThinkingLevelSelectProps) {
+  return (
+    <Select
+      aria-label='Thinking level'
+      className={styles.select}
+      isDisabled={isDisabled}
+      value={value}
+      onChange={(selected) => {
+        if (selected) {
+          onChange(selected as ThinkingLevel);
+        }
+      }}
+    >
+      <Select.Trigger>
+        <Select.Value>
+          <span className={styles.value}>
+            <Lightbulb size={14} />
+            {`Thinking: ${getLabel(value)}`}
+          </span>
+        </Select.Value>
+        <Select.Indicator />
+      </Select.Trigger>
+      <Select.Popover>
+        <ListBox>
+          {THINKING_LEVEL_OPTIONS.map((option) => (
+            <ListBox.Item
+              key={option.id}
+              id={option.id}
+              textValue={option.label}
+            >
+              {option.label}
+              <ListBox.ItemIndicator />
+            </ListBox.Item>
+          ))}
+        </ListBox>
+      </Select.Popover>
+    </Select>
+  );
+}

--- a/apps/frontend/src/pages/chat/components/ChatInput/components/ThinkingLevelSelect/ThinkingLevelSelect.tsx
+++ b/apps/frontend/src/pages/chat/components/ChatInput/components/ThinkingLevelSelect/ThinkingLevelSelect.tsx
@@ -4,19 +4,17 @@ import {Lightbulb} from 'lucide-react';
 
 import styles from './styles.module.css';
 
-const THINKING_LEVEL_OPTIONS: readonly {
-  id: ThinkingLevel;
-  label: string;
-}[] = [
-  {id: 'none', label: 'None'},
-  {id: 'low', label: 'Low'},
-  {id: 'medium', label: 'Medium'},
-  {id: 'high', label: 'High'},
-];
+const THINKING_LEVEL_LABELS: Record<ThinkingLevel, string> = {
+  none: 'None',
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+};
 
-function getLabel(id: ThinkingLevel): string {
-  return THINKING_LEVEL_OPTIONS.find((o) => o.id === id)?.label ?? 'None';
-}
+const THINKING_LEVELS = Object.entries(THINKING_LEVEL_LABELS) as [
+  ThinkingLevel,
+  string,
+][];
 
 interface ThinkingLevelSelectProps {
   value: ThinkingLevel;
@@ -45,20 +43,16 @@ export function ThinkingLevelSelect({
         <Select.Value>
           <span className={styles.value}>
             <Lightbulb size={14} />
-            {`Thinking: ${getLabel(value)}`}
+            {`Thinking: ${THINKING_LEVEL_LABELS[value]}`}
           </span>
         </Select.Value>
         <Select.Indicator />
       </Select.Trigger>
       <Select.Popover>
         <ListBox>
-          {THINKING_LEVEL_OPTIONS.map((option) => (
-            <ListBox.Item
-              key={option.id}
-              id={option.id}
-              textValue={option.label}
-            >
-              {option.label}
+          {THINKING_LEVELS.map(([id, label]) => (
+            <ListBox.Item key={id} id={id} textValue={label}>
+              {label}
               <ListBox.ItemIndicator />
             </ListBox.Item>
           ))}

--- a/apps/frontend/src/pages/chat/components/ChatInput/components/ThinkingLevelSelect/index.ts
+++ b/apps/frontend/src/pages/chat/components/ChatInput/components/ThinkingLevelSelect/index.ts
@@ -1,0 +1,1 @@
+export {ThinkingLevelSelect} from './ThinkingLevelSelect.js';

--- a/apps/frontend/src/pages/chat/components/ChatInput/components/ThinkingLevelSelect/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/ChatInput/components/ThinkingLevelSelect/styles.module.css
@@ -1,0 +1,10 @@
+.select {
+  min-width: fit-content;
+  width: 180px;
+}
+
+.value {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}

--- a/apps/frontend/src/pages/chat/components/ChatInput/hooks/useThinkingLevel.ts
+++ b/apps/frontend/src/pages/chat/components/ChatInput/hooks/useThinkingLevel.ts
@@ -1,0 +1,8 @@
+import type {ThinkingLevel} from '@omnicraft/api-schema';
+import {useState} from 'react';
+
+export function useThinkingLevel() {
+  const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>('none');
+
+  return {thinkingLevel, setThinkingLevel};
+}

--- a/apps/frontend/src/pages/chat/hooks/useStreamChat.ts
+++ b/apps/frontend/src/pages/chat/hooks/useStreamChat.ts
@@ -1,3 +1,4 @@
+import type {ThinkingLevel} from '@omnicraft/api-schema';
 import {useCallback, useRef, useState} from 'react';
 
 import {streamChatCompletion} from '@/api/chat/index.js';
@@ -24,7 +25,7 @@ export function useStreamChat({
   const eventBus = useChatEventBus();
 
   const sendMessage = useCallback(
-    async (content: string) => {
+    async (content: string, thinkingLevel: ThinkingLevel) => {
       if (isStreaming) return;
 
       const trimmed = content.trim();
@@ -48,7 +49,7 @@ export function useStreamChat({
         const stream = streamChatCompletion(
           activeSessionId,
           trimmed,
-          'none',
+          thinkingLevel,
           abortController.signal,
         );
 


### PR DESCRIPTION
## Summary

- Add a `ThinkingLevelSelect` dropdown (with Lightbulb icon) between the textarea and Send button in the chat input area
- Users can choose thinking/reasoning level (None, Low, Medium, High) per message — selection persists across messages
- Thread `thinkingLevel` through the full call chain (`ChatInput` → `ChatPageView` → `useStreamChat` → `streamChatCompletion`), replacing the hardcoded `'none'`
- Select is disabled during streaming, matching the Send button behavior

Closes #83

## Test plan

- [x] Verify the thinking level selector renders between textarea and Send button
- [x] Select different thinking levels and send messages — confirm the correct level is sent to the backend
- [x] Verify the selection persists across messages (choosing "High" stays "High" after sending)
- [x] Verify the selector is disabled during streaming
- [x] Verify "Thinking: Medium" text does not wrap (min-width: fit-content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)