### PR TITLE
feat: distinguish tool execution error from result failure

### DIFF
--- a/apps/backend/src/agent-core/agent/agent.ts
+++ b/apps/backend/src/agent-core/agent/agent.ts
@@ -199,7 +199,7 @@ export abstract class Agent {
           type: 'tool-execute-end' as const,
           callId: toolCall.callId,
           result: result.content,
-          isError: result.isError,
+          status: result.status,
         } satisfies AgentToolExecuteEndEvent;
         toolResults.set(toolCall.callId, {
           callId: toolCall.callId,
@@ -388,12 +388,12 @@ export abstract class Agent {
     availableTools: ReadonlyMap<string, ToolDefinition>,
     onOutput: (chunk: string) => void,
     signal: AbortSignal,
-  ): Promise<{content: string; isError: boolean}> {
+  ): Promise<{content: string; status: 'success' | 'failure' | 'error'}> {
     const tool = availableTools.get(toolCall.toolName);
     if (!tool) {
       return {
         content: `Error: Unknown tool: ${toolCall.toolName}`,
-        isError: true,
+        status: 'error',
       };
     }
 
@@ -411,11 +411,11 @@ export abstract class Agent {
       const parsedArgs: unknown = tool.parameters.parse(
         JSON.parse(toolCall.arguments),
       );
-      const content = await tool.execute(parsedArgs, context, onOutput);
-      return {content, isError: false};
+      const result = await tool.execute(parsedArgs, context, onOutput);
+      return {content: result.content, status: result.status};
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      return {content: `Error: ${message}`, isError: true};
+      return {content: `Error: ${message}`, status: 'error'};
     }
   }
 }

--- a/apps/backend/src/agent-core/agent/agent.ts
+++ b/apps/backend/src/agent-core/agent/agent.ts
@@ -381,7 +381,7 @@ export abstract class Agent {
   }
 
   /**
-   * Executes a single tool call. Returns the result content and whether it errored.
+   * Executes a single tool call. Returns the result content and execution status.
    */
   private async executeTool(
     toolCall: LlmToolCall,

--- a/apps/backend/src/agent-core/agent/types.ts
+++ b/apps/backend/src/agent-core/agent/types.ts
@@ -23,7 +23,7 @@ export interface AgentToolExecuteEndEvent {
   type: 'tool-execute-end';
   callId: string;
   result: string;
-  isError: boolean;
+  status: 'success' | 'failure' | 'error';
 }
 
 /** A new message is starting (user or assistant). */

--- a/apps/backend/src/agent-core/tool/index.ts
+++ b/apps/backend/src/agent-core/tool/index.ts
@@ -3,6 +3,8 @@ export {ToolRegistry} from './tool-registry.js';
 export type {
   ShellState,
   ToolDefinition,
+  ToolExecuteResult,
+  ToolExecuteStatus,
   ToolExecutionContext,
 } from './types.js';
 export type {AllowedPathEntry} from '@omnicraft/settings-schema';

--- a/apps/backend/src/agent-core/tool/load-skill.test.ts
+++ b/apps/backend/src/agent-core/tool/load-skill.test.ts
@@ -40,8 +40,9 @@ describe('loadSkillTool', () => {
       }),
     );
 
-    expect(result).toContain('# Test Skill');
-    expect(result).toContain('Do this.');
+    expect(result.content).toContain('# Test Skill');
+    expect(result.content).toContain('Do this.');
+    expect(result.status).toBe('success');
   });
 
   it('returns error message when skill is not found', async () => {
@@ -50,7 +51,8 @@ describe('loadSkillTool', () => {
       createMockContext(),
     );
 
-    expect(result).toContain('not found');
-    expect(result).toContain('nonexistent');
+    expect(result.content).toContain('not found');
+    expect(result.content).toContain('nonexistent');
+    expect(result.status).toBe('failure');
   });
 });

--- a/apps/backend/src/agent-core/tool/load-skill.ts
+++ b/apps/backend/src/agent-core/tool/load-skill.ts
@@ -1,6 +1,10 @@
 import {z} from 'zod';
 
-import type {ToolDefinition, ToolExecutionContext} from './types.js';
+import type {
+  ToolDefinition,
+  ToolExecuteResult,
+  ToolExecutionContext,
+} from './types.js';
 
 const parameters = z.object({
   name: z.string().describe('Name of the skill to load'),
@@ -16,11 +20,14 @@ export const loadSkillTool: ToolDefinition<typeof parameters> = {
   async execute(
     args: z.infer<typeof parameters>,
     context: ToolExecutionContext,
-  ): Promise<string> {
+  ): Promise<ToolExecuteResult> {
     const skill = context.availableSkills.get(args.name);
     if (!skill) {
-      return `Error: Skill "${args.name}" not found.`;
+      return {
+        content: `Error: Skill "${args.name}" not found.`,
+        status: 'failure',
+      };
     }
-    return skill.getContent();
+    return {content: await skill.getContent(), status: 'success'};
   },
 };

--- a/apps/backend/src/agent-core/tool/testing.ts
+++ b/apps/backend/src/agent-core/tool/testing.ts
@@ -17,7 +17,7 @@ export function createMockTool(name: string): ToolDefinition {
     displayName: `Mock: ${name}`,
     description: `Mock tool: ${name}`,
     parameters: z.object({}),
-    execute: () => Promise.resolve('ok'),
+    execute: () => Promise.resolve({content: 'ok', status: 'success' as const}),
   };
 }
 

--- a/apps/backend/src/agent-core/tool/types.ts
+++ b/apps/backend/src/agent-core/tool/types.ts
@@ -38,13 +38,22 @@ export interface ToolExecutionContext {
   readonly signal: AbortSignal;
 }
 
+/** Status of a tool execution result reported by the tool itself. */
+export type ToolExecuteStatus = 'success' | 'failure';
+
+/** Structured result returned by a tool's execute method. */
+export interface ToolExecuteResult {
+  readonly content: string;
+  readonly status: ToolExecuteStatus;
+}
+
 /**
  * A stateless, singleton tool definition.
  *
  * - `parameters`: Zod schema used for type inference, runtime validation,
  *   and JSON Schema generation for LLM APIs.
  * - `execute`: Receives validated args from the LLM and execution context
- *   from the Agent. Returns a text result.
+ *   from the Agent. Returns a structured result with content and status.
  */
 export interface ToolDefinition<T extends z.ZodType = z.ZodType> {
   readonly name: string;
@@ -56,5 +65,5 @@ export interface ToolDefinition<T extends z.ZodType = z.ZodType> {
     args: z.infer<T>,
     context: ToolExecutionContext,
     onOutput?: (chunk: string) => void,
-  ): Promise<string> | string;
+  ): Promise<ToolExecuteResult> | ToolExecuteResult;
 }

--- a/apps/backend/src/agent/tools/bash/run-command.test.ts
+++ b/apps/backend/src/agent/tools/bash/run-command.test.ts
@@ -36,7 +36,8 @@ describe('runCommandTool', () => {
   describe('output formatting', () => {
     it('returns "(No output)" for silent successful commands', async () => {
       const result = await runCommandTool.execute({command: 'true'}, context);
-      expect(result).toBe('(No output)');
+      expect(result.content).toBe('(No output)');
+      expect(result.status).toBe('success');
     });
 
     it('includes exit code for failed commands', async () => {
@@ -44,7 +45,8 @@ describe('runCommandTool', () => {
         {command: 'exit 42'},
         context,
       );
-      expect(result).toContain('Exit code: 42');
+      expect(result.content).toContain('Exit code: 42');
+      expect(result.status).toBe('failure');
     });
 
     it('includes stderr section when present', async () => {
@@ -52,8 +54,9 @@ describe('runCommandTool', () => {
         {command: 'echo error >&2'},
         context,
       );
-      expect(result).toContain('(stderr)');
-      expect(result).toContain('error');
+      expect(result.content).toContain('(stderr)');
+      expect(result.content).toContain('error');
+      expect(result.status).toBe('success');
     });
 
     it('includes timeout message', async () => {
@@ -61,7 +64,8 @@ describe('runCommandTool', () => {
         {command: 'sleep 30', timeout: 500},
         context,
       );
-      expect(result).toContain('Command timed out');
+      expect(result.content).toContain('Command timed out');
+      expect(result.status).toBe('failure');
     });
 
     it('saves large output to a temp file', async () => {
@@ -69,7 +73,8 @@ describe('runCommandTool', () => {
         {command: 'head -c 41000 /dev/urandom | base64'},
         context,
       );
-      expect(result).toContain('Output saved to file:');
+      expect(result.content).toContain('Output saved to file:');
+      expect(result.status).toBe('success');
     });
   });
 
@@ -87,15 +92,17 @@ describe('runCommandTool', () => {
       await fs.mkdir(subDir);
 
       const result = await runCommandTool.execute({command: 'cd sub'}, context);
-      expect(result).toContain('Working directory:');
-      expect(result).toContain(subDir);
+      expect(result.content).toContain('Working directory:');
+      expect(result.content).toContain(subDir);
+      expect(result.status).toBe('success');
     });
 
     it('resets CWD when command navigates outside workingDirectory', async () => {
       const result = await runCommandTool.execute({command: 'cd /'}, context);
 
       expect(context.shellState.cwd).toBe(tmpDir);
-      expect(result).toContain('Working directory reset to:');
+      expect(result.content).toContain('Working directory reset to:');
+      expect(result.status).toBe('success');
     });
 
     it('uses tracked CWD for subsequent commands', async () => {
@@ -104,7 +111,8 @@ describe('runCommandTool', () => {
 
       await runCommandTool.execute({command: 'cd sub'}, context);
       const result = await runCommandTool.execute({command: 'pwd'}, context);
-      expect(result).toContain(subDir);
+      expect(result.content).toContain(subDir);
+      expect(result.status).toBe('success');
     });
   });
 });

--- a/apps/backend/src/agent/tools/bash/run-command.ts
+++ b/apps/backend/src/agent/tools/bash/run-command.ts
@@ -5,6 +5,7 @@ import {z} from 'zod';
 
 import type {
   ToolDefinition,
+  ToolExecuteResult,
   ToolExecutionContext,
 } from '@/agent-core/tool/index.js';
 import {ShellCommandRunner} from '@/helpers/shell-command-runner.js';
@@ -67,7 +68,7 @@ export const runCommandTool: ToolDefinition<typeof parameters> = {
     args: RunCommandArgs,
     context: ToolExecutionContext,
     onOutput?: (chunk: string) => void,
-  ): Promise<string> {
+  ): Promise<ToolExecuteResult> {
     const {shellState, workingDirectory, signal} = context;
     const timeout = args.timeout ?? DEFAULT_TIMEOUT_MS;
 
@@ -124,9 +125,10 @@ export const runCommandTool: ToolDefinition<typeof parameters> = {
     output = output.trim();
 
     if (!output) {
-      return '(No output)';
+      return {content: '(No output)', status: 'success'};
     }
 
-    return output;
+    const failed = result.timedOut || result.exitCode !== 0;
+    return {content: output, status: failed ? 'failure' : 'success'};
   },
 };

--- a/apps/backend/src/agent/tools/core/get-current-time.test.ts
+++ b/apps/backend/src/agent/tools/core/get-current-time.test.ts
@@ -13,7 +13,8 @@ describe('getCurrentTimeTool', () => {
   it('returns a valid ISO 8601 date string', async () => {
     const result = await getCurrentTimeTool.execute({}, createMockContext());
 
-    expect(new Date(result).toISOString()).toBe(result);
+    expect(result.status).toBe('success');
+    expect(new Date(result.content).toISOString()).toBe(result.content);
   });
 
   it('returns approximately the current time', async () => {
@@ -21,7 +22,7 @@ describe('getCurrentTimeTool', () => {
     const result = await getCurrentTimeTool.execute({}, createMockContext());
     const after = Date.now();
 
-    const resultTime = new Date(result).getTime();
+    const resultTime = new Date(result.content).getTime();
     expect(resultTime).toBeGreaterThanOrEqual(before);
     expect(resultTime).toBeLessThanOrEqual(after);
   });

--- a/apps/backend/src/agent/tools/core/get-current-time.ts
+++ b/apps/backend/src/agent/tools/core/get-current-time.ts
@@ -1,6 +1,9 @@
 import {z} from 'zod';
 
-import type {ToolDefinition} from '@/agent-core/tool/index.js';
+import type {
+  ToolDefinition,
+  ToolExecuteResult,
+} from '@/agent-core/tool/index.js';
 
 const parameters = z.object({});
 
@@ -13,7 +16,7 @@ export const getCurrentTimeTool: ToolDefinition<typeof parameters> = {
     'You do not have access to the current time by default — ' +
     'call this tool whenever the user asks anything that depends on the current date, time, day of week, or timezone.',
   parameters,
-  execute(): string {
-    return new Date().toISOString();
+  execute(): ToolExecuteResult {
+    return {content: new Date().toISOString(), status: 'success'};
   },
 };

--- a/apps/backend/src/agent/tools/file/edit-file.test.ts
+++ b/apps/backend/src/agent/tools/file/edit-file.test.ts
@@ -49,7 +49,8 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain('File edited:');
+      expect(result.content).toContain('File edited:');
+      expect(result.status).toBe('success');
     });
 
     it('replaces a unique string', async () => {
@@ -70,10 +71,11 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain('File edited: test.ts');
-      expect(result).toContain('1 replacement(s)');
-      expect(result).toContain('-const x = 1;');
-      expect(result).toContain('+const x = 42;');
+      expect(result.content).toContain('File edited: test.ts');
+      expect(result.content).toContain('1 replacement(s)');
+      expect(result.content).toContain('-const x = 1;');
+      expect(result.content).toContain('+const x = 42;');
+      expect(result.status).toBe('success');
       const written = await fs.readFile(path.join(tmpDir, 'test.ts'), 'utf-8');
       expect(written).toBe('const x = 42;\nconst y = 2;\n');
     });
@@ -97,7 +99,8 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain('3 replacement(s)');
+      expect(result.content).toContain('3 replacement(s)');
+      expect(result.status).toBe('success');
       const written = await fs.readFile(path.join(tmpDir, 'test.ts'), 'utf-8');
       expect(written).toBe('qux\nbar\nqux\nbaz\nqux\n');
     });
@@ -116,10 +119,11 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain('---');
-      expect(result).toContain('+++');
-      expect(result).toContain('-old line');
-      expect(result).toContain('+new line');
+      expect(result.content).toContain('---');
+      expect(result.content).toContain('+++');
+      expect(result.content).toContain('-old line');
+      expect(result.content).toContain('+new line');
+      expect(result.status).toBe('success');
     });
 
     it('truncates large diffs at 4KB', async () => {
@@ -138,9 +142,10 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain('File edited: big.ts');
-      expect(result).toContain('Diff truncated');
-      expect(result).toContain('Read the file to review');
+      expect(result.content).toContain('File edited: big.ts');
+      expect(result.content).toContain('Diff truncated');
+      expect(result.content).toContain('Read the file to review');
+      expect(result.status).toBe('success');
     });
 
     it('accepts absolute paths within workingDirectory', async () => {
@@ -153,7 +158,8 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain('File edited:');
+      expect(result.content).toContain('File edited:');
+      expect(result.status).toBe('success');
     });
   });
 
@@ -186,7 +192,8 @@ describe('editFileTool', () => {
         extraContext,
       );
 
-      expect(result).toContain('File edited:');
+      expect(result.content).toContain('File edited:');
+      expect(result.status).toBe('success');
       const written = await fs.readFile(filePath, 'utf-8');
       expect(written).toBe('new content');
     });
@@ -206,7 +213,10 @@ describe('editFileTool', () => {
         extraContext,
       );
 
-      expect(result).toContain('Error: Access denied: path is read-only');
+      expect(result.content).toContain(
+        'Error: Access denied: path is read-only',
+      );
+      expect(result.status).toBe('failure');
     });
   });
 
@@ -217,9 +227,10 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain(
+      expect(result.content).toContain(
         'Error: Access denied: path is outside the allowed directories',
       );
+      expect(result.status).toBe('failure');
     });
 
     it('rejects path traversal attacks', async () => {
@@ -228,7 +239,8 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Access denied');
+      expect(result.content).toContain('Error: Access denied');
+      expect(result.status).toBe('failure');
     });
 
     it('returns error for nonexistent file', async () => {
@@ -237,7 +249,8 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: File not found');
+      expect(result.content).toContain('Error: File not found');
+      expect(result.status).toBe('failure');
     });
 
     it('returns error for directories', async () => {
@@ -248,7 +261,8 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Not a file');
+      expect(result.content).toContain('Error: Not a file');
+      expect(result.status).toBe('failure');
     });
 
     it('returns error when oldString not found', async () => {
@@ -265,7 +279,8 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: old string not found');
+      expect(result.content).toContain('Error: old string not found');
+      expect(result.status).toBe('failure');
     });
 
     it('rejects no-op replacement when oldString equals newString', async () => {
@@ -278,7 +293,10 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: oldString and newString are identical');
+      expect(result.content).toContain(
+        'Error: oldString and newString are identical',
+      );
+      expect(result.status).toBe('failure');
     });
 
     it('returns error on multiple matches without replaceAll', async () => {
@@ -295,8 +313,9 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Found 2 matches');
-      expect(result).toContain('replaceAll');
+      expect(result.content).toContain('Error: Found 2 matches');
+      expect(result.content).toContain('replaceAll');
+      expect(result.status).toBe('failure');
     });
 
     it('rejects files exceeding 10MB', async () => {
@@ -310,7 +329,8 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: File exceeds');
+      expect(result.content).toContain('Error: File exceeds');
+      expect(result.status).toBe('failure');
     });
 
     it('rejects editing a file that was not read', async () => {
@@ -321,7 +341,10 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Read the file before modifying it');
+      expect(result.content).toContain(
+        'Error: Read the file before modifying it',
+      );
+      expect(result.status).toBe('failure');
     });
 
     it('rejects editing a file modified since last read', async () => {
@@ -334,7 +357,10 @@ describe('editFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: File has been modified since last read');
+      expect(result.content).toContain(
+        'Error: File has been modified since last read',
+      );
+      expect(result.status).toBe('failure');
     });
   });
 });

--- a/apps/backend/src/agent/tools/file/edit-file.ts
+++ b/apps/backend/src/agent/tools/file/edit-file.ts
@@ -8,6 +8,7 @@ import {z} from 'zod';
 import {FileStatCheckResult} from '@/agent-core/agent/index.js';
 import type {
   ToolDefinition,
+  ToolExecuteResult,
   ToolExecutionContext,
 } from '@/agent-core/tool/index.js';
 
@@ -55,7 +56,7 @@ export const editFileTool: ToolDefinition<typeof parameters> = {
   async execute(
     args: EditFileArgs,
     context: ToolExecutionContext,
-  ): Promise<string> {
+  ): Promise<ToolExecuteResult> {
     const {workingDirectory} = context;
 
     // 1. Resolve path
@@ -69,10 +70,17 @@ export const editFileTool: ToolDefinition<typeof parameters> = {
       context.extraAllowedPaths,
     );
     if (accessResult === AccessCheckResult.ERROR_OUTSIDE_ALLOWED_DIRECTORIES) {
-      return 'Error: Access denied: path is outside the allowed directories';
+      return {
+        content:
+          'Error: Access denied: path is outside the allowed directories',
+        status: 'failure',
+      };
     }
     if (accessResult === AccessCheckResult.ERROR_READ_ONLY) {
-      return 'Error: Access denied: path is read-only';
+      return {
+        content: 'Error: Access denied: path is read-only',
+        status: 'failure',
+      };
     }
 
     // 3. Read file
@@ -80,15 +88,24 @@ export const editFileTool: ToolDefinition<typeof parameters> = {
     try {
       stat = await fs.stat(absolutePath);
     } catch {
-      return `Error: File not found: ${args.filePath}`;
+      return {
+        content: `Error: File not found: ${args.filePath}`,
+        status: 'failure',
+      };
     }
 
     if (!stat.isFile()) {
-      return `Error: Not a file: ${args.filePath}`;
+      return {
+        content: `Error: Not a file: ${args.filePath}`,
+        status: 'failure',
+      };
     }
 
     if (stat.size > MAX_FILE_SIZE) {
-      return `Error: File exceeds ${MAX_FILE_SIZE} byte limit`;
+      return {
+        content: `Error: File exceeds ${MAX_FILE_SIZE} byte limit`,
+        status: 'failure',
+      };
     }
 
     const checkResult = context.fileStatTracker.canModify(
@@ -97,10 +114,17 @@ export const editFileTool: ToolDefinition<typeof parameters> = {
       stat.mtimeMs,
     );
     if (checkResult === FileStatCheckResult.NOT_READ) {
-      return 'Error: Read the file before modifying it';
+      return {
+        content: 'Error: Read the file before modifying it',
+        status: 'failure',
+      };
     }
     if (checkResult === FileStatCheckResult.MODIFIED_SINCE_LAST_READ) {
-      return 'Error: File has been modified since last read. Read the file again before modifying it';
+      return {
+        content:
+          'Error: File has been modified since last read. Read the file again before modifying it',
+        status: 'failure',
+      };
     }
 
     let oldContent: string;
@@ -108,26 +132,35 @@ export const editFileTool: ToolDefinition<typeof parameters> = {
       oldContent = await fs.readFile(absolutePath, 'utf-8');
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      return `Error: ${message}`;
+      return {content: `Error: ${message}`, status: 'failure'};
     }
 
     // 4. Check for no-op replacement
     if (args.oldString === args.newString) {
-      return 'Error: oldString and newString are identical. No changes needed.';
+      return {
+        content:
+          'Error: oldString and newString are identical. No changes needed.',
+        status: 'failure',
+      };
     }
 
     // 5. Count occurrences
     const matchCount = countOccurrences(oldContent, args.oldString);
 
     if (matchCount === 0) {
-      return `Error: old string not found in ${args.filePath}`;
+      return {
+        content: `Error: old string not found in ${args.filePath}`,
+        status: 'failure',
+      };
     }
 
     if (matchCount > 1 && !args.replaceAll) {
-      return (
-        `Error: Found ${matchCount} matches in ${args.filePath}. ` +
-        'Provide more context to make a unique match, or set replaceAll to replace all occurrences.'
-      );
+      return {
+        content:
+          `Error: Found ${matchCount} matches in ${args.filePath}. ` +
+          'Provide more context to make a unique match, or set replaceAll to replace all occurrences.',
+        status: 'failure',
+      };
     }
 
     // 5. Perform replacement
@@ -140,7 +173,7 @@ export const editFileTool: ToolDefinition<typeof parameters> = {
       await fs.writeFile(absolutePath, newContent, 'utf-8');
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      return `Error: ${message}`;
+      return {content: `Error: ${message}`, status: 'failure'};
     }
 
     // Track new file stat
@@ -154,9 +187,12 @@ export const editFileTool: ToolDefinition<typeof parameters> = {
 
     if (Buffer.byteLength(diff) > MAX_DIFF_SIZE) {
       const truncated = diff.slice(0, MAX_DIFF_SIZE);
-      return `${header}\n${truncated}\n... Diff truncated. Read the file to review the modified sections.`;
+      return {
+        content: `${header}\n${truncated}\n... Diff truncated. Read the file to review the modified sections.`,
+        status: 'success',
+      };
     }
 
-    return `${header}\n${diff}`;
+    return {content: `${header}\n${diff}`, status: 'success'};
   },
 };

--- a/apps/backend/src/agent/tools/file/find-files.test.ts
+++ b/apps/backend/src/agent/tools/file/find-files.test.ts
@@ -45,10 +45,11 @@ describe('findFilesTool', () => {
 
       const result = await findFilesTool.execute({pattern: '**/*.ts'}, context);
 
-      expect(result).toContain('Found 2 files');
-      expect(result).toContain('a.ts');
-      expect(result).toContain('b.ts');
-      expect(result).not.toContain('c.js');
+      expect(result.content).toContain('Found 2 files');
+      expect(result.content).toContain('a.ts');
+      expect(result.content).toContain('b.ts');
+      expect(result.content).not.toContain('c.js');
+      expect(result.status).toBe('success');
     });
 
     it('finds files in subdirectories', async () => {
@@ -60,9 +61,10 @@ describe('findFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('Found 2 files');
-      expect(result).toContain('src/foo.ts');
-      expect(result).toContain('src/bar/baz.ts');
+      expect(result.content).toContain('Found 2 files');
+      expect(result.content).toContain('src/foo.ts');
+      expect(result.content).toContain('src/bar/baz.ts');
+      expect(result.status).toBe('success');
     });
 
     it('returns results sorted alphabetically', async () => {
@@ -72,9 +74,10 @@ describe('findFilesTool', () => {
 
       const result = await findFilesTool.execute({pattern: '**/*.ts'}, context);
 
-      const lines = result.split('\n');
+      const lines = result.content.split('\n');
       const filePaths = lines.filter((l) => l.endsWith('.ts'));
       expect(filePaths).toEqual(['a.ts', 'b.ts', 'c.ts']);
+      expect(result.status).toBe('success');
     });
 
     it('matches dotfiles when dot is in pattern', async () => {
@@ -84,9 +87,10 @@ describe('findFilesTool', () => {
 
       const result = await findFilesTool.execute({pattern: '.*'}, context);
 
-      expect(result).toContain('.env');
-      expect(result).toContain('.gitignore');
-      expect(result).not.toContain('readme.md');
+      expect(result.content).toContain('.env');
+      expect(result.content).toContain('.gitignore');
+      expect(result.content).not.toContain('readme.md');
+      expect(result.status).toBe('success');
     });
 
     it('searches within a custom path', async () => {
@@ -98,8 +102,9 @@ describe('findFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('a.ts');
-      expect(result).not.toContain('b.ts');
+      expect(result.content).toContain('a.ts');
+      expect(result.content).not.toContain('b.ts');
+      expect(result.status).toBe('success');
     });
 
     it('searches with an absolute custom path', async () => {
@@ -111,8 +116,9 @@ describe('findFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('a.ts');
-      expect(result).not.toContain('b.ts');
+      expect(result.content).toContain('a.ts');
+      expect(result.content).not.toContain('b.ts');
+      expect(result.status).toBe('success');
     });
 
     it('supports brace expansion (or semantics)', async () => {
@@ -125,9 +131,10 @@ describe('findFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('a.ts');
-      expect(result).toContain('b.tsx');
-      expect(result).not.toContain('c.js');
+      expect(result.content).toContain('a.ts');
+      expect(result.content).toContain('b.tsx');
+      expect(result.content).not.toContain('c.js');
+      expect(result.status).toBe('success');
     });
 
     it('returns no-match message when nothing found', async () => {
@@ -136,7 +143,8 @@ describe('findFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('No files found matching');
+      expect(result.content).toContain('No files found matching');
+      expect(result.status).toBe('success');
     });
 
     it('truncates results exceeding 100 entries', async () => {
@@ -147,9 +155,10 @@ describe('findFilesTool', () => {
 
       const result = await findFilesTool.execute({pattern: '**/*.ts'}, context);
 
-      expect(result).toContain('Found 100+ files');
-      expect(result).toContain('showing first 100');
-      expect(result).toContain('Use a more specific pattern');
+      expect(result.content).toContain('Found 100+ files');
+      expect(result.content).toContain('showing first 100');
+      expect(result.content).toContain('Use a more specific pattern');
+      expect(result.status).toBe('success');
     });
   });
 
@@ -178,7 +187,8 @@ describe('findFilesTool', () => {
         extraContext,
       );
 
-      expect(result).toContain('lib.ts');
+      expect(result.content).toContain('lib.ts');
+      expect(result.status).toBe('success');
     });
 
     it('allows searching in an extra read-write path', async () => {
@@ -195,7 +205,8 @@ describe('findFilesTool', () => {
         extraContext,
       );
 
-      expect(result).toContain('rw.ts');
+      expect(result.content).toContain('rw.ts');
+      expect(result.status).toBe('success');
     });
   });
 
@@ -217,10 +228,11 @@ describe('findFilesTool', () => {
 
       vi.restoreAllMocks();
 
-      expect(result).toContain('search timed out after 30s');
-      expect(result).toContain('Results may be incomplete');
+      expect(result.content).toContain('search timed out after 30s');
+      expect(result.content).toContain('Results may be incomplete');
       // Should have collected at least 1 file before timeout
-      expect(result).toContain('.ts');
+      expect(result.content).toContain('.ts');
+      expect(result.status).toBe('failure');
     });
 
     it('rejects path outside workingDirectory', async () => {
@@ -229,7 +241,8 @@ describe('findFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Access denied');
+      expect(result.content).toContain('Error: Access denied');
+      expect(result.status).toBe('failure');
     });
 
     it('rejects path traversal attacks', async () => {
@@ -238,7 +251,8 @@ describe('findFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Access denied');
+      expect(result.content).toContain('Error: Access denied');
+      expect(result.status).toBe('failure');
     });
 
     it('returns error for nonexistent directory', async () => {
@@ -247,7 +261,8 @@ describe('findFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Directory not found');
+      expect(result.content).toContain('Error: Directory not found');
+      expect(result.status).toBe('failure');
     });
 
     it('returns error when path is a file', async () => {
@@ -258,7 +273,8 @@ describe('findFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Not a directory');
+      expect(result.content).toContain('Error: Not a directory');
+      expect(result.status).toBe('failure');
     });
   });
 });

--- a/apps/backend/src/agent/tools/file/find-files.ts
+++ b/apps/backend/src/agent/tools/file/find-files.ts
@@ -8,6 +8,7 @@ import {z} from 'zod';
 
 import type {
   ToolDefinition,
+  ToolExecuteResult,
   ToolExecutionContext,
 } from '@/agent-core/tool/index.js';
 
@@ -46,7 +47,7 @@ export const findFilesTool: ToolDefinition<typeof parameters> = {
   async execute(
     args: FindFilesArgs,
     context: ToolExecutionContext,
-  ): Promise<string> {
+  ): Promise<ToolExecuteResult> {
     const {workingDirectory} = context;
 
     // 1. Resolve search directory
@@ -60,7 +61,11 @@ export const findFilesTool: ToolDefinition<typeof parameters> = {
       context.extraAllowedPaths,
     );
     if (accessResult === AccessCheckResult.ERROR_OUTSIDE_ALLOWED_DIRECTORIES) {
-      return 'Error: Access denied: path is outside the allowed directories';
+      return {
+        content:
+          'Error: Access denied: path is outside the allowed directories',
+        status: 'failure',
+      };
     }
 
     // 3. Verify directory exists
@@ -68,11 +73,17 @@ export const findFilesTool: ToolDefinition<typeof parameters> = {
     try {
       stat = await fs.stat(searchDir);
     } catch {
-      return `Error: Directory not found: ${args.path}`;
+      return {
+        content: `Error: Directory not found: ${args.path}`,
+        status: 'failure',
+      };
     }
 
     if (!stat.isDirectory()) {
-      return `Error: Not a directory: ${args.path}`;
+      return {
+        content: `Error: Not a directory: ${args.path}`,
+        status: 'failure',
+      };
     }
 
     // 4. Run fast-glob with stream
@@ -101,7 +112,7 @@ export const findFilesTool: ToolDefinition<typeof parameters> = {
     } catch (error: unknown) {
       if (entries.length === 0) {
         const message = error instanceof Error ? error.message : String(error);
-        return `Error: ${message}`;
+        return {content: `Error: ${message}`, status: 'failure'};
       }
     }
 
@@ -113,26 +124,38 @@ export const findFilesTool: ToolDefinition<typeof parameters> = {
     const hitLimit = entries.length >= MAX_RESULTS;
 
     if (entries.length === 0 && timedOut) {
-      return `No files found matching "${args.pattern}" in ${displayPath} (search timed out after 30s).`;
+      return {
+        content: `No files found matching "${args.pattern}" in ${displayPath} (search timed out after 30s).`,
+        status: 'failure',
+      };
     }
 
     if (entries.length === 0) {
-      return `No files found matching "${args.pattern}" in ${displayPath}.`;
+      return {
+        content: `No files found matching "${args.pattern}" in ${displayPath}.`,
+        status: 'success',
+      };
     }
 
     const body = entries.join('\n');
 
     if (timedOut) {
       const header = `Found ${entries.length} files matching "${args.pattern}" in ${displayPath} (search timed out after 30s):`;
-      return `${header}\n${body}\nResults may be incomplete. Use a more specific pattern to narrow down.`;
+      return {
+        content: `${header}\n${body}\nResults may be incomplete. Use a more specific pattern to narrow down.`,
+        status: 'failure',
+      };
     }
 
     if (hitLimit) {
       const header = `Found ${MAX_RESULTS}+ files matching "${args.pattern}" in ${displayPath} (showing first ${MAX_RESULTS}):`;
-      return `${header}\n${body}\nUse a more specific pattern to narrow down.`;
+      return {
+        content: `${header}\n${body}\nUse a more specific pattern to narrow down.`,
+        status: 'success',
+      };
     }
 
     const header = `Found ${entries.length} files matching "${args.pattern}" in ${displayPath}:`;
-    return `${header}\n${body}`;
+    return {content: `${header}\n${body}`, status: 'success'};
   },
 };

--- a/apps/backend/src/agent/tools/file/read-file.test.ts
+++ b/apps/backend/src/agent/tools/file/read-file.test.ts
@@ -45,10 +45,11 @@ describe('readFileTool', () => {
         context,
       );
 
-      expect(result).toContain('File: hello.txt (3 lines)');
-      expect(result).toContain('1\tline1');
-      expect(result).toContain('2\tline2');
-      expect(result).toContain('3\tline3');
+      expect(result.content).toContain('File: hello.txt (3 lines)');
+      expect(result.content).toContain('1\tline1');
+      expect(result.content).toContain('2\tline2');
+      expect(result.content).toContain('3\tline3');
+      expect(result.status).toBe('success');
     });
 
     it('reads partial file with startLine', async () => {
@@ -58,10 +59,11 @@ describe('readFileTool', () => {
         context,
       );
 
-      expect(result).toContain('(5 lines, showing lines 3-5)');
-      expect(result).toContain('3\tc');
-      expect(result).toContain('5\te');
-      expect(result).not.toContain('1\ta');
+      expect(result.content).toContain('(5 lines, showing lines 3-5)');
+      expect(result.content).toContain('3\tc');
+      expect(result.content).toContain('5\te');
+      expect(result.content).not.toContain('1\ta');
+      expect(result.status).toBe('success');
     });
 
     it('reads partial file with startLine and lineCount', async () => {
@@ -71,10 +73,11 @@ describe('readFileTool', () => {
         context,
       );
 
-      expect(result).toContain('(5 lines, showing lines 2-3)');
-      expect(result).toContain('2\tb');
-      expect(result).toContain('3\tc');
-      expect(result).not.toContain('4\td');
+      expect(result.content).toContain('(5 lines, showing lines 2-3)');
+      expect(result.content).toContain('2\tb');
+      expect(result.content).toContain('3\tc');
+      expect(result.content).not.toContain('4\td');
+      expect(result.status).toBe('success');
     });
 
     it('resolves relative paths against workingDirectory', async () => {
@@ -84,15 +87,17 @@ describe('readFileTool', () => {
         context,
       );
 
-      expect(result).toContain('File: sub/file.txt');
-      expect(result).toContain('content');
+      expect(result.content).toContain('File: sub/file.txt');
+      expect(result.content).toContain('content');
+      expect(result.status).toBe('success');
     });
 
     it('accepts absolute paths within workingDirectory', async () => {
       const absPath = await writeFile('abs.txt', 'data');
       const result = await readFileTool.execute({filePath: absPath}, context);
 
-      expect(result).toContain('data');
+      expect(result.content).toContain('data');
+      expect(result.status).toBe('success');
     });
 
     it('right-aligns line numbers', async () => {
@@ -105,8 +110,9 @@ describe('readFileTool', () => {
         context,
       );
 
-      expect(result).toContain('  1\tline1');
-      expect(result).toContain('  2\tline2');
+      expect(result.content).toContain('  1\tline1');
+      expect(result.content).toContain('  2\tline2');
+      expect(result.status).toBe('success');
     });
     it('handles empty file', async () => {
       await writeFile('empty.txt', '');
@@ -115,7 +121,8 @@ describe('readFileTool', () => {
         context,
       );
 
-      expect(result).toContain('File: empty.txt (0 lines)');
+      expect(result.content).toContain('File: empty.txt (0 lines)');
+      expect(result.status).toBe('success');
     });
 
     it('returns empty content when startLine exceeds total lines', async () => {
@@ -125,7 +132,8 @@ describe('readFileTool', () => {
         context,
       );
 
-      expect(result).toContain('(3 lines, showing lines 100-3)');
+      expect(result.content).toContain('(3 lines, showing lines 100-3)');
+      expect(result.status).toBe('success');
     });
 
     it('tracks file stat after successful read', async () => {
@@ -134,12 +142,12 @@ describe('readFileTool', () => {
 
       await readFileTool.execute({filePath: 'tracked.txt'}, context);
 
-      const result = context.fileStatTracker.canModify(
+      const checkResult = context.fileStatTracker.canModify(
         path.join(tmpDir, 'tracked.txt'),
         stat.size,
         stat.mtimeMs,
       );
-      expect(result).toBe('ok');
+      expect(checkResult).toBe('ok');
     });
   });
 
@@ -166,7 +174,8 @@ describe('readFileTool', () => {
 
       const result = await readFileTool.execute({filePath}, extraContext);
 
-      expect(result).toContain('extra content');
+      expect(result.content).toContain('extra content');
+      expect(result.status).toBe('success');
     });
 
     it('allows reading a file in an extra read-write path', async () => {
@@ -181,7 +190,8 @@ describe('readFileTool', () => {
 
       const result = await readFileTool.execute({filePath}, extraContext);
 
-      expect(result).toContain('rw content');
+      expect(result.content).toContain('rw content');
+      expect(result.status).toBe('success');
     });
 
     it('rejects reading a file outside all allowed paths', async () => {
@@ -197,7 +207,8 @@ describe('readFileTool', () => {
 
       const result = await readFileTool.execute({filePath}, extraContext);
 
-      expect(result).toContain('Error: Access denied');
+      expect(result.content).toContain('Error: Access denied');
+      expect(result.status).toBe('failure');
 
       await fs.rm(otherDir, {recursive: true, force: true});
     });
@@ -210,7 +221,8 @@ describe('readFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Access denied');
+      expect(result.content).toContain('Error: Access denied');
+      expect(result.status).toBe('failure');
     });
 
     it('rejects path traversal attacks', async () => {
@@ -219,7 +231,8 @@ describe('readFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Access denied');
+      expect(result.content).toContain('Error: Access denied');
+      expect(result.status).toBe('failure');
     });
 
     it('returns error for nonexistent file', async () => {
@@ -228,14 +241,16 @@ describe('readFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: File not found');
+      expect(result.content).toContain('Error: File not found');
+      expect(result.status).toBe('failure');
     });
 
     it('returns error for directories', async () => {
       await fs.mkdir(path.join(tmpDir, 'adir'));
       const result = await readFileTool.execute({filePath: 'adir'}, context);
 
-      expect(result).toContain('Error: Not a file');
+      expect(result.content).toContain('Error: Not a file');
+      expect(result.status).toBe('failure');
     });
 
     it('returns error for binary files', async () => {
@@ -249,7 +264,8 @@ describe('readFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Binary file detected');
+      expect(result.content).toContain('Error: Binary file detected');
+      expect(result.status).toBe('failure');
     });
 
     it('returns error when result exceeds 32KB', async () => {
@@ -262,9 +278,10 @@ describe('readFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Read result exceeds');
-      expect(result).toContain('byte limit');
-      expect(result).toContain('Use startLine and lineCount');
+      expect(result.content).toContain('Error: Read result exceeds');
+      expect(result.content).toContain('byte limit');
+      expect(result.content).toContain('Use startLine and lineCount');
+      expect(result.status).toBe('failure');
     });
   });
 });

--- a/apps/backend/src/agent/tools/file/read-file.ts
+++ b/apps/backend/src/agent/tools/file/read-file.ts
@@ -6,6 +6,7 @@ import {z} from 'zod';
 
 import type {
   ToolDefinition,
+  ToolExecuteResult,
   ToolExecutionContext,
 } from '@/agent-core/tool/index.js';
 
@@ -54,7 +55,7 @@ export const readFileTool: ToolDefinition<typeof parameters> = {
   async execute(
     args: ReadFileArgs,
     context: ToolExecutionContext,
-  ): Promise<string> {
+  ): Promise<ToolExecuteResult> {
     const {workingDirectory, fileCache} = context;
 
     // 1. Resolve path
@@ -68,7 +69,11 @@ export const readFileTool: ToolDefinition<typeof parameters> = {
       context.extraAllowedPaths,
     );
     if (accessResult === AccessCheckResult.ERROR_OUTSIDE_ALLOWED_DIRECTORIES) {
-      return 'Error: Access denied: path is outside the allowed directories';
+      return {
+        content:
+          'Error: Access denied: path is outside the allowed directories',
+        status: 'failure',
+      };
     }
 
     // 3. Stat
@@ -76,20 +81,32 @@ export const readFileTool: ToolDefinition<typeof parameters> = {
     try {
       stat = await fs.stat(absolutePath);
     } catch {
-      return `Error: File not found: ${args.filePath}`;
+      return {
+        content: `Error: File not found: ${args.filePath}`,
+        status: 'failure',
+      };
     }
 
     if (!stat.isFile()) {
-      return `Error: Not a file: ${args.filePath}`;
+      return {
+        content: `Error: Not a file: ${args.filePath}`,
+        status: 'failure',
+      };
     }
 
     // 4. Binary check
     try {
       if (await isBinaryFile(absolutePath)) {
-        return `Error: Binary file detected: ${args.filePath}. Only text files are supported.`;
+        return {
+          content: `Error: Binary file detected: ${args.filePath}. Only text files are supported.`,
+          status: 'failure',
+        };
       }
     } catch {
-      return `Error: Unable to check if file is binary: ${args.filePath}`;
+      return {
+        content: `Error: Unable to check if file is binary: ${args.filePath}`,
+        status: 'failure',
+      };
     }
 
     // 5–6. Get content and extract lines
@@ -129,13 +146,15 @@ export const readFileTool: ToolDefinition<typeof parameters> = {
       }
     } catch (error: unknown) {
       if (error instanceof ReadSizeLimitError) {
-        return (
-          `Error: ${error.message}. ` +
-          `Use startLine and lineCount to read a smaller portion.`
-        );
+        return {
+          content:
+            `Error: ${error.message}. ` +
+            `Use startLine and lineCount to read a smaller portion.`,
+          status: 'failure',
+        };
       }
       const message = error instanceof Error ? error.message : String(error);
-      return `Error: ${message}`;
+      return {content: `Error: ${message}`, status: 'failure'};
     }
 
     const endLine = args.lineCount
@@ -158,6 +177,6 @@ export const readFileTool: ToolDefinition<typeof parameters> = {
     // 8. Track file stat for modification safety
     context.fileStatTracker.set(absolutePath, stat.size, stat.mtimeMs);
 
-    return `${header}\n${formatted}`;
+    return {content: `${header}\n${formatted}`, status: 'success'};
   },
 };

--- a/apps/backend/src/agent/tools/file/search-files.test.ts
+++ b/apps/backend/src/agent/tools/file/search-files.test.ts
@@ -126,9 +126,10 @@ describe('searchFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('Found 2 matches');
-      expect(result).toContain('a.ts:1: import foo');
-      expect(result).toContain('b.ts:1: import baz');
+      expect(result.content).toContain('Found 2 matches');
+      expect(result.content).toContain('a.ts:1: import foo');
+      expect(result.content).toContain('b.ts:1: import baz');
+      expect(result.status).toBe('success');
     });
 
     it('filters by filePattern', async () => {
@@ -140,8 +141,9 @@ describe('searchFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('a.ts');
-      expect(result).not.toContain('b.js');
+      expect(result.content).toContain('a.ts');
+      expect(result.content).not.toContain('b.js');
+      expect(result.status).toBe('success');
     });
 
     it('searches within a custom path', async () => {
@@ -153,8 +155,9 @@ describe('searchFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('a.ts');
-      expect(result).not.toContain('b.ts');
+      expect(result.content).toContain('a.ts');
+      expect(result.content).not.toContain('b.ts');
+      expect(result.status).toBe('success');
     });
 
     it('returns no-match message when nothing found', async () => {
@@ -162,7 +165,8 @@ describe('searchFilesTool', () => {
 
       const result = await searchFilesTool.execute({pattern: 'xyz'}, context);
 
-      expect(result).toContain('No matches found');
+      expect(result.content).toContain('No matches found');
+      expect(result.status).toBe('success');
     });
 
     it('skips binary files', async () => {
@@ -176,8 +180,9 @@ describe('searchFilesTool', () => {
 
       const result = await searchFilesTool.execute({pattern: 'A'}, context);
 
-      expect(result).toContain('text.ts');
-      expect(result).not.toContain('binary.bin');
+      expect(result.content).toContain('text.ts');
+      expect(result.content).not.toContain('binary.bin');
+      expect(result.status).toBe('success');
     });
 
     it('sorts results by file path', async () => {
@@ -187,10 +192,11 @@ describe('searchFilesTool', () => {
 
       const result = await searchFilesTool.execute({pattern: 'match'}, context);
 
-      const lines = result.split('\n').filter((l) => /:\d+:/.test(l));
+      const lines = result.content.split('\n').filter((l) => /:\d+:/.test(l));
       expect(lines[0]).toContain('a.ts');
       expect(lines[1]).toContain('b.ts');
       expect(lines[2]).toContain('c.ts');
+      expect(result.status).toBe('success');
     });
 
     it('truncates at 100 matches', async () => {
@@ -204,8 +210,9 @@ describe('searchFilesTool', () => {
 
       const result = await searchFilesTool.execute({pattern: 'match'}, context);
 
-      expect(result).toContain('100+');
-      expect(result).toContain('showing first 100');
+      expect(result.content).toContain('100+');
+      expect(result.content).toContain('showing first 100');
+      expect(result.status).toBe('success');
     });
 
     it('returns partial results on timeout', async () => {
@@ -222,7 +229,8 @@ describe('searchFilesTool', () => {
 
       vi.restoreAllMocks();
 
-      expect(result).toContain('timed out after 30s');
+      expect(result.content).toContain('timed out after 30s');
+      expect(result.status).toBe('failure');
     });
   });
 
@@ -233,7 +241,8 @@ describe('searchFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Access denied');
+      expect(result.content).toContain('Error: Access denied');
+      expect(result.status).toBe('failure');
     });
 
     it('returns error for nonexistent directory', async () => {
@@ -242,7 +251,8 @@ describe('searchFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Directory not found');
+      expect(result.content).toContain('Error: Directory not found');
+      expect(result.status).toBe('failure');
     });
 
     it('returns error for invalid regex', async () => {
@@ -250,7 +260,8 @@ describe('searchFilesTool', () => {
 
       const result = await searchFilesTool.execute({pattern: 'a**'}, context);
 
-      expect(result).toContain('Error: Invalid regex pattern');
+      expect(result.content).toContain('Error: Invalid regex pattern');
+      expect(result.status).toBe('failure');
     });
 
     it('rejects unsafe regex patterns', async () => {
@@ -261,7 +272,8 @@ describe('searchFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Regex pattern rejected');
+      expect(result.content).toContain('Error: Regex pattern rejected');
+      expect(result.status).toBe('failure');
     });
 
     it('returns error when path is a file', async () => {
@@ -272,7 +284,8 @@ describe('searchFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Not a directory');
+      expect(result.content).toContain('Error: Not a directory');
+      expect(result.status).toBe('failure');
     });
 
     it('rejects path traversal attacks', async () => {
@@ -281,7 +294,8 @@ describe('searchFilesTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Access denied');
+      expect(result.content).toContain('Error: Access denied');
+      expect(result.status).toBe('failure');
     });
   });
 
@@ -310,8 +324,9 @@ describe('searchFilesTool', () => {
         extraContext,
       );
 
-      expect(result).toContain('lib.ts');
-      expect(result).toContain('findme');
+      expect(result.content).toContain('lib.ts');
+      expect(result.content).toContain('findme');
+      expect(result.status).toBe('success');
     });
 
     it('allows searching in an extra read-write path', async () => {
@@ -328,7 +343,8 @@ describe('searchFilesTool', () => {
         extraContext,
       );
 
-      expect(result).toContain('rw.ts');
+      expect(result.content).toContain('rw.ts');
+      expect(result.status).toBe('success');
     });
   });
 });

--- a/apps/backend/src/agent/tools/file/search-files.ts
+++ b/apps/backend/src/agent/tools/file/search-files.ts
@@ -11,6 +11,7 @@ import {z} from 'zod';
 
 import type {
   ToolDefinition,
+  ToolExecuteResult,
   ToolExecutionContext,
 } from '@/agent-core/tool/index.js';
 
@@ -100,7 +101,7 @@ export const searchFilesTool: ToolDefinition<typeof parameters> = {
   async execute(
     args: SearchFilesArgs,
     context: ToolExecutionContext,
-  ): Promise<string> {
+  ): Promise<ToolExecuteResult> {
     const {workingDirectory} = context;
 
     // 1. Resolve search directory
@@ -114,7 +115,11 @@ export const searchFilesTool: ToolDefinition<typeof parameters> = {
       context.extraAllowedPaths,
     );
     if (accessResult === AccessCheckResult.ERROR_OUTSIDE_ALLOWED_DIRECTORIES) {
-      return 'Error: Access denied: path is outside the allowed directories';
+      return {
+        content:
+          'Error: Access denied: path is outside the allowed directories',
+        status: 'failure',
+      };
     }
 
     // 3. Verify directory exists
@@ -122,16 +127,26 @@ export const searchFilesTool: ToolDefinition<typeof parameters> = {
     try {
       stat = await fs.stat(searchDir);
     } catch {
-      return `Error: Directory not found: ${args.path}`;
+      return {
+        content: `Error: Directory not found: ${args.path}`,
+        status: 'failure',
+      };
     }
 
     if (!stat.isDirectory()) {
-      return `Error: Not a directory: ${args.path}`;
+      return {
+        content: `Error: Not a directory: ${args.path}`,
+        status: 'failure',
+      };
     }
 
     // 4. Compile regex
     if (!isSafeRegex(args.pattern)) {
-      return 'Error: Regex pattern rejected — potential catastrophic backtracking';
+      return {
+        content:
+          'Error: Regex pattern rejected — potential catastrophic backtracking',
+        status: 'failure',
+      };
     }
 
     let regex: RegExp;
@@ -139,7 +154,10 @@ export const searchFilesTool: ToolDefinition<typeof parameters> = {
       regex = new RegExp(args.pattern);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      return `Error: Invalid regex pattern: ${message}`;
+      return {
+        content: `Error: Invalid regex pattern: ${message}`,
+        status: 'failure',
+      };
     }
 
     // 5. Enumerate files and search concurrently
@@ -205,7 +223,7 @@ export const searchFilesTool: ToolDefinition<typeof parameters> = {
     } catch (error: unknown) {
       if (totalMatches === 0) {
         const message = error instanceof Error ? error.message : String(error);
-        return `Error: ${message}`;
+        return {content: `Error: ${message}`, status: 'failure'};
       }
     }
 
@@ -225,11 +243,17 @@ export const searchFilesTool: ToolDefinition<typeof parameters> = {
     const hitLimit = totalMatches >= MAX_MATCHES;
 
     if (totalMatches === 0 && timedOut) {
-      return `No matches found for /${args.pattern}/ in ${displayPath} (search timed out after 30s).`;
+      return {
+        content: `No matches found for /${args.pattern}/ in ${displayPath} (search timed out after 30s).`,
+        status: 'failure',
+      };
     }
 
     if (totalMatches === 0) {
-      return `No matches found for /${args.pattern}/ in ${displayPath}.`;
+      return {
+        content: `No matches found for /${args.pattern}/ in ${displayPath}.`,
+        status: 'success',
+      };
     }
 
     const lines: string[] = [];
@@ -247,15 +271,21 @@ export const searchFilesTool: ToolDefinition<typeof parameters> = {
 
     if (timedOut) {
       const header = `Found ${count} matches for /${args.pattern}/ in ${displayPath} (search timed out after 30s):`;
-      return `${header}\n${body}\nResults may be incomplete. Use a more specific pattern to narrow down.`;
+      return {
+        content: `${header}\n${body}\nResults may be incomplete. Use a more specific pattern to narrow down.`,
+        status: 'failure',
+      };
     }
 
     if (hitLimit) {
       const header = `Found ${MAX_MATCHES}+ matches for /${args.pattern}/ in ${displayPath} (showing first ${MAX_MATCHES}):`;
-      return `${header}\n${body}\nUse a more specific pattern to narrow down.`;
+      return {
+        content: `${header}\n${body}\nUse a more specific pattern to narrow down.`,
+        status: 'success',
+      };
     }
 
     const header = `Found ${count} matches for /${args.pattern}/ in ${displayPath}:`;
-    return `${header}\n${body}`;
+    return {content: `${header}\n${body}`, status: 'success'};
   },
 };

--- a/apps/backend/src/agent/tools/file/write-file.test.ts
+++ b/apps/backend/src/agent/tools/file/write-file.test.ts
@@ -37,8 +37,9 @@ describe('writeFileTool', () => {
         context,
       );
 
-      expect(result).toContain('File written: hello.txt');
-      expect(result).toContain('1 lines');
+      expect(result.content).toContain('File written: hello.txt');
+      expect(result.content).toContain('1 lines');
+      expect(result.status).toBe('success');
       const written = await fs.readFile(
         path.join(tmpDir, 'hello.txt'),
         'utf-8',
@@ -57,7 +58,8 @@ describe('writeFileTool', () => {
         context,
       );
 
-      expect(result).toContain('File written: existing.txt');
+      expect(result.content).toContain('File written: existing.txt');
+      expect(result.status).toBe('success');
       const written = await fs.readFile(filePath, 'utf-8');
       expect(written).toBe('new content');
     });
@@ -68,7 +70,10 @@ describe('writeFileTool', () => {
         context,
       );
 
-      expect(result).toContain('File written: deep/nested/dir/file.txt');
+      expect(result.content).toContain(
+        'File written: deep/nested/dir/file.txt',
+      );
+      expect(result.status).toBe('success');
       const written = await fs.readFile(
         path.join(tmpDir, 'deep/nested/dir/file.txt'),
         'utf-8',
@@ -82,7 +87,8 @@ describe('writeFileTool', () => {
         context,
       );
 
-      expect(result).toContain('3 lines');
+      expect(result.content).toContain('3 lines');
+      expect(result.status).toBe('success');
     });
 
     it('handles empty content', async () => {
@@ -91,8 +97,9 @@ describe('writeFileTool', () => {
         context,
       );
 
-      expect(result).toContain('File written: empty.txt');
-      expect(result).toContain('0 lines');
+      expect(result.content).toContain('File written: empty.txt');
+      expect(result.content).toContain('0 lines');
+      expect(result.status).toBe('success');
     });
 
     it('accepts absolute paths within workingDirectory', async () => {
@@ -102,7 +109,8 @@ describe('writeFileTool', () => {
         context,
       );
 
-      expect(result).toContain('File written:');
+      expect(result.content).toContain('File written:');
+      expect(result.status).toBe('success');
       const written = await fs.readFile(absPath, 'utf-8');
       expect(written).toBe('absolute');
     });
@@ -118,7 +126,8 @@ describe('writeFileTool', () => {
         context,
       );
 
-      expect(result).toContain('File written:');
+      expect(result.content).toContain('File written:');
+      expect(result.status).toBe('success');
     });
   });
 
@@ -146,7 +155,8 @@ describe('writeFileTool', () => {
         extraContext,
       );
 
-      expect(result).toContain('File written:');
+      expect(result.content).toContain('File written:');
+      expect(result.status).toBe('success');
       const written = await fs.readFile(filePath, 'utf-8');
       expect(written).toBe('extra content');
     });
@@ -164,7 +174,10 @@ describe('writeFileTool', () => {
         extraContext,
       );
 
-      expect(result).toContain('Error: Access denied: path is read-only');
+      expect(result.content).toContain(
+        'Error: Access denied: path is read-only',
+      );
+      expect(result.status).toBe('failure');
     });
   });
 
@@ -175,9 +188,10 @@ describe('writeFileTool', () => {
         context,
       );
 
-      expect(result).toContain(
+      expect(result.content).toContain(
         'Error: Access denied: path is outside the allowed directories',
       );
+      expect(result.status).toBe('failure');
     });
 
     it('rejects path traversal attacks', async () => {
@@ -186,7 +200,8 @@ describe('writeFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Access denied');
+      expect(result.content).toContain('Error: Access denied');
+      expect(result.status).toBe('failure');
     });
 
     it('rejects content exceeding 1MB', async () => {
@@ -196,7 +211,8 @@ describe('writeFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Content exceeds');
+      expect(result.content).toContain('Error: Content exceeds');
+      expect(result.status).toBe('failure');
     });
 
     it('rejects overwriting a file that was not read', async () => {
@@ -207,7 +223,10 @@ describe('writeFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: Read the file before modifying it');
+      expect(result.content).toContain(
+        'Error: Read the file before modifying it',
+      );
+      expect(result.status).toBe('failure');
     });
 
     it('rejects overwriting a file modified since last read', async () => {
@@ -221,7 +240,10 @@ describe('writeFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: File has been modified since last read');
+      expect(result.content).toContain(
+        'Error: File has been modified since last read',
+      );
+      expect(result.status).toBe('failure');
     });
 
     it('allows creating a new file without prior read', async () => {
@@ -230,7 +252,8 @@ describe('writeFileTool', () => {
         context,
       );
 
-      expect(result).toContain('File written:');
+      expect(result.content).toContain('File written:');
+      expect(result.status).toBe('success');
     });
 
     it('rejects writing a previously read file that was deleted', async () => {
@@ -245,7 +268,10 @@ describe('writeFileTool', () => {
         context,
       );
 
-      expect(result).toContain('Error: File has been deleted since last read');
+      expect(result.content).toContain(
+        'Error: File has been deleted since last read',
+      );
+      expect(result.status).toBe('failure');
     });
   });
 });

--- a/apps/backend/src/agent/tools/file/write-file.ts
+++ b/apps/backend/src/agent/tools/file/write-file.ts
@@ -7,6 +7,7 @@ import {z} from 'zod';
 import {FileStatCheckResult} from '@/agent-core/agent/index.js';
 import type {
   ToolDefinition,
+  ToolExecuteResult,
   ToolExecutionContext,
 } from '@/agent-core/tool/index.js';
 
@@ -35,12 +36,15 @@ export const writeFileTool: ToolDefinition<typeof parameters> = {
   async execute(
     args: WriteFileArgs,
     context: ToolExecutionContext,
-  ): Promise<string> {
+  ): Promise<ToolExecuteResult> {
     const {workingDirectory} = context;
 
     // 1. Check content size
     if (Buffer.byteLength(args.content) > MAX_CONTENT_SIZE) {
-      return `Error: Content exceeds ${MAX_CONTENT_SIZE} byte limit`;
+      return {
+        content: `Error: Content exceeds ${MAX_CONTENT_SIZE} byte limit`,
+        status: 'failure',
+      };
     }
 
     // 2. Resolve path
@@ -54,10 +58,17 @@ export const writeFileTool: ToolDefinition<typeof parameters> = {
       context.extraAllowedPaths,
     );
     if (accessResult === AccessCheckResult.ERROR_OUTSIDE_ALLOWED_DIRECTORIES) {
-      return 'Error: Access denied: path is outside the allowed directories';
+      return {
+        content:
+          'Error: Access denied: path is outside the allowed directories',
+        status: 'failure',
+      };
     }
     if (accessResult === AccessCheckResult.ERROR_READ_ONLY) {
-      return 'Error: Access denied: path is read-only';
+      return {
+        content: 'Error: Access denied: path is read-only',
+        status: 'failure',
+      };
     }
 
     // 4. Check if file exists — if so, verify it was read first
@@ -75,15 +86,26 @@ export const writeFileTool: ToolDefinition<typeof parameters> = {
         existingStat.mtimeMs,
       );
       if (checkResult === FileStatCheckResult.NOT_READ) {
-        return 'Error: Read the file before modifying it';
+        return {
+          content: 'Error: Read the file before modifying it',
+          status: 'failure',
+        };
       }
       if (checkResult === FileStatCheckResult.MODIFIED_SINCE_LAST_READ) {
-        return 'Error: File has been modified since last read. Read the file again before modifying it';
+        return {
+          content:
+            'Error: File has been modified since last read. Read the file again before modifying it',
+          status: 'failure',
+        };
       }
     } else {
       const checkResult = context.fileStatTracker.canModify(absolutePath, 0, 0);
       if (checkResult === FileStatCheckResult.MODIFIED_SINCE_LAST_READ) {
-        return 'Error: File has been deleted since last read. Verify that the write is still intended after deletion, then retry.';
+        return {
+          content:
+            'Error: File has been deleted since last read. Verify that the write is still intended after deletion, then retry.',
+          status: 'failure',
+        };
       }
     }
 
@@ -95,7 +117,7 @@ export const writeFileTool: ToolDefinition<typeof parameters> = {
       await fs.writeFile(absolutePath, args.content, 'utf-8');
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      return `Error: ${message}`;
+      return {content: `Error: ${message}`, status: 'failure'};
     }
 
     // Track new file stat
@@ -105,6 +127,9 @@ export const writeFileTool: ToolDefinition<typeof parameters> = {
 
     // 7. Count lines and return success
     const lineCount = await countLines(Buffer.from(args.content));
-    return `File written: ${args.filePath} (${lineCount} lines)`;
+    return {
+      content: `File written: ${args.filePath} (${lineCount} lines)`,
+      status: 'success',
+    };
   },
 };

--- a/apps/backend/src/agent/tools/web/web-fetch-raw.test.ts
+++ b/apps/backend/src/agent/tools/web/web-fetch-raw.test.ts
@@ -36,8 +36,9 @@ describe('webFetchRawTool', () => {
         {url: serverUrl(server)},
         createMockContext(),
       );
-      expect(result).toContain('<html>');
-      expect(result).toContain('<h1>Hello World</h1>');
+      expect(result.content).toContain('<html>');
+      expect(result.content).toContain('<h1>Hello World</h1>');
+      expect(result.status).toBe('success');
     });
 
     it('does not add a Title: line header', async () => {
@@ -45,7 +46,8 @@ describe('webFetchRawTool', () => {
         {url: serverUrl(server)},
         createMockContext(),
       );
-      expect(result).not.toMatch(/^Title:/m);
+      expect(result.content).not.toMatch(/^Title:/m);
+      expect(result.status).toBe('success');
     });
   });
 
@@ -67,7 +69,8 @@ describe('webFetchRawTool', () => {
         {url: serverUrl(server)},
         createMockContext(),
       );
-      expect(result).toContain(jsonBody);
+      expect(result.content).toContain(jsonBody);
+      expect(result.status).toBe('success');
     });
   });
 
@@ -77,8 +80,9 @@ describe('webFetchRawTool', () => {
         {url: 'ftp://files.example.com/data'},
         createMockContext(),
       );
-      expect(result).toMatch(/Error/i);
-      expect(result).toContain('ftp:');
+      expect(result.content).toMatch(/Error/i);
+      expect(result.content).toContain('ftp:');
+      expect(result.status).toBe('failure');
     });
   });
 
@@ -102,7 +106,8 @@ describe('webFetchRawTool', () => {
         {url: serverUrl(server)},
         createMockContext(),
       );
-      expect(result).toMatch(/Error/i);
+      expect(result.content).toMatch(/Error/i);
+      expect(result.status).toBe('failure');
     });
   });
 
@@ -117,8 +122,9 @@ describe('webFetchRawTool', () => {
           {url: serverUrl(server)},
           createMockContext(),
         );
-        expect(result).toContain('Content saved to file:');
-        expect(result).toContain('URL:');
+        expect(result.content).toContain('Content saved to file:');
+        expect(result.content).toContain('URL:');
+        expect(result.status).toBe('success');
       } finally {
         await stopServer(server);
       }

--- a/apps/backend/src/agent/tools/web/web-fetch-raw.ts
+++ b/apps/backend/src/agent/tools/web/web-fetch-raw.ts
@@ -2,6 +2,7 @@ import {z} from 'zod';
 
 import type {
   ToolDefinition,
+  ToolExecuteResult,
   ToolExecutionContext,
 } from '@/agent-core/tool/index.js';
 import {writeToTempFile} from '@/helpers/fs.js';
@@ -33,9 +34,9 @@ export const webFetchRawTool: ToolDefinition<typeof parameters> = {
   async execute(
     args: WebFetchRawArgs,
     _context: ToolExecutionContext,
-  ): Promise<string> {
+  ): Promise<ToolExecuteResult> {
     const urlError = validateUrl(args.url);
-    if (urlError) return urlError;
+    if (urlError) return {content: urlError, status: 'failure'};
 
     let body: string;
     try {
@@ -50,7 +51,10 @@ export const webFetchRawTool: ToolDefinition<typeof parameters> = {
       body = result.body;
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      return `Error: Failed to fetch URL: ${message}`;
+      return {
+        content: `Error: Failed to fetch URL: ${message}`,
+        status: 'failure',
+      };
     }
 
     const header = `URL: ${args.url}`;
@@ -61,11 +65,17 @@ export const webFetchRawTool: ToolDefinition<typeof parameters> = {
         filePath = await writeToTempFile(body, '.md');
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
-        return `Error: Failed to save content to temporary file: ${message}`;
+        return {
+          content: `Error: Failed to save content to temporary file: ${message}`,
+          status: 'failure',
+        };
       }
-      return `${header}\nContent saved to file: ${filePath}`;
+      return {
+        content: `${header}\nContent saved to file: ${filePath}`,
+        status: 'success',
+      };
     }
 
-    return `${header}\n\n${body}`;
+    return {content: `${header}\n\n${body}`, status: 'success'};
   },
 };

--- a/apps/backend/src/agent/tools/web/web-fetch.test.ts
+++ b/apps/backend/src/agent/tools/web/web-fetch.test.ts
@@ -53,8 +53,9 @@ describe('webFetchTool', () => {
           {url: serverUrl(server), includeFullPage: false},
           context,
         );
-        expect(result).toContain('URL:');
-        expect(result).toContain('Hello World');
+        expect(result.content).toContain('URL:');
+        expect(result.content).toContain('Hello World');
+        expect(result.status).toBe('success');
       } finally {
         await stopServer(server);
       }
@@ -81,8 +82,9 @@ describe('webFetchTool', () => {
           {url: serverUrl(server), includeFullPage: true},
           context,
         );
-        expect(result).toContain('URL:');
-        expect(result).toContain('Main Content');
+        expect(result.content).toContain('URL:');
+        expect(result.content).toContain('Main Content');
+        expect(result.status).toBe('success');
       } finally {
         await stopServer(server);
       }
@@ -100,10 +102,11 @@ describe('webFetchTool', () => {
           {url: serverUrl(server)},
           context,
         );
-        expect(result).toContain('URL:');
-        expect(result).not.toContain('Title:');
-        expect(result).toContain('"key"');
-        expect(result).toContain('"value"');
+        expect(result.content).toContain('URL:');
+        expect(result.content).not.toContain('Title:');
+        expect(result.content).toContain('"key"');
+        expect(result.content).toContain('"value"');
+        expect(result.status).toBe('success');
       } finally {
         await stopServer(server);
       }
@@ -116,7 +119,8 @@ describe('webFetchTool', () => {
         {url: 'ftp://files.example.com/data'},
         context,
       );
-      expect(result).toContain('ftp:');
+      expect(result.content).toContain('ftp:');
+      expect(result.status).toBe('failure');
     });
 
     it('returns an error for non-text content types', async () => {
@@ -128,7 +132,8 @@ describe('webFetchTool', () => {
           {url: serverUrl(server)},
           context,
         );
-        expect(result).toContain('Unsupported content type');
+        expect(result.content).toContain('Unsupported content type');
+        expect(result.status).toBe('failure');
       } finally {
         await stopServer(server);
       }
@@ -139,7 +144,8 @@ describe('webFetchTool', () => {
         {url: 'http://127.0.0.1:1'},
         context,
       );
-      expect(result).toContain('Failed to fetch URL');
+      expect(result.content).toContain('Failed to fetch URL');
+      expect(result.status).toBe('failure');
     });
   });
 
@@ -155,8 +161,9 @@ describe('webFetchTool', () => {
           {url: serverUrl(server)},
           context,
         );
-        expect(result).toContain('Content saved to file:');
-        expect(result).toContain('URL:');
+        expect(result.content).toContain('Content saved to file:');
+        expect(result.content).toContain('URL:');
+        expect(result.status).toBe('success');
       } finally {
         await stopServer(server);
       }
@@ -174,7 +181,8 @@ describe('webFetchTool', () => {
           {url: serverUrl(server)},
           context,
         );
-        expect(result).toContain('Note: Article extraction failed');
+        expect(result.content).toContain('Note: Article extraction failed');
+        expect(result.status).toBe('success');
       } finally {
         await stopServer(server);
       }

--- a/apps/backend/src/agent/tools/web/web-fetch.ts
+++ b/apps/backend/src/agent/tools/web/web-fetch.ts
@@ -5,6 +5,7 @@ import {z} from 'zod';
 
 import type {
   ToolDefinition,
+  ToolExecuteResult,
   ToolExecutionContext,
 } from '@/agent-core/tool/index.js';
 import {writeToTempFile} from '@/helpers/fs.js';
@@ -99,9 +100,9 @@ export const webFetchTool: ToolDefinition<typeof parameters> = {
   async execute(
     args: WebFetchArgs,
     _context: ToolExecutionContext,
-  ): Promise<string> {
+  ): Promise<ToolExecuteResult> {
     const urlError = validateUrl(args.url);
-    if (urlError) return urlError;
+    if (urlError) return {content: urlError, status: 'failure'};
 
     let body: string;
     let contentType: string;
@@ -118,7 +119,10 @@ export const webFetchTool: ToolDefinition<typeof parameters> = {
       contentType = result.contentType;
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      return `Error: Failed to fetch URL: ${message}`;
+      return {
+        content: `Error: Failed to fetch URL: ${message}`,
+        status: 'failure',
+      };
     }
 
     const includeFullPage = args.includeFullPage ?? false;
@@ -144,16 +148,25 @@ export const webFetchTool: ToolDefinition<typeof parameters> = {
         filePath = await writeToTempFile(content, '.md');
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
-        return `Error: Failed to save content to temporary file: ${message}`;
+        return {
+          content: `Error: Failed to save content to temporary file: ${message}`,
+          status: 'failure',
+        };
       }
-      return formatResponse(
-        args.url,
-        title,
-        `Content saved to file: ${filePath}`,
-        note,
-      );
+      return {
+        content: formatResponse(
+          args.url,
+          title,
+          `Content saved to file: ${filePath}`,
+          note,
+        ),
+        status: 'success',
+      };
     }
 
-    return formatResponse(args.url, title, content, note);
+    return {
+      content: formatResponse(args.url, title, content, note),
+      status: 'success',
+    };
   },
 };

--- a/apps/backend/src/agent/tools/web/web-search.test.ts
+++ b/apps/backend/src/agent/tools/web/web-search.test.ts
@@ -22,7 +22,8 @@ describe('webSearchTool', () => {
       {query: 'test query'},
       createMockContext(),
     );
-    expect(result).toContain('Error:');
-    expect(result).toContain('Tavily API key is not configured');
+    expect(result.content).toContain('Error:');
+    expect(result.content).toContain('Tavily API key is not configured');
+    expect(result.status).toBe('failure');
   });
 });

--- a/apps/backend/src/agent/tools/web/web-search.ts
+++ b/apps/backend/src/agent/tools/web/web-search.ts
@@ -3,6 +3,7 @@ import {z} from 'zod';
 
 import type {
   ToolDefinition,
+  ToolExecuteResult,
   ToolExecutionContext,
 } from '@/agent-core/tool/index.js';
 import {SettingsManager} from '@/models/settings-manager/index.js';
@@ -54,13 +55,17 @@ export const webSearchTool: ToolDefinition<typeof parameters> = {
   async execute(
     args: WebSearchArgs,
     _context: ToolExecutionContext,
-  ): Promise<string> {
+  ): Promise<ToolExecuteResult> {
     // 1. Read API key from settings
     const settings = await SettingsManager.getInstance().getAll();
     const apiKey = settings.search.tavilyApiKey;
 
     if (!apiKey) {
-      return 'Error: Tavily API key is not configured. Set it in Settings > Search.';
+      return {
+        content:
+          'Error: Tavily API key is not configured. Set it in Settings > Search.',
+        status: 'failure',
+      };
     }
 
     // 2. Call Tavily
@@ -74,18 +79,21 @@ export const webSearchTool: ToolDefinition<typeof parameters> = {
       });
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      return `Error: Search failed: ${message}`;
+      return {content: `Error: Search failed: ${message}`, status: 'failure'};
     }
 
     // 3. Format response
     if (response.results.length === 0) {
-      return `No results found for "${args.query}"`;
+      return {
+        content: `No results found for "${args.query}"`,
+        status: 'success',
+      };
     }
 
     const header = `Found ${response.results.length.toString()} results for "${args.query}":`;
     const formatted = response.results
       .map((r, i) => formatResult(i, r))
       .join('\n\n');
-    return `${header}\n\n${formatted}`;
+    return {content: `${header}\n\n${formatted}`, status: 'success'};
   },
 };

--- a/apps/frontend/src/pages/chat/components/MessageList/components/ToolExecutionCard/ToolExecutionCard.tsx
+++ b/apps/frontend/src/pages/chat/components/MessageList/components/ToolExecutionCard/ToolExecutionCard.tsx
@@ -6,7 +6,7 @@ interface ToolExecutionCardProps {
   toolName: string;
   displayName: string;
   arguments: string;
-  status: 'running' | 'done' | 'error';
+  status: 'running' | 'done' | 'failure' | 'error';
   result?: string;
 }
 

--- a/apps/frontend/src/pages/chat/components/MessageList/components/ToolExecutionCard/ToolExecutionCardView.tsx
+++ b/apps/frontend/src/pages/chat/components/MessageList/components/ToolExecutionCard/ToolExecutionCardView.tsx
@@ -1,6 +1,6 @@
 import {Disclosure, ScrollShadow, Spinner} from '@heroui/react';
 import clsx from 'clsx';
-import {CircleCheck, CircleX} from 'lucide-react';
+import {CircleAlert, CircleCheck, CircleX} from 'lucide-react';
 import {useMemo} from 'react';
 
 import styles from './styles.module.css';
@@ -9,7 +9,7 @@ interface ToolExecutionCardViewProps {
   toolName: string;
   displayName: string;
   arguments: string;
-  status: 'running' | 'done' | 'error';
+  status: 'running' | 'done' | 'failure' | 'error';
   result?: string;
   output?: string;
 }
@@ -45,6 +45,12 @@ export function ToolExecutionCardView({
                 size={STATUS_ICON_SIZE}
               />
             )}
+            {status === 'failure' && (
+              <CircleAlert
+                className={styles.statusFailure}
+                size={STATUS_ICON_SIZE}
+              />
+            )}
             {status === 'error' && (
               <CircleX className={styles.statusError} size={STATUS_ICON_SIZE} />
             )}
@@ -75,6 +81,7 @@ export function ToolExecutionCardView({
                 <span className={styles.label}>Result</span>
                 <ScrollShadow
                   className={clsx(styles.pre, {
+                    [styles.preFailure]: status === 'failure',
                     [styles.preError]: status === 'error',
                   })}
                 >

--- a/apps/frontend/src/pages/chat/components/MessageList/components/ToolExecutionCard/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/MessageList/components/ToolExecutionCard/styles.module.css
@@ -31,6 +31,11 @@
   flex-shrink: 0;
 }
 
+.statusFailure {
+  color: var(--warning);
+  flex-shrink: 0;
+}
+
 .statusError {
   color: var(--danger);
   flex-shrink: 0;
@@ -75,6 +80,10 @@
   overflow-y: auto;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.preFailure {
+  color: var(--warning);
 }
 
 .preError {

--- a/apps/frontend/src/pages/chat/components/MessageList/hooks/useMessageList.test.ts
+++ b/apps/frontend/src/pages/chat/components/MessageList/hooks/useMessageList.test.ts
@@ -56,7 +56,7 @@ describe('transformMessages', () => {
           type: 'tool-execution-end',
           callId: 'c1',
           result: 'found it',
-          isError: false,
+          status: 'success',
         },
       },
     ];
@@ -102,7 +102,7 @@ describe('transformMessages', () => {
     ]);
   });
 
-  it('marks tool as error when isError is true', () => {
+  it('marks tool as error when status is error', () => {
     const messages: ChatMessage[] = [
       {
         id: null,
@@ -124,7 +124,7 @@ describe('transformMessages', () => {
           type: 'tool-execution-end',
           callId: 'c1',
           result: 'Error: failed',
-          isError: true,
+          status: 'error',
         },
       },
     ];
@@ -170,7 +170,7 @@ describe('transformMessages', () => {
           type: 'tool-execution-end',
           callId: 'c1',
           result: 'result',
-          isError: false,
+          status: 'success',
         },
       },
       {
@@ -197,7 +197,7 @@ describe('transformMessages', () => {
           type: 'tool-execution-end',
           callId: 'c1',
           result: 'orphan result',
-          isError: false,
+          status: 'success',
         },
       },
     ];

--- a/apps/frontend/src/pages/chat/components/MessageList/hooks/useMessageList.test.ts
+++ b/apps/frontend/src/pages/chat/components/MessageList/hooks/useMessageList.test.ts
@@ -102,6 +102,46 @@ describe('transformMessages', () => {
     ]);
   });
 
+  it('marks tool as failure when status is failure', () => {
+    const messages: ChatMessage[] = [
+      {
+        id: null,
+        createdAt: null,
+        role: 'assistant',
+        content: {
+          type: 'tool-execution-start',
+          callId: 'c1',
+          toolName: 'run_command',
+          displayName: 'Run Command',
+          arguments: '{"command":"exit 1"}',
+        },
+      },
+      {
+        id: null,
+        createdAt: null,
+        role: 'assistant',
+        content: {
+          type: 'tool-execution-end',
+          callId: 'c1',
+          result: 'Exit code: 1',
+          status: 'failure',
+        },
+      },
+    ];
+    const result = transformMessages(messages);
+    expect(result).toEqual([
+      {
+        type: 'tool-execution',
+        callId: 'c1',
+        toolName: 'run_command',
+        displayName: 'Run Command',
+        arguments: '{"command":"exit 1"}',
+        status: 'failure',
+        result: 'Exit code: 1',
+      },
+    ]);
+  });
+
   it('marks tool as error when status is error', () => {
     const messages: ChatMessage[] = [
       {

--- a/apps/frontend/src/pages/chat/components/MessageList/hooks/useMessageList.ts
+++ b/apps/frontend/src/pages/chat/components/MessageList/hooks/useMessageList.ts
@@ -22,7 +22,7 @@ export interface ToolExecutionRenderItem {
   toolName: string;
   displayName: string;
   arguments: string;
-  status: 'running' | 'done' | 'error';
+  status: 'running' | 'done' | 'failure' | 'error';
   result?: string;
 }
 
@@ -36,12 +36,15 @@ export function transformMessages(
   messages: ChatMessage[],
 ): MessageRenderItem[] {
   // First pass: collect tool-execution-end events by callId
-  const endEvents = new Map<string, {result: string; isError: boolean}>();
+  const endEvents = new Map<
+    string,
+    {result: string; status: 'success' | 'failure' | 'error'}
+  >();
   for (const message of messages) {
     if (message.content.type === 'tool-execution-end') {
       endEvents.set(message.content.callId, {
         result: message.content.result,
-        isError: message.content.isError,
+        status: message.content.status,
       });
     }
   }
@@ -79,7 +82,12 @@ export function transformMessages(
             toolName: content.toolName,
             displayName: content.displayName,
             arguments: content.arguments,
-            status: endEvent.isError ? 'error' : 'done',
+            status:
+              endEvent.status === 'success'
+                ? 'done'
+                : endEvent.status === 'failure'
+                  ? 'failure'
+                  : 'error',
             result: endEvent.result,
           });
         } else {

--- a/apps/frontend/src/pages/chat/hooks/useStreamChat.ts
+++ b/apps/frontend/src/pages/chat/hooks/useStreamChat.ts
@@ -72,7 +72,7 @@ export function useStreamChat({
                 type: 'tool-execution-end',
                 callId: event.callId,
                 result: event.result,
-                isError: event.isError,
+                status: event.status,
               });
               break;
             case 'message-start':

--- a/apps/frontend/src/pages/chat/types.ts
+++ b/apps/frontend/src/pages/chat/types.ts
@@ -22,7 +22,7 @@ export interface ToolExecutionEndContent {
   type: 'tool-execution-end';
   callId: string;
   result: string;
-  isError: boolean;
+  status: 'success' | 'failure' | 'error';
 }
 
 /** A single content entry in a chat message. */

--- a/packages/sse-events/src/schema.ts
+++ b/packages/sse-events/src/schema.ts
@@ -24,7 +24,7 @@ export const sseToolExecuteEndEventSchema = z.object({
   type: z.literal('tool-execute-end'),
   callId: z.string(),
   result: z.string(),
-  isError: z.boolean(),
+  status: z.enum(['success', 'failure', 'error']),
 });
 export type SseToolExecuteEndEvent = z.infer<
   typeof sseToolExecuteEndEventSchema


### PR DESCRIPTION
## Summary

- Introduce `ToolExecuteResult` type with `status: 'success' | 'failure'` as the structured return type for all tool `execute` methods, replacing the previous plain `string` return
- Replace the binary `isError: boolean` flag with a three-way `status: 'success' | 'failure' | 'error'` across the agent event → SSE → frontend pipeline
- Add amber CircleAlert icon for `failure` status in the frontend UI, visually distinguishing result-level failures (e.g., timeouts, non-zero exit codes) from execution errors (exceptions) and successes
- Update all 11 tool implementations and their tests to use the new structured result type

## Test plan

- [x] `bun run typecheck` passes on both backend and frontend
- [x] Backend: 27 test files / 395 tests all passing
- [x] Frontend: 5 test files / 68 tests all passing
- [x] ESLint passes on both backend and frontend
- [x] Manual test: run a command that times out → should show amber CircleAlert instead of green checkmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)