### PR TITLE
feat(backend): add model-capacity module for querying model token limits

### DIFF
--- a/apps/backend/src/agent-core/llm-api/claude/stream.ts
+++ b/apps/backend/src/agent-core/llm-api/claude/stream.ts
@@ -44,6 +44,12 @@ export async function* streamClaude(
 
   const thinking = toThinkingConfig(options.thinkingLevel);
   const maxTokens = await modelCapacity.getMaxOutputTokens(options.config);
+  if (thinking?.type === 'enabled') {
+    assert(
+      thinking.budget_tokens < maxTokens,
+      `Thinking budget (${thinking.budget_tokens.toString()}) must be less than max_tokens (${maxTokens.toString()})`,
+    );
+  }
 
   const stream = client.messages.stream(
     {

--- a/apps/backend/src/agent-core/llm-api/claude/stream.ts
+++ b/apps/backend/src/agent-core/llm-api/claude/stream.ts
@@ -43,13 +43,7 @@ export async function* streamClaude(
   }
 
   const thinking = toThinkingConfig(options.thinkingLevel);
-  // budget_tokens must be < max_tokens; clamp in case the fallback is small.
-  const maxOutputTokens = await modelCapacity.getMaxOutputTokens(
-    options.config,
-  );
-  const thinkingBudget =
-    thinking?.type === 'enabled' ? thinking.budget_tokens : 0;
-  const maxTokens = Math.max(maxOutputTokens, thinkingBudget + 1);
+  const maxTokens = await modelCapacity.getMaxOutputTokens(options.config);
 
   const stream = client.messages.stream(
     {

--- a/apps/backend/src/agent-core/llm-api/claude/stream.ts
+++ b/apps/backend/src/agent-core/llm-api/claude/stream.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 
 import Anthropic from '@anthropic-ai/sdk';
 
-import {getClaudeMaxOutputTokens} from '../../model-capacity/claude-capacity.js';
+import {modelCapacity} from '../../model-capacity/index.js';
 import type {LlmCompletionOptions, LlmEventStream, LlmUsage} from '../types.js';
 import {
   addCacheBreakpoint,
@@ -45,7 +45,9 @@ export async function* streamClaude(
   const thinking = toThinkingConfig(options.thinkingLevel);
   // Use the model's actual max output tokens instead of a hardcoded value.
   // Math.max ensures budget_tokens < max_tokens even if the fallback is small.
-  const maxOutputTokens = await getClaudeMaxOutputTokens(options.config);
+  const maxOutputTokens = await modelCapacity.getMaxOutputTokens(
+    options.config,
+  );
   const thinkingBudget =
     thinking?.type === 'enabled' ? thinking.budget_tokens : 0;
   const maxTokens = Math.max(maxOutputTokens, thinkingBudget + 1);

--- a/apps/backend/src/agent-core/llm-api/claude/stream.ts
+++ b/apps/backend/src/agent-core/llm-api/claude/stream.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 
 import Anthropic from '@anthropic-ai/sdk';
 
+import {getClaudeMaxOutputTokens} from '../../model-capacity/claude-capacity.js';
 import type {LlmCompletionOptions, LlmEventStream, LlmUsage} from '../types.js';
 import {
   addCacheBreakpoint,
@@ -42,10 +43,12 @@ export async function* streamClaude(
   }
 
   const thinking = toThinkingConfig(options.thinkingLevel);
-  // budget_tokens must be < max_tokens. Ensure max_tokens accommodates the
-  // thinking budget plus room for the actual response.
-  const maxTokens =
-    thinking?.type === 'enabled' ? thinking.budget_tokens + 4096 : 4096;
+  // Use the model's actual max output tokens instead of a hardcoded value.
+  // Math.max ensures budget_tokens < max_tokens even if the fallback is small.
+  const maxOutputTokens = await getClaudeMaxOutputTokens(options.config);
+  const thinkingBudget =
+    thinking?.type === 'enabled' ? thinking.budget_tokens : 0;
+  const maxTokens = Math.max(maxOutputTokens, thinkingBudget + 1);
 
   const stream = client.messages.stream(
     {

--- a/apps/backend/src/agent-core/llm-api/claude/stream.ts
+++ b/apps/backend/src/agent-core/llm-api/claude/stream.ts
@@ -43,8 +43,7 @@ export async function* streamClaude(
   }
 
   const thinking = toThinkingConfig(options.thinkingLevel);
-  // Use the model's actual max output tokens instead of a hardcoded value.
-  // Math.max ensures budget_tokens < max_tokens even if the fallback is small.
+  // budget_tokens must be < max_tokens; clamp in case the fallback is small.
   const maxOutputTokens = await modelCapacity.getMaxOutputTokens(
     options.config,
   );

--- a/apps/backend/src/agent-core/llm-api/openai-responses/stream.ts
+++ b/apps/backend/src/agent-core/llm-api/openai-responses/stream.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 
 import OpenAIClient from 'openai';
 
+import {getOpenAIMaxOutputTokens} from '../../model-capacity/openai-capacity.js';
 import type {
   LlmCompletionOptions,
   LlmEventStream,
@@ -23,10 +24,12 @@ export async function* streamOpenAIResponses(
   const input = toInputItems(messages);
   const tools = options.tools.map(toFunctionTool);
   const reasoning = toReasoning(options.thinkingLevel);
+  const maxOutputTokens = getOpenAIMaxOutputTokens(options.config);
 
   const stream = await client.responses.create(
     {
       model: config.model,
+      max_output_tokens: maxOutputTokens,
       input,
       stream: true,
       store: false,

--- a/apps/backend/src/agent-core/llm-api/openai-responses/stream.ts
+++ b/apps/backend/src/agent-core/llm-api/openai-responses/stream.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 
 import OpenAIClient from 'openai';
 
-import {getOpenAIMaxOutputTokens} from '../../model-capacity/openai-capacity.js';
+import {modelCapacity} from '../../model-capacity/index.js';
 import type {
   LlmCompletionOptions,
   LlmEventStream,
@@ -24,7 +24,9 @@ export async function* streamOpenAIResponses(
   const input = toInputItems(messages);
   const tools = options.tools.map(toFunctionTool);
   const reasoning = toReasoning(options.thinkingLevel);
-  const maxOutputTokens = getOpenAIMaxOutputTokens(options.config);
+  const maxOutputTokens = await modelCapacity.getMaxOutputTokens(
+    options.config,
+  );
 
   const stream = await client.responses.create(
     {

--- a/apps/backend/src/agent-core/llm-api/openai/stream.ts
+++ b/apps/backend/src/agent-core/llm-api/openai/stream.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert';
 import type OpenAI from 'openai';
 import OpenAIClient from 'openai';
 
+import {getOpenAIMaxOutputTokens} from '../../model-capacity/openai-capacity.js';
 import type {LlmCompletionOptions, LlmEventStream} from '../types.js';
 import {toOpenAITool, toReasoningEffort, toSdkMessage} from './helpers.js';
 
@@ -25,10 +26,12 @@ export async function* streamOpenAI(
 
   const openaiTools = options.tools.map(toOpenAITool);
   const reasoningEffort = toReasoningEffort(options.thinkingLevel);
+  const maxOutputTokens = getOpenAIMaxOutputTokens(options.config);
 
   const stream = await client.chat.completions.create(
     {
       model: config.model,
+      max_completion_tokens: maxOutputTokens,
       messages: sdkMessages,
       stream: true,
       stream_options: {include_usage: true},

--- a/apps/backend/src/agent-core/llm-api/openai/stream.ts
+++ b/apps/backend/src/agent-core/llm-api/openai/stream.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import type OpenAI from 'openai';
 import OpenAIClient from 'openai';
 
-import {getOpenAIMaxOutputTokens} from '../../model-capacity/openai-capacity.js';
+import {modelCapacity} from '../../model-capacity/index.js';
 import type {LlmCompletionOptions, LlmEventStream} from '../types.js';
 import {toOpenAITool, toReasoningEffort, toSdkMessage} from './helpers.js';
 
@@ -26,7 +26,9 @@ export async function* streamOpenAI(
 
   const openaiTools = options.tools.map(toOpenAITool);
   const reasoningEffort = toReasoningEffort(options.thinkingLevel);
-  const maxOutputTokens = getOpenAIMaxOutputTokens(options.config);
+  const maxOutputTokens = await modelCapacity.getMaxOutputTokens(
+    options.config,
+  );
 
   const stream = await client.chat.completions.create(
     {

--- a/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
+++ b/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
@@ -1,0 +1,63 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+import type {LlmConfig} from '../llm-api/types.js';
+
+const DEFAULT_MAX_OUTPUT_TOKENS = 16_384;
+const DEFAULT_MAX_INPUT_TOKENS = 200_000;
+
+interface CachedCapacity {
+  maxOutputTokens: number;
+  maxInputTokens: number;
+}
+
+/** Module-level cache keyed by `${baseUrl}::${model}`. */
+const cache = new Map<string, CachedCapacity>();
+
+function cacheKey(config: Readonly<LlmConfig>): string {
+  return `${config.baseUrl}::${config.model}`;
+}
+
+/** Queries the Anthropic Models API and caches the result. */
+async function resolve(config: Readonly<LlmConfig>): Promise<CachedCapacity> {
+  const key = cacheKey(config);
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  try {
+    const client = new Anthropic({
+      apiKey: config.apiKey,
+      baseURL: config.baseUrl,
+    });
+    const model = await client.models.retrieve(config.model);
+    const capacity: CachedCapacity = {
+      maxOutputTokens: model.max_tokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+      maxInputTokens: model.max_input_tokens ?? DEFAULT_MAX_INPUT_TOKENS,
+    };
+    cache.set(key, capacity);
+    return capacity;
+  } catch {
+    // Proxy may not support /v1/models — fall back to safe defaults.
+    const fallback: CachedCapacity = {
+      maxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
+      maxInputTokens: DEFAULT_MAX_INPUT_TOKENS,
+    };
+    cache.set(key, fallback);
+    return fallback;
+  }
+}
+
+/** Returns the max output tokens for a Claude model. */
+export async function getClaudeMaxOutputTokens(
+  config: Readonly<LlmConfig>,
+): Promise<number> {
+  const capacity = await resolve(config);
+  return capacity.maxOutputTokens;
+}
+
+/** Returns the max input tokens (context window) for a Claude model. */
+export async function getClaudeMaxInputTokens(
+  config: Readonly<LlmConfig>,
+): Promise<number> {
+  const capacity = await resolve(config);
+  return capacity.maxInputTokens;
+}

--- a/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
+++ b/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
@@ -7,6 +7,20 @@ import type {LlmConfig} from '../llm-api/types.js';
 const DEFAULT_MAX_OUTPUT_TOKENS = 16_384;
 const DEFAULT_MAX_INPUT_TOKENS = 200_000;
 
+/**
+ * Known Claude model capacities. Checked before the SDK call so that
+ * proxies that don't implement `/v1/models/{id}` still get correct limits.
+ */
+const KNOWN_MODELS = new Map([
+  ['claude-opus-4.6-1m', {maxOutputTokens: 64_000, maxInputTokens: 1_000_000}],
+  ['claude-opus-4.6', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
+  ['claude-sonnet-4.6', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
+  ['claude-sonnet-4', {maxOutputTokens: 16_000, maxInputTokens: 216_000}],
+  ['claude-sonnet-4.5', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
+  ['claude-opus-4.5', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
+  ['claude-haiku-4.5', {maxOutputTokens: 64_000, maxInputTokens: 200_000}],
+]);
+
 interface CachedCapacity {
   maxOutputTokens: number;
   maxInputTokens: number;
@@ -24,6 +38,14 @@ async function resolve(config: Readonly<LlmConfig>): Promise<CachedCapacity> {
   const key = cacheKey(config);
   const cached = cache.get(key);
   if (cached) return cached;
+
+  // Check the static table first — works even when the proxy doesn't
+  // support the Anthropic /v1/models/{id} endpoint.
+  const known = KNOWN_MODELS.get(config.model);
+  if (known) {
+    cache.set(key, known);
+    return known;
+  }
 
   try {
     const client = new Anthropic({

--- a/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
+++ b/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
@@ -1,9 +1,8 @@
 import Anthropic from '@anthropic-ai/sdk';
-import pino from 'pino';
+
+import {logger} from '@/logger.js';
 
 import type {LlmConfig} from '../llm-api/types.js';
-
-const logger = pino({name: 'model-capacity'});
 
 const DEFAULT_MAX_OUTPUT_TOKENS = 16_384;
 const DEFAULT_MAX_INPUT_TOKENS = 200_000;

--- a/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
+++ b/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
@@ -1,6 +1,9 @@
 import Anthropic from '@anthropic-ai/sdk';
+import pino from 'pino';
 
 import type {LlmConfig} from '../llm-api/types.js';
+
+const logger = pino({name: 'model-capacity'});
 
 const DEFAULT_MAX_OUTPUT_TOKENS = 16_384;
 const DEFAULT_MAX_INPUT_TOKENS = 200_000;
@@ -35,9 +38,13 @@ async function resolve(config: Readonly<LlmConfig>): Promise<CachedCapacity> {
     };
     cache.set(key, capacity);
     return capacity;
-  } catch {
+  } catch (error) {
     // Proxy may not support /v1/models — fall back to safe defaults.
     // Do not cache the fallback so transient failures can self-heal on retry.
+    logger.warn(
+      {model: config.model, baseUrl: config.baseUrl, err: error},
+      'Failed to retrieve model capacity, using defaults',
+    );
     return {
       maxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
       maxInputTokens: DEFAULT_MAX_INPUT_TOKENS,

--- a/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
+++ b/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
@@ -37,12 +37,11 @@ async function resolve(config: Readonly<LlmConfig>): Promise<CachedCapacity> {
     return capacity;
   } catch {
     // Proxy may not support /v1/models — fall back to safe defaults.
-    const fallback: CachedCapacity = {
+    // Do not cache the fallback so transient failures can self-heal on retry.
+    return {
       maxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
       maxInputTokens: DEFAULT_MAX_INPUT_TOKENS,
     };
-    cache.set(key, fallback);
-    return fallback;
   }
 }
 

--- a/apps/backend/src/agent-core/model-capacity/index.ts
+++ b/apps/backend/src/agent-core/model-capacity/index.ts
@@ -1,0 +1,1 @@
+export {modelCapacity} from './model-capacity.js';

--- a/apps/backend/src/agent-core/model-capacity/model-capacity.test.ts
+++ b/apps/backend/src/agent-core/model-capacity/model-capacity.test.ts
@@ -1,7 +1,17 @@
-import {describe, expect, it} from 'vitest';
+import {afterEach, describe, expect, it, vi} from 'vitest';
 
 import type {LlmConfig} from '../llm-api/types.js';
-import {modelCapacity} from './model-capacity.js';
+
+const mockRetrieve = vi.fn();
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class {
+    models = {retrieve: mockRetrieve};
+  },
+}));
+
+// Dynamic import so the mock is in place before the module loads.
+const {modelCapacity} = await import('./model-capacity.js');
 
 function makeConfig(
   overrides: Partial<LlmConfig> & Pick<LlmConfig, 'apiFormat' | 'model'>,
@@ -13,12 +23,15 @@ function makeConfig(
   };
 }
 
+afterEach(() => {
+  mockRetrieve.mockReset();
+});
+
 describe('modelCapacity', () => {
-  describe('getMaxOutputTokens', () => {
-    it('returns known output limit for a known OpenAI model', async () => {
+  describe('OpenAI path', () => {
+    it('returns known output limit for a known model', async () => {
       const config = makeConfig({apiFormat: 'openai', model: 'gpt-5.4'});
-      const result = await modelCapacity.getMaxOutputTokens(config);
-      expect(result).toBe(128_000);
+      expect(await modelCapacity.getMaxOutputTokens(config)).toBe(128_000);
     });
 
     it('returns known output limit via openai-responses format', async () => {
@@ -26,52 +39,89 @@ describe('modelCapacity', () => {
         apiFormat: 'openai-responses',
         model: 'gpt-5.2-codex',
       });
-      const result = await modelCapacity.getMaxOutputTokens(config);
-      expect(result).toBe(128_000);
+      expect(await modelCapacity.getMaxOutputTokens(config)).toBe(128_000);
     });
 
-    it('returns default for an unknown OpenAI model', async () => {
+    it('returns default for an unknown model', async () => {
       const config = makeConfig({
         apiFormat: 'openai',
         model: 'unknown-model-xyz',
       });
-      const result = await modelCapacity.getMaxOutputTokens(config);
-      expect(result).toBe(16_384);
+      expect(await modelCapacity.getMaxOutputTokens(config)).toBe(16_384);
+      expect(await modelCapacity.getMaxInputTokens(config)).toBe(128_000);
     });
 
-    it('returns known output limit for a Gemini model', async () => {
+    it('returns known limits for a Gemini model', async () => {
       const config = makeConfig({
         apiFormat: 'openai',
         model: 'gemini-2.5-pro',
       });
-      const result = await modelCapacity.getMaxOutputTokens(config);
-      expect(result).toBe(64_000);
+      expect(await modelCapacity.getMaxOutputTokens(config)).toBe(64_000);
+      expect(await modelCapacity.getMaxInputTokens(config)).toBe(128_000);
     });
   });
 
-  describe('getMaxInputTokens', () => {
-    it('returns known input limit for a known OpenAI model', async () => {
-      const config = makeConfig({apiFormat: 'openai', model: 'gpt-5.2'});
-      const result = await modelCapacity.getMaxInputTokens(config);
-      expect(result).toBe(400_000);
+  describe('Claude path', () => {
+    it('returns limits from the Anthropic Models API', async () => {
+      mockRetrieve.mockResolvedValue({
+        max_tokens: 128_000,
+        max_input_tokens: 1_000_000,
+      });
+      const config = makeConfig({
+        apiFormat: 'claude',
+        model: 'claude-opus-4-6',
+      });
+
+      expect(await modelCapacity.getMaxOutputTokens(config)).toBe(128_000);
+      expect(await modelCapacity.getMaxInputTokens(config)).toBe(1_000_000);
+      expect(mockRetrieve).toHaveBeenCalledWith('claude-opus-4-6');
     });
 
-    it('returns default for an unknown OpenAI model', async () => {
-      const config = makeConfig({
-        apiFormat: 'openai',
-        model: 'unknown-model-xyz',
+    it('caches the result for subsequent calls', async () => {
+      mockRetrieve.mockResolvedValue({
+        max_tokens: 64_000,
+        max_input_tokens: 200_000,
       });
-      const result = await modelCapacity.getMaxInputTokens(config);
-      expect(result).toBe(128_000);
+      const config = makeConfig({
+        apiFormat: 'claude',
+        model: 'claude-sonnet-4-6',
+      });
+
+      await modelCapacity.getMaxOutputTokens(config);
+      await modelCapacity.getMaxInputTokens(config);
+
+      // Only one API call despite two queries.
+      expect(mockRetrieve).toHaveBeenCalledTimes(1);
     });
 
-    it('returns known input limit for a Gemini model', async () => {
+    it('falls back to defaults when the API call fails', async () => {
+      mockRetrieve.mockRejectedValue(new Error('Not Found'));
       const config = makeConfig({
-        apiFormat: 'openai-responses',
-        model: 'gemini-3.1-pro-preview',
+        apiFormat: 'claude',
+        model: 'claude-unknown',
       });
-      const result = await modelCapacity.getMaxInputTokens(config);
-      expect(result).toBe(200_000);
+
+      expect(await modelCapacity.getMaxOutputTokens(config)).toBe(16_384);
+      expect(await modelCapacity.getMaxInputTokens(config)).toBe(200_000);
+    });
+
+    it('retries the API call after a transient failure', async () => {
+      mockRetrieve
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({
+          max_tokens: 64_000,
+          max_input_tokens: 200_000,
+        });
+      const config = makeConfig({
+        apiFormat: 'claude',
+        model: 'claude-retry-test',
+      });
+
+      // First call fails → defaults.
+      expect(await modelCapacity.getMaxOutputTokens(config)).toBe(16_384);
+      // Second call succeeds → real values.
+      expect(await modelCapacity.getMaxOutputTokens(config)).toBe(64_000);
+      expect(mockRetrieve).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/apps/backend/src/agent-core/model-capacity/model-capacity.test.ts
+++ b/apps/backend/src/agent-core/model-capacity/model-capacity.test.ts
@@ -1,0 +1,77 @@
+import {describe, expect, it} from 'vitest';
+
+import type {LlmConfig} from '../llm-api/types.js';
+import {modelCapacity} from './model-capacity.js';
+
+function makeConfig(
+  overrides: Partial<LlmConfig> & Pick<LlmConfig, 'apiFormat' | 'model'>,
+): LlmConfig {
+  return {
+    apiKey: 'test-key',
+    baseUrl: 'https://api.example.com',
+    ...overrides,
+  };
+}
+
+describe('modelCapacity', () => {
+  describe('getMaxOutputTokens', () => {
+    it('returns known output limit for a known OpenAI model', async () => {
+      const config = makeConfig({apiFormat: 'openai', model: 'gpt-5.4'});
+      const result = await modelCapacity.getMaxOutputTokens(config);
+      expect(result).toBe(128_000);
+    });
+
+    it('returns known output limit via openai-responses format', async () => {
+      const config = makeConfig({
+        apiFormat: 'openai-responses',
+        model: 'gpt-5.2-codex',
+      });
+      const result = await modelCapacity.getMaxOutputTokens(config);
+      expect(result).toBe(128_000);
+    });
+
+    it('returns default for an unknown OpenAI model', async () => {
+      const config = makeConfig({
+        apiFormat: 'openai',
+        model: 'unknown-model-xyz',
+      });
+      const result = await modelCapacity.getMaxOutputTokens(config);
+      expect(result).toBe(16_384);
+    });
+
+    it('returns known output limit for a Gemini model', async () => {
+      const config = makeConfig({
+        apiFormat: 'openai',
+        model: 'gemini-2.5-pro',
+      });
+      const result = await modelCapacity.getMaxOutputTokens(config);
+      expect(result).toBe(64_000);
+    });
+  });
+
+  describe('getMaxInputTokens', () => {
+    it('returns known input limit for a known OpenAI model', async () => {
+      const config = makeConfig({apiFormat: 'openai', model: 'gpt-5.2'});
+      const result = await modelCapacity.getMaxInputTokens(config);
+      expect(result).toBe(400_000);
+    });
+
+    it('returns default for an unknown OpenAI model', async () => {
+      const config = makeConfig({
+        apiFormat: 'openai',
+        model: 'unknown-model-xyz',
+      });
+      const result = await modelCapacity.getMaxInputTokens(config);
+      expect(result).toBe(128_000);
+    });
+
+    it('returns known input limit for a Gemini model', async () => {
+      const config = makeConfig({
+        apiFormat: 'openai-responses',
+        model: 'gemini-3.1-pro-preview',
+      });
+      const result = await modelCapacity.getMaxInputTokens(config);
+      expect(result).toBe(200_000);
+    });
+  });
+});

--- a/apps/backend/src/agent-core/model-capacity/model-capacity.ts
+++ b/apps/backend/src/agent-core/model-capacity/model-capacity.ts
@@ -1,0 +1,34 @@
+import type {LlmConfig} from '../llm-api/types.js';
+import {
+  getClaudeMaxInputTokens,
+  getClaudeMaxOutputTokens,
+} from './claude-capacity.js';
+import {
+  getOpenAIMaxInputTokens,
+  getOpenAIMaxOutputTokens,
+} from './openai-capacity.js';
+
+/** Queries model token limits, dispatching by provider. */
+export const modelCapacity = {
+  /** Returns the maximum output tokens for the configured model. */
+  async getMaxOutputTokens(config: Readonly<LlmConfig>): Promise<number> {
+    switch (config.apiFormat) {
+      case 'claude':
+        return getClaudeMaxOutputTokens(config);
+      case 'openai':
+      case 'openai-responses':
+        return getOpenAIMaxOutputTokens(config);
+    }
+  },
+
+  /** Returns the maximum input tokens (context window) for the configured model. */
+  async getMaxInputTokens(config: Readonly<LlmConfig>): Promise<number> {
+    switch (config.apiFormat) {
+      case 'claude':
+        return getClaudeMaxInputTokens(config);
+      case 'openai':
+      case 'openai-responses':
+        return getOpenAIMaxInputTokens(config);
+    }
+  },
+};

--- a/apps/backend/src/agent-core/model-capacity/openai-capacity.ts
+++ b/apps/backend/src/agent-core/model-capacity/openai-capacity.ts
@@ -1,0 +1,44 @@
+import type {LlmConfig} from '../llm-api/types.js';
+
+const DEFAULT_MAX_OUTPUT_TOKENS = 16_384;
+const DEFAULT_MAX_INPUT_TOKENS = 128_000;
+
+/**
+ * Known model capacities from OpenAI-compatible providers (OpenAI, Gemini, etc.).
+ * These values must be maintained manually since the OpenAI API does not expose
+ * token limits programmatically.
+ */
+const KNOWN_MODELS = new Map([
+  ['gpt-4o', {maxOutputTokens: 4_096, maxInputTokens: 128_000}],
+  ['gpt-4.1', {maxOutputTokens: 16_384, maxInputTokens: 128_000}],
+  ['gpt-5-mini', {maxOutputTokens: 64_000, maxInputTokens: 264_000}],
+  ['gpt-5.1', {maxOutputTokens: 64_000, maxInputTokens: 264_000}],
+  ['gpt-5.2', {maxOutputTokens: 128_000, maxInputTokens: 400_000}],
+  ['gpt-5.2-codex', {maxOutputTokens: 128_000, maxInputTokens: 400_000}],
+  ['gpt-5.3-codex', {maxOutputTokens: 128_000, maxInputTokens: 400_000}],
+  ['gpt-5.4-mini', {maxOutputTokens: 128_000, maxInputTokens: 400_000}],
+  ['gpt-5.4', {maxOutputTokens: 128_000, maxInputTokens: 400_000}],
+  ['gemini-2.5-pro', {maxOutputTokens: 64_000, maxInputTokens: 128_000}],
+  [
+    'gemini-3-flash-preview',
+    {maxOutputTokens: 64_000, maxInputTokens: 128_000},
+  ],
+  [
+    'gemini-3.1-pro-preview',
+    {maxOutputTokens: 64_000, maxInputTokens: 200_000},
+  ],
+]);
+
+/** Returns the max output tokens for an OpenAI-compatible model. */
+export function getOpenAIMaxOutputTokens(config: Readonly<LlmConfig>): number {
+  return (
+    KNOWN_MODELS.get(config.model)?.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS
+  );
+}
+
+/** Returns the max input tokens (context window) for an OpenAI-compatible model. */
+export function getOpenAIMaxInputTokens(config: Readonly<LlmConfig>): number {
+  return (
+    KNOWN_MODELS.get(config.model)?.maxInputTokens ?? DEFAULT_MAX_INPUT_TOKENS
+  );
+}


### PR DESCRIPTION
## Summary

- Add `agent-core/model-capacity/` module that provides `modelCapacity.getMaxOutputTokens()` and `modelCapacity.getMaxInputTokens()` to query per-model token limits
- Anthropic models: auto-detected via `client.models.retrieve()` with result caching and fallback defaults
- OpenAI/Gemini models: static lookup table (12 models) with sensible defaults for unknown models

Closes #12

## Test plan

- [x] 7 unit tests covering known models, unknown model defaults, and both `openai`/`openai-responses` apiFormats
- [x] All 402 backend tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)