### PR TITLE
feat: display model name and context usage ratio in chat UI

### DIFF
--- a/apps/backend/src/agent-core/agent/agent.ts
+++ b/apps/backend/src/agent-core/agent/agent.ts
@@ -12,6 +12,7 @@ import type {
   SseToolExecuteDeltaEvent,
   SseToolExecuteEndEvent,
   SseToolExecuteStartEvent,
+  SseUsage,
 } from '@omnicraft/sse-events';
 
 import {AsyncChannel} from '@/helpers/async-channel.js';
@@ -20,6 +21,7 @@ import {agentEventBus} from '../events/index.js';
 import type {LlmConfig, LlmToolCall} from '../llm-api/index.js';
 import type {LlmSessionEventStream, ToolResult} from '../llm-session/index.js';
 import {LlmSession} from '../llm-session/index.js';
+import {modelCapacity} from '../model-capacity/index.js';
 import type {SkillDefinition} from '../skill/index.js';
 import type {
   AllowedPathEntry,
@@ -54,6 +56,7 @@ export abstract class Agent {
   private readonly skillRegistries: AgentOptions['skillRegistries'];
   private readonly baseSystemPrompt: string;
   private readonly getMaxToolRounds: AgentOptions['getMaxToolRounds'];
+  private readonly getConfig: () => Promise<LlmConfig>;
 
   private readonly workingDirectory: string;
 
@@ -77,6 +80,7 @@ export abstract class Agent {
     this.skillRegistries = options.skillRegistries;
     this.baseSystemPrompt = options.baseSystemPrompt;
     this.getMaxToolRounds = options.getMaxToolRounds;
+    this.getConfig = getConfig;
 
     this.extraAllowedPaths = [
       {path: os.tmpdir(), mode: 'read-write' as const},
@@ -154,7 +158,7 @@ export abstract class Agent {
         yield {
           type: 'done',
           reason: 'max_rounds_reached',
-          usage: this.llmSession.getUsage(),
+          usage: await this.buildSseUsage(),
         } satisfies SseDoneEvent;
         return;
       }
@@ -243,13 +247,27 @@ export abstract class Agent {
     yield {
       type: 'done',
       reason: 'complete',
-      usage: this.llmSession.getUsage(),
+      usage: await this.buildSseUsage(),
     } satisfies SseDoneEvent;
   }
 
   // -------------------------------------------------------------------------
   // Private helpers
   // -------------------------------------------------------------------------
+
+  /**
+   * Builds the full SseUsage object by combining LLM session token counts
+   * with model metadata from the config.
+   */
+  private async buildSseUsage(): Promise<SseUsage> {
+    const config = await this.getConfig();
+    const maxInputTokens = await modelCapacity.getMaxInputTokens(config);
+    return {
+      model: config.model,
+      maxInputTokens,
+      ...this.llmSession.getUsage(),
+    };
+  }
 
   /**
    * Merges tools from all registries, deduplicates by reference identity.

--- a/apps/backend/src/agent-core/llm-api/types.ts
+++ b/apps/backend/src/agent-core/llm-api/types.ts
@@ -1,5 +1,4 @@
 import type {ThinkingLevel} from '@omnicraft/api-schema';
-import type {SseUsage} from '@omnicraft/sse-events';
 
 import type {ToolDefinition} from '../tool/types.js';
 
@@ -57,8 +56,12 @@ export interface LlmConfig {
   model: string;
 }
 
-/** Token usage statistics. Re-exported from the shared SSE events package. */
-export type LlmUsage = SseUsage;
+/** Token usage statistics for internal LLM session accumulation. */
+export interface LlmUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+}
 
 /** The LLM response has started. */
 export interface LlmMessageStartEvent {

--- a/apps/frontend/src/pages/chat/components/InfoBar/components/UsageInfo/UsageInfo.tsx
+++ b/apps/frontend/src/pages/chat/components/InfoBar/components/UsageInfo/UsageInfo.tsx
@@ -7,16 +7,26 @@ interface UsageInfoProps {
   usage: SseUsage;
 }
 
+const CONTEXT_WARNING_THRESHOLD = 0.8;
+
 export function UsageInfo({usage}: UsageInfoProps) {
   const cacheRate =
     usage.inputTokens > 0
       ? Math.round((usage.cacheReadInputTokens / usage.inputTokens) * 100)
       : 0;
 
+  const contextRatio =
+    usage.maxInputTokens > 0 ? usage.inputTokens / usage.maxInputTokens : 0;
+  const contextPercent = Math.round(contextRatio * 100);
+  const isContextHigh = contextRatio > CONTEXT_WARNING_THRESHOLD;
+
   return (
     <div className={styles.container}>
-      <span className={styles.item}>
-        Input: {formatTokenCount(usage.inputTokens)}
+      <span className={styles.item}>{usage.model}</span>
+      <span className={`${styles.item} ${isContextHigh ? styles.warning : ''}`}>
+        Input: {formatTokenCount(usage.inputTokens)} /{' '}
+        {formatTokenCount(usage.maxInputTokens)}
+        <span className={styles.rate}> ({contextPercent}%)</span>
       </span>
       <span className={styles.item}>
         Output: {formatTokenCount(usage.outputTokens)}

--- a/apps/frontend/src/pages/chat/components/InfoBar/components/UsageInfo/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/InfoBar/components/UsageInfo/styles.module.css
@@ -10,3 +10,7 @@
 .rate {
   opacity: 0.7;
 }
+
+.warning {
+  color: var(--warning);
+}

--- a/packages/sse-events/src/schema.ts
+++ b/packages/sse-events/src/schema.ts
@@ -51,6 +51,8 @@ export type SseToolExecuteDeltaEvent = z.infer<
 
 /** Token usage statistics shared between backend and frontend. */
 export const sseUsageSchema = z.object({
+  model: z.string(),
+  maxInputTokens: z.number(),
   inputTokens: z.number(),
   outputTokens: z.number(),
   cacheReadInputTokens: z.number(),


### PR DESCRIPTION
## Summary

- Add `model` and `maxInputTokens` fields to `SseUsage` schema in `@omnicraft/sse-events`
- Break `LlmUsage = SseUsage` alias so backend `LlmSession` keeps its own simpler type for token accumulation
- Agent populates model info via `modelCapacity.getMaxInputTokens()` when emitting `done` events
- Frontend `UsageInfo` displays model name, input tokens as ratio (`42.0K / 200.0K (21%)`), and warning color when >80%

## Test plan

- [x] Type check passes for `sse-events`, backend, and frontend
- [x] Backend lint passes
- [x] All 403 backend tests pass
- [x] All 75 frontend tests pass
- [x] Manual: send a message, verify InfoBar shows model name and context ratio
- [x] Manual: verify warning color appears when context usage exceeds 80%

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)