### PR TITLE
refactor: share write_file parameter schema between frontend and backend

### DIFF
--- a/apps/backend/src/agent/tools/file/write-file.ts
+++ b/apps/backend/src/agent/tools/file/write-file.ts
@@ -2,7 +2,11 @@ import type {Stats} from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import {TOOL_NAME, writeFileResultSchema} from '@omnicraft/tool-schemas';
+import {
+  TOOL_NAME,
+  writeFileParametersSchema,
+  writeFileResultSchema,
+} from '@omnicraft/tool-schemas';
 import {z} from 'zod';
 
 import {FileStatCheckResult} from '@/agent-core/agent/index.js';
@@ -16,13 +20,7 @@ import {countLines} from './helpers.js';
 
 const MAX_CONTENT_SIZE = 1_048_576; // 1MB
 
-const parameters = z.object({
-  filePath: z
-    .string()
-    .min(1)
-    .describe('File path, absolute or relative to working directory'),
-  content: z.string().describe('File content to write'),
-});
+const parameters = writeFileParametersSchema;
 
 type WriteFileArgs = z.infer<typeof parameters>;
 type WriteFileResult = z.infer<typeof writeFileResultSchema>;

--- a/apps/frontend/src/pages/chat/components/MessageList/components/ToolExecutionCard/components/WriteFileResult/WriteFileResult.tsx
+++ b/apps/frontend/src/pages/chat/components/MessageList/components/ToolExecutionCard/components/WriteFileResult/WriteFileResult.tsx
@@ -1,9 +1,7 @@
+import {writeFileParametersSchema} from '@omnicraft/tool-schemas';
 import {useMemo} from 'react';
-import {z} from 'zod';
 
 import {ReadFileResult} from '../ReadFileResult/index.js';
-
-const writeFileArgsSchema = z.object({content: z.string()});
 
 interface WriteFileResultProps {
   filePath: string;
@@ -32,7 +30,7 @@ export function WriteFileResult({
 function extractContent(jsonString: string): string {
   try {
     const parsed: unknown = JSON.parse(jsonString);
-    const result = writeFileArgsSchema.safeParse(parsed);
+    const result = writeFileParametersSchema.safeParse(parsed);
     if (result.success) {
       return result.data.content;
     }

--- a/packages/tool-schemas/src/index.ts
+++ b/packages/tool-schemas/src/index.ts
@@ -1,6 +1,7 @@
 export {
   askUserBridgeResponseSchema,
   askUserParametersSchema,
+  writeFileParametersSchema,
 } from './parameter-schemas.js';
 export type {
   AnyToolResultData,

--- a/packages/tool-schemas/src/parameter-schemas.ts
+++ b/packages/tool-schemas/src/parameter-schemas.ts
@@ -1,5 +1,13 @@
 import {z} from 'zod';
 
+export const writeFileParametersSchema = z.object({
+  filePath: z
+    .string()
+    .min(1)
+    .describe('File path, absolute or relative to working directory'),
+  content: z.string().describe('File content to write'),
+});
+
 export const askUserParametersSchema = z.object({
   questions: z
     .array(


### PR DESCRIPTION
## Summary

- Extract `writeFileParametersSchema` to `@omnicraft/tool-schemas` shared package
- Backend `write-file.ts` now imports the shared schema instead of defining it locally
- Frontend `WriteFileResult.tsx` uses the shared schema instead of a local guess (`z.object({content: z.string()})`)

## Test plan

- [x] TypeScript type check passes for `tool-schemas`, `backend`, and `frontend`
- [ ] Verify write file tool execution still renders correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)