### PR TITLE
refactor: share all tool parameter schemas between frontend and backend

### DIFF
--- a/apps/backend/src/agent-core/tool/load-skill.ts
+++ b/apps/backend/src/agent-core/tool/load-skill.ts
@@ -1,4 +1,8 @@
-import {loadSkillResultSchema, TOOL_NAME} from '@omnicraft/tool-schemas';
+import {
+  loadSkillParametersSchema,
+  loadSkillResultSchema,
+  TOOL_NAME,
+} from '@omnicraft/tool-schemas';
 import {z} from 'zod';
 
 import type {
@@ -7,9 +11,7 @@ import type {
   ToolExecutionContext,
 } from './types.js';
 
-const parameters = z.object({
-  name: z.string().describe('Name of the skill to load'),
-});
+const parameters = loadSkillParametersSchema;
 
 type LoadSkillResult = z.infer<typeof loadSkillResultSchema>;
 

--- a/apps/backend/src/agent/tools/bash/run-command.ts
+++ b/apps/backend/src/agent/tools/bash/run-command.ts
@@ -1,7 +1,12 @@
 import {realpathSync} from 'node:fs';
 import fs from 'node:fs/promises';
 
-import {runCommandResultSchema, TOOL_NAME} from '@omnicraft/tool-schemas';
+import {
+  RUN_COMMAND_DEFAULT_TIMEOUT_MS,
+  runCommandParametersSchema,
+  runCommandResultSchema,
+  TOOL_NAME,
+} from '@omnicraft/tool-schemas';
 import {z} from 'zod';
 
 import type {
@@ -11,22 +16,10 @@ import type {
 import {isSubPathOrSelf} from '@/helpers/path-access.js';
 import {ShellCommandRunner} from '@/helpers/shell-command-runner.js';
 
-const DEFAULT_TIMEOUT_MS = 120_000;
-const MAX_TIMEOUT_MS = 600_000;
+const DEFAULT_TIMEOUT_MS = RUN_COMMAND_DEFAULT_TIMEOUT_MS;
 const MAX_INLINE_BYTES = 32_768; // 32KB
 
-const parameters = z.object({
-  command: z.string().min(1).describe('The shell command to execute'),
-  timeout: z
-    .number()
-    .int()
-    .min(1)
-    .max(MAX_TIMEOUT_MS)
-    .optional()
-    .describe(
-      `Timeout in milliseconds (default: ${DEFAULT_TIMEOUT_MS}, max: ${MAX_TIMEOUT_MS})`,
-    ),
-});
+const parameters = runCommandParametersSchema;
 
 type RunCommandArgs = z.infer<typeof parameters>;
 type RunCommandResult = z.infer<typeof runCommandResultSchema>;

--- a/apps/backend/src/agent/tools/bash/run-command.ts
+++ b/apps/backend/src/agent/tools/bash/run-command.ts
@@ -2,7 +2,6 @@ import {realpathSync} from 'node:fs';
 import fs from 'node:fs/promises';
 
 import {
-  RUN_COMMAND_DEFAULT_TIMEOUT_MS,
   runCommandParametersSchema,
   runCommandResultSchema,
   TOOL_NAME,
@@ -16,7 +15,7 @@ import type {
 import {isSubPathOrSelf} from '@/helpers/path-access.js';
 import {ShellCommandRunner} from '@/helpers/shell-command-runner.js';
 
-const DEFAULT_TIMEOUT_MS = RUN_COMMAND_DEFAULT_TIMEOUT_MS;
+const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_INLINE_BYTES = 32_768; // 32KB
 
 const parameters = runCommandParametersSchema;

--- a/apps/backend/src/agent/tools/file/edit-file.ts
+++ b/apps/backend/src/agent/tools/file/edit-file.ts
@@ -2,7 +2,11 @@ import type {Stats} from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import {editFileResultSchema, TOOL_NAME} from '@omnicraft/tool-schemas';
+import {
+  editFileParametersSchema,
+  editFileResultSchema,
+  TOOL_NAME,
+} from '@omnicraft/tool-schemas';
 import {createPatch} from 'diff';
 import {z} from 'zod';
 
@@ -16,20 +20,7 @@ import {AccessCheckResult, checkAccess} from '@/helpers/path-access.js';
 const MAX_DIFF_SIZE = 4_096; // 4KB
 const MAX_FILE_SIZE = 10_485_760; // 10MB
 
-const parameters = z.object({
-  filePath: z
-    .string()
-    .min(1)
-    .describe('File path, absolute or relative to working directory'),
-  oldString: z.string().min(1).describe('The exact string to find and replace'),
-  newString: z.string().describe('The replacement string'),
-  replaceAll: z
-    .boolean()
-    .optional()
-    .describe(
-      'Replace all occurrences. Defaults to false (requires unique match)',
-    ),
-});
+const parameters = editFileParametersSchema;
 
 type EditFileArgs = z.infer<typeof parameters>;
 type EditFileResult = z.infer<typeof editFileResultSchema>;

--- a/apps/backend/src/agent/tools/file/find-files.ts
+++ b/apps/backend/src/agent/tools/file/find-files.ts
@@ -3,7 +3,11 @@ import type {Stats} from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import {findFilesResultSchema, TOOL_NAME} from '@omnicraft/tool-schemas';
+import {
+  findFilesParametersSchema,
+  findFilesResultSchema,
+  TOOL_NAME,
+} from '@omnicraft/tool-schemas';
 import fg from 'fast-glob';
 import {z} from 'zod';
 
@@ -18,20 +22,7 @@ import {searchFilesTool} from './search-files.js';
 const MAX_RESULTS = 100;
 const TIMEOUT_MS = 30_000;
 
-const parameters = z.object({
-  pattern: z
-    .string()
-    .min(1)
-    .describe(
-      'Glob pattern to match files, e.g. "**/*.ts", "src/{components,hooks}/**/*.ts"',
-    ),
-  path: z
-    .string()
-    .optional()
-    .describe(
-      'Search root directory (relative or absolute), defaults to working directory',
-    ),
-});
+const parameters = findFilesParametersSchema;
 
 type FindFilesArgs = z.infer<typeof parameters>;
 type FindFilesResult = z.infer<typeof findFilesResultSchema>;

--- a/apps/backend/src/agent/tools/file/read-file.ts
+++ b/apps/backend/src/agent/tools/file/read-file.ts
@@ -2,7 +2,11 @@ import type {Stats} from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import {readFileResultSchema, TOOL_NAME} from '@omnicraft/tool-schemas';
+import {
+  readFileParametersSchema,
+  readFileResultSchema,
+  TOOL_NAME,
+} from '@omnicraft/tool-schemas';
 import {z} from 'zod';
 
 import type {
@@ -22,23 +26,7 @@ import {
 const MAX_RETURN_SIZE = 32_768; // 32KB
 const MAX_FULL_READ_FILE_SIZE = 1_048_576; // 1MB
 
-const parameters = z.object({
-  filePath: z
-    .string()
-    .describe('File path, absolute or relative to working directory'),
-  startLine: z
-    .number()
-    .int()
-    .min(1)
-    .optional()
-    .describe('Start line number (1-based), defaults to 1'),
-  lineCount: z
-    .number()
-    .int()
-    .min(1)
-    .optional()
-    .describe('Number of lines to read, defaults to end of file'),
-});
+const parameters = readFileParametersSchema;
 
 type ReadFileArgs = z.infer<typeof parameters>;
 type ReadFileResult = z.infer<typeof readFileResultSchema>;

--- a/apps/backend/src/agent/tools/file/search-files.ts
+++ b/apps/backend/src/agent/tools/file/search-files.ts
@@ -5,7 +5,11 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import readline from 'node:readline';
 
-import {searchFilesResultSchema, TOOL_NAME} from '@omnicraft/tool-schemas';
+import {
+  searchFilesParametersSchema,
+  searchFilesResultSchema,
+  TOOL_NAME,
+} from '@omnicraft/tool-schemas';
 import fg from 'fast-glob';
 import isSafeRegex from 'safe-regex2';
 import {z} from 'zod';
@@ -68,26 +72,7 @@ export async function searchFile(
   return matches;
 }
 
-const parameters = z.object({
-  pattern: z
-    .string()
-    .min(1)
-    .describe(
-      'Pattern string compiled to a JavaScript RegExp and matched with .test() per line',
-    ),
-  path: z
-    .string()
-    .optional()
-    .describe(
-      'Search root directory (relative or absolute), defaults to working directory',
-    ),
-  filePattern: z
-    .string()
-    .optional()
-    .describe(
-      'Glob pattern to filter files, e.g. "**/*.ts", defaults to "**/*"',
-    ),
-});
+const parameters = searchFilesParametersSchema;
 
 type SearchFilesArgs = z.infer<typeof parameters>;
 type SearchFilesResult = z.infer<typeof searchFilesResultSchema>;

--- a/apps/backend/src/agent/tools/web/web-fetch-raw.ts
+++ b/apps/backend/src/agent/tools/web/web-fetch-raw.ts
@@ -1,4 +1,8 @@
-import {TOOL_NAME, webFetchRawResultSchema} from '@omnicraft/tool-schemas';
+import {
+  TOOL_NAME,
+  webFetchRawParametersSchema,
+  webFetchRawResultSchema,
+} from '@omnicraft/tool-schemas';
 import {z} from 'zod';
 
 import type {
@@ -17,9 +21,7 @@ import {fetchBody} from './helpers.js';
 import {validateUrl} from './url-validator.js';
 import {webFetchTool} from './web-fetch.js';
 
-const parameters = z.object({
-  url: z.url().describe('The URL to fetch.'),
-});
+const parameters = webFetchRawParametersSchema;
 
 type WebFetchRawArgs = z.infer<typeof parameters>;
 type WebFetchRawResult = z.infer<typeof webFetchRawResultSchema>;

--- a/apps/backend/src/agent/tools/web/web-fetch.ts
+++ b/apps/backend/src/agent/tools/web/web-fetch.ts
@@ -1,5 +1,9 @@
 import {Readability} from '@mozilla/readability';
-import {TOOL_NAME, webFetchResultSchema} from '@omnicraft/tool-schemas';
+import {
+  TOOL_NAME,
+  webFetchParametersSchema,
+  webFetchResultSchema,
+} from '@omnicraft/tool-schemas';
 import {parseHTML} from 'linkedom';
 import TurndownService from 'turndown';
 import {z} from 'zod';
@@ -19,16 +23,7 @@ import {
 import {fetchBody} from './helpers.js';
 import {validateUrl} from './url-validator.js';
 
-const parameters = z.object({
-  url: z.url().describe('The URL to fetch.'),
-  includeFullPage: z
-    .boolean()
-    .optional()
-    .describe(
-      'Defaults to false. When false, only the main article content is extracted. ' +
-        'Set to true to include the full page content if extraction is incomplete or missing information.',
-    ),
-});
+const parameters = webFetchParametersSchema;
 
 type WebFetchArgs = z.infer<typeof parameters>;
 

--- a/apps/backend/src/agent/tools/web/web-search.ts
+++ b/apps/backend/src/agent/tools/web/web-search.ts
@@ -1,4 +1,8 @@
-import {TOOL_NAME, webSearchResultSchema} from '@omnicraft/tool-schemas';
+import {
+  TOOL_NAME,
+  webSearchParametersSchema,
+  webSearchResultSchema,
+} from '@omnicraft/tool-schemas';
 import {tavily, type TavilySearchResponse} from '@tavily/core';
 import {z} from 'zod';
 
@@ -8,24 +12,7 @@ import type {
 } from '@/agent-core/tool/index.js';
 import {SettingsManager} from '@/models/settings-manager/index.js';
 
-const parameters = z.object({
-  query: z.string().describe('Search keywords.'),
-  maxResults: z
-    .number()
-    .int()
-    .min(1)
-    .max(20)
-    .optional()
-    .describe('Number of results to return. Defaults to 5.'),
-  includeDomains: z
-    .array(z.string())
-    .optional()
-    .describe('Only search these domains.'),
-  excludeDomains: z
-    .array(z.string())
-    .optional()
-    .describe('Exclude these domains from results.'),
-});
+const parameters = webSearchParametersSchema;
 
 type WebSearchArgs = z.infer<typeof parameters>;
 type WebSearchResult = z.infer<typeof webSearchResultSchema>;

--- a/packages/tool-schemas/src/index.ts
+++ b/packages/tool-schemas/src/index.ts
@@ -5,8 +5,6 @@ export {
   findFilesParametersSchema,
   loadSkillParametersSchema,
   readFileParametersSchema,
-  RUN_COMMAND_DEFAULT_TIMEOUT_MS,
-  RUN_COMMAND_MAX_TIMEOUT_MS,
   runCommandParametersSchema,
   searchFilesParametersSchema,
   webFetchParametersSchema,

--- a/packages/tool-schemas/src/index.ts
+++ b/packages/tool-schemas/src/index.ts
@@ -1,6 +1,17 @@
 export {
   askUserBridgeResponseSchema,
   askUserParametersSchema,
+  editFileParametersSchema,
+  findFilesParametersSchema,
+  loadSkillParametersSchema,
+  readFileParametersSchema,
+  RUN_COMMAND_DEFAULT_TIMEOUT_MS,
+  RUN_COMMAND_MAX_TIMEOUT_MS,
+  runCommandParametersSchema,
+  searchFilesParametersSchema,
+  webFetchParametersSchema,
+  webFetchRawParametersSchema,
+  webSearchParametersSchema,
   writeFileParametersSchema,
 } from './parameter-schemas.js';
 export type {

--- a/packages/tool-schemas/src/parameter-schemas.ts
+++ b/packages/tool-schemas/src/parameter-schemas.ts
@@ -89,8 +89,8 @@ export const searchFilesParametersSchema = z.object({
 
 // --- run_command ---
 
-export const RUN_COMMAND_DEFAULT_TIMEOUT_MS = 120_000;
-export const RUN_COMMAND_MAX_TIMEOUT_MS = 600_000;
+const DEFAULT_TIMEOUT_MS = 120_000;
+const MAX_TIMEOUT_MS = 600_000;
 
 export const runCommandParametersSchema = z.object({
   command: z.string().min(1).describe('The shell command to execute'),
@@ -98,10 +98,10 @@ export const runCommandParametersSchema = z.object({
     .number()
     .int()
     .min(1)
-    .max(RUN_COMMAND_MAX_TIMEOUT_MS)
+    .max(MAX_TIMEOUT_MS)
     .optional()
     .describe(
-      `Timeout in milliseconds (default: ${RUN_COMMAND_DEFAULT_TIMEOUT_MS}, max: ${RUN_COMMAND_MAX_TIMEOUT_MS})`,
+      `Timeout in milliseconds (default: ${DEFAULT_TIMEOUT_MS}, max: ${MAX_TIMEOUT_MS})`,
     ),
 });
 

--- a/packages/tool-schemas/src/parameter-schemas.ts
+++ b/packages/tool-schemas/src/parameter-schemas.ts
@@ -1,5 +1,27 @@
 import {z} from 'zod';
 
+// --- read_file ---
+
+export const readFileParametersSchema = z.object({
+  filePath: z
+    .string()
+    .describe('File path, absolute or relative to working directory'),
+  startLine: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe('Start line number (1-based), defaults to 1'),
+  lineCount: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe('Number of lines to read, defaults to end of file'),
+});
+
+// --- write_file ---
+
 export const writeFileParametersSchema = z.object({
   filePath: z
     .string()
@@ -7,6 +29,129 @@ export const writeFileParametersSchema = z.object({
     .describe('File path, absolute or relative to working directory'),
   content: z.string().describe('File content to write'),
 });
+
+// --- edit_file ---
+
+export const editFileParametersSchema = z.object({
+  filePath: z
+    .string()
+    .min(1)
+    .describe('File path, absolute or relative to working directory'),
+  oldString: z.string().min(1).describe('The exact string to find and replace'),
+  newString: z.string().describe('The replacement string'),
+  replaceAll: z
+    .boolean()
+    .optional()
+    .describe(
+      'Replace all occurrences. Defaults to false (requires unique match)',
+    ),
+});
+
+// --- find_files ---
+
+export const findFilesParametersSchema = z.object({
+  pattern: z
+    .string()
+    .min(1)
+    .describe(
+      'Glob pattern to match files, e.g. "**/*.ts", "src/{components,hooks}/**/*.ts"',
+    ),
+  path: z
+    .string()
+    .optional()
+    .describe(
+      'Search root directory (relative or absolute), defaults to working directory',
+    ),
+});
+
+// --- search_files ---
+
+export const searchFilesParametersSchema = z.object({
+  pattern: z
+    .string()
+    .min(1)
+    .describe(
+      'Pattern string compiled to a JavaScript RegExp and matched with .test() per line',
+    ),
+  path: z
+    .string()
+    .optional()
+    .describe(
+      'Search root directory (relative or absolute), defaults to working directory',
+    ),
+  filePattern: z
+    .string()
+    .optional()
+    .describe(
+      'Glob pattern to filter files, e.g. "**/*.ts", defaults to "**/*"',
+    ),
+});
+
+// --- run_command ---
+
+export const RUN_COMMAND_DEFAULT_TIMEOUT_MS = 120_000;
+export const RUN_COMMAND_MAX_TIMEOUT_MS = 600_000;
+
+export const runCommandParametersSchema = z.object({
+  command: z.string().min(1).describe('The shell command to execute'),
+  timeout: z
+    .number()
+    .int()
+    .min(1)
+    .max(RUN_COMMAND_MAX_TIMEOUT_MS)
+    .optional()
+    .describe(
+      `Timeout in milliseconds (default: ${RUN_COMMAND_DEFAULT_TIMEOUT_MS}, max: ${RUN_COMMAND_MAX_TIMEOUT_MS})`,
+    ),
+});
+
+// --- web_search ---
+
+export const webSearchParametersSchema = z.object({
+  query: z.string().describe('Search keywords.'),
+  maxResults: z
+    .number()
+    .int()
+    .min(1)
+    .max(20)
+    .optional()
+    .describe('Number of results to return. Defaults to 5.'),
+  includeDomains: z
+    .array(z.string())
+    .optional()
+    .describe('Only search these domains.'),
+  excludeDomains: z
+    .array(z.string())
+    .optional()
+    .describe('Exclude these domains from results.'),
+});
+
+// --- web_fetch ---
+
+export const webFetchParametersSchema = z.object({
+  url: z.url().describe('The URL to fetch.'),
+  includeFullPage: z
+    .boolean()
+    .optional()
+    .describe(
+      'Defaults to false. When false, only the main article content is extracted. ' +
+        'Set to true to include the full page content if extraction is incomplete or missing information.',
+    ),
+});
+
+// --- web_fetch_raw ---
+
+export const webFetchRawParametersSchema = z.object({
+  url: z.url().describe('The URL to fetch.'),
+});
+
+// --- load_skill ---
+
+export const loadSkillParametersSchema = z.object({
+  name: z.string().describe('Name of the skill to load'),
+});
+
+// --- ask_user ---
 
 export const askUserParametersSchema = z.object({
   questions: z


### PR DESCRIPTION
## Summary

- Move parameter schemas for all frontend-visible tools to `@omnicraft/tool-schemas`, following the pattern established for `write_file` in #112
- Backend tool files now import shared schemas instead of defining them locally
- Enables the frontend to parse and display tool parameters in `ToolResultView` (followup: #119)

**Tools migrated:** `read_file`, `edit_file`, `find_files`, `search_files`, `run_command`, `web_search`, `web_fetch`, `web_fetch_raw`, `load_skill`

**Skipped:** `get_current_time` (no parameters), `dispatch_agent` (hidden from frontend)

## Test plan

- [x] `bun tsc --noEmit` passes for `@omnicraft/tool-schemas`
- [x] `bun run typecheck` passes for `@omnicraft/backend`
- [x] `bun tsc -b` passes for `@omnicraft/frontend`
- [x] `bun run lint` passes for `@omnicraft/backend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)