### PR TITLE
feat: session decoupling — push-based Agent + SSE events API

### DIFF
--- a/apps/backend/src/agent-core/agent/agent-sse-log.test.ts
+++ b/apps/backend/src/agent-core/agent/agent-sse-log.test.ts
@@ -131,7 +131,9 @@ describe('AgentSseLog', () => {
 
       // Next call blocks — resolve a race to prove it
       const timeout = new Promise<'timeout'>((r) =>
-        setTimeout(() => { r('timeout'); }, 50),
+        setTimeout(() => {
+          r('timeout');
+        }, 50),
       );
       const next = iter.next().then(() => 'resolved' as const);
       expect(await Promise.race([next, timeout])).toBe('timeout');

--- a/apps/backend/src/agent-core/agent/agent-sse-log.test.ts
+++ b/apps/backend/src/agent-core/agent/agent-sse-log.test.ts
@@ -32,11 +32,10 @@ async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
 }
 
 describe('AgentSseLog', () => {
-  describe('append and seal basics', () => {
-    it('starts with length 0 and not sealed', () => {
+  describe('append basics', () => {
+    it('starts with length 0', () => {
       const log = new AgentSseLog();
       expect(log.length).toBe(0);
-      expect(log.sealed).toBe(false);
     });
 
     it('increments length on append', () => {
@@ -47,51 +46,50 @@ describe('AgentSseLog', () => {
       expect(log.length).toBe(2);
     });
 
-    it('marks sealed after seal()', () => {
+    it('append always works (no seal)', () => {
       const log = new AgentSseLog();
-      log.seal();
-      expect(log.sealed).toBe(true);
-    });
-
-    it('throws when appending to a sealed log', () => {
-      const log = new AgentSseLog();
-      log.seal();
-      expect(() => {
-        log.append(textDelta('x'));
-      }).toThrow('Cannot append to a sealed AgentSseLog');
-    });
-
-    it('allows sealing an already sealed log without error', () => {
-      const log = new AgentSseLog();
-      log.seal();
-      expect(() => {
-        log.seal();
-      }).not.toThrow();
+      log.append(textDelta('a'));
+      log.append(textDelta('b'));
+      log.append(textDelta('c'));
+      expect(log.length).toBe(3);
+      // Can keep appending indefinitely
+      log.append(doneEvent());
+      expect(log.length).toBe(4);
     });
   });
 
   describe('single reader: replay and live events', () => {
-    it('replays all existing events then ends on seal', async () => {
+    it('replays all existing events', async () => {
       const log = new AgentSseLog();
       log.append(textDelta('a'));
       log.append(textDelta('b'));
-      log.seal();
 
-      const events = await collect(log.createReader());
+      const controller = new AbortController();
+      const collected = collect(log.createReader({signal: controller.signal}));
+
+      await new Promise((r) => setTimeout(r, 10));
+      controller.abort();
+
+      const events = await collected;
       expect(events).toEqual([textDelta('a'), textDelta('b')]);
     });
 
     it('receives live events appended after reader starts', async () => {
       const log = new AgentSseLog();
+      const controller = new AbortController();
 
-      const resultPromise = collect(log.createReader());
+      const resultPromise = collect(
+        log.createReader({signal: controller.signal}),
+      );
 
       // Let the reader start waiting.
       await Promise.resolve();
 
       log.append(textDelta('live-1'));
       log.append(textDelta('live-2'));
-      log.seal();
+
+      await new Promise((r) => setTimeout(r, 10));
+      controller.abort();
 
       const events = await resultPromise;
       expect(events).toEqual([textDelta('live-1'), textDelta('live-2')]);
@@ -100,40 +98,59 @@ describe('AgentSseLog', () => {
     it('replays existing events then receives live events', async () => {
       const log = new AgentSseLog();
       log.append(textDelta('existing'));
+      const controller = new AbortController();
 
-      const resultPromise = collect(log.createReader());
+      const resultPromise = collect(
+        log.createReader({signal: controller.signal}),
+      );
 
       // Let the reader replay and then wait.
       await Promise.resolve();
 
       log.append(textDelta('live'));
-      log.seal();
+
+      await new Promise((r) => setTimeout(r, 10));
+      controller.abort();
 
       const events = await resultPromise;
       expect(events).toEqual([textDelta('existing'), textDelta('live')]);
     });
   });
 
-  describe('reader ends when log is sealed', () => {
-    it('ends iteration immediately for an already-sealed empty log', async () => {
+  describe('reader ends only via AbortSignal', () => {
+    it('reader blocks indefinitely when not aborted', async () => {
       const log = new AgentSseLog();
-      log.seal();
+      log.append(textDelta('a'));
 
-      const events = await collect(log.createReader());
-      expect(events).toEqual([]);
+      const reader = log.createReader();
+      const iter = reader[Symbol.asyncIterator]();
+
+      // First event is available immediately
+      const first = await iter.next();
+      expect(first.value).toEqual(textDelta('a'));
+
+      // Next call blocks — resolve a race to prove it
+      const timeout = new Promise<'timeout'>((r) =>
+        setTimeout(() => { r('timeout'); }, 50),
+      );
+      const next = iter.next().then(() => 'resolved' as const);
+      expect(await Promise.race([next, timeout])).toBe('timeout');
     });
 
-    it('ends iteration after draining remaining events on seal', async () => {
+    it('reader ends when signal is aborted after draining', async () => {
       const log = new AgentSseLog();
+      log.append(textDelta('a'));
+      log.append(textDelta('b'));
 
-      const resultPromise = collect(log.createReader());
-      await Promise.resolve();
+      const controller = new AbortController();
+      const collected = collect(log.createReader({signal: controller.signal}));
 
-      log.append(doneEvent());
-      log.seal();
+      // Let the reader drain existing events, then abort
+      await new Promise((r) => setTimeout(r, 10));
+      controller.abort();
 
-      const events = await resultPromise;
-      expect(events).toEqual([doneEvent()]);
+      const events = await collected;
+      expect(events).toEqual([textDelta('a'), textDelta('b')]);
     });
   });
 
@@ -141,14 +158,21 @@ describe('AgentSseLog', () => {
     it('two readers independently iterate the same log', async () => {
       const log = new AgentSseLog();
       log.append(textDelta('a'));
+      const controller = new AbortController();
 
-      const reader1Promise = collect(log.createReader());
-      const reader2Promise = collect(log.createReader());
+      const reader1Promise = collect(
+        log.createReader({signal: controller.signal}),
+      );
+      const reader2Promise = collect(
+        log.createReader({signal: controller.signal}),
+      );
 
       await Promise.resolve();
 
       log.append(textDelta('b'));
-      log.seal();
+
+      await new Promise((r) => setTimeout(r, 10));
+      controller.abort();
 
       const [result1, result2] = await Promise.all([
         reader1Promise,
@@ -163,15 +187,26 @@ describe('AgentSseLog', () => {
       log.append(textDelta('a'));
       log.append(textDelta('b'));
       log.append(textDelta('c'));
-      log.seal();
+      const controller = new AbortController();
 
-      const all = await collect(log.createReader());
-      const fromOne = await collect(log.createReader({startIndex: 1}));
-      const fromTwo = await collect(log.createReader({startIndex: 2}));
+      const all = collect(log.createReader({signal: controller.signal}));
+      const fromOne = collect(
+        log.createReader({startIndex: 1, signal: controller.signal}),
+      );
+      const fromTwo = collect(
+        log.createReader({startIndex: 2, signal: controller.signal}),
+      );
 
-      expect(all).toEqual([textDelta('a'), textDelta('b'), textDelta('c')]);
-      expect(fromOne).toEqual([textDelta('b'), textDelta('c')]);
-      expect(fromTwo).toEqual([textDelta('c')]);
+      await new Promise((r) => setTimeout(r, 10));
+      controller.abort();
+
+      expect(await all).toEqual([
+        textDelta('a'),
+        textDelta('b'),
+        textDelta('c'),
+      ]);
+      expect(await fromOne).toEqual([textDelta('b'), textDelta('c')]);
+      expect(await fromTwo).toEqual([textDelta('c')]);
     });
   });
 
@@ -212,22 +247,27 @@ describe('AgentSseLog', () => {
 
     it('does not affect other readers when one is aborted', async () => {
       const log = new AgentSseLog();
-      const controller = new AbortController();
+      const abortController = new AbortController();
+      const normalController = new AbortController();
 
       const abortablePromise = collect(
-        log.createReader({signal: controller.signal}),
+        log.createReader({signal: abortController.signal}),
       );
-      const normalPromise = collect(log.createReader());
+      const normalPromise = collect(
+        log.createReader({signal: normalController.signal}),
+      );
 
       await Promise.resolve();
 
       log.append(textDelta('shared'));
       await Promise.resolve();
 
-      controller.abort();
+      abortController.abort();
 
       log.append(textDelta('after-abort'));
-      log.seal();
+
+      await new Promise((r) => setTimeout(r, 10));
+      normalController.abort();
 
       const [abortableResult, normalResult] = await Promise.all([
         abortablePromise,
@@ -248,35 +288,53 @@ describe('AgentSseLog', () => {
       log.append(textDelta('0'));
       log.append(textDelta('1'));
       log.append(textDelta('2'));
-      log.seal();
+      const controller = new AbortController();
 
-      const events = await collect(log.createReader({startIndex: 2}));
+      const collected = collect(
+        log.createReader({startIndex: 2, signal: controller.signal}),
+      );
+      await new Promise((r) => setTimeout(r, 10));
+      controller.abort();
+
+      const events = await collected;
       expect(events).toEqual([textDelta('2')]);
     });
 
-    it('returns empty when startIndex equals length on a sealed log', async () => {
+    it('returns empty when startIndex equals length', async () => {
       const log = new AgentSseLog();
       log.append(textDelta('a'));
-      log.seal();
+      const controller = new AbortController();
 
-      const events = await collect(log.createReader({startIndex: 1}));
+      const collected = collect(
+        log.createReader({startIndex: 1, signal: controller.signal}),
+      );
+      await new Promise((r) => setTimeout(r, 10));
+      controller.abort();
+
+      const events = await collected;
       expect(events).toEqual([]);
     });
 
     it('waits for events when startIndex is beyond current length', async () => {
       const log = new AgentSseLog();
+      const controller = new AbortController();
 
-      const resultPromise = collect(log.createReader({startIndex: 2}));
+      const resultPromise = collect(
+        log.createReader({startIndex: 2, signal: controller.signal}),
+      );
       await Promise.resolve();
 
       log.append(textDelta('0'));
       log.append(textDelta('1'));
       log.append(textDelta('2'));
-      log.seal();
+
+      await new Promise((r) => setTimeout(r, 10));
+      controller.abort();
 
       const events = await resultPromise;
       expect(events).toEqual([textDelta('2')]);
     });
+
     it('throws when startIndex is negative', () => {
       const log = new AgentSseLog();
       expect(() => log.createReader({startIndex: -1})).toThrow(

--- a/apps/backend/src/agent-core/agent/agent-sse-log.ts
+++ b/apps/backend/src/agent-core/agent/agent-sse-log.ts
@@ -20,15 +20,22 @@ export class AgentSseLog {
   private readonly events: SseEvent[] = [];
   private readonly waiters = new Set<() => void>();
 
+  /** Number of events in the log. */
   get length(): number {
     return this.events.length;
   }
 
+  /** Appends an event to the log and wakes all waiting readers. */
   append(event: SseEvent): void {
     this.events.push(event);
     this.notifyWaiters();
   }
 
+  /**
+   * Creates a reader that replays events from {@link startIndex},
+   * then blocks waiting for new events until the signal is aborted.
+   * Abort ends iteration silently.
+   */
   createReader(options?: AgentSseLogReaderOptions): AsyncIterable<SseEvent> {
     const startIndex = options?.startIndex ?? 0;
     assert(startIndex >= 0, 'startIndex must be non-negative');
@@ -57,6 +64,10 @@ export class AgentSseLog {
     }
   }
 
+  /**
+   * Returns a promise that resolves when a waiter notification fires
+   * or the signal aborts. Returns `true` if aborted, `false` otherwise.
+   */
   private waitForChange(signal?: AbortSignal): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       const cleanup = (): void => {

--- a/apps/backend/src/agent-core/agent/agent-sse-log.ts
+++ b/apps/backend/src/agent-core/agent/agent-sse-log.ts
@@ -15,8 +15,6 @@ export interface AgentSseLogReaderOptions {
  * A single writer appends events via {@link append}. Multiple readers
  * can independently iterate over the log via {@link createReader},
  * replaying historical events and then blocking for new ones.
- *
- * Readers end only via {@link AbortSignal}; the log has no "sealed" state.
  */
 export class AgentSseLog {
   private readonly events: SseEvent[] = [];

--- a/apps/backend/src/agent-core/agent/agent-sse-log.ts
+++ b/apps/backend/src/agent-core/agent/agent-sse-log.ts
@@ -59,7 +59,7 @@ export class AgentSseLog {
       }
 
       // Wait for new events or abort.
-      const aborted = await this.waitForChange(signal);
+      const aborted = await this.waitForAppendOrAbort(signal);
       if (aborted) return;
     }
   }
@@ -68,7 +68,7 @@ export class AgentSseLog {
    * Returns a promise that resolves when a waiter notification fires
    * or the signal aborts. Returns `true` if aborted, `false` otherwise.
    */
-  private waitForChange(signal?: AbortSignal): Promise<boolean> {
+  private waitForAppendOrAbort(signal?: AbortSignal): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       const cleanup = (): void => {
         this.waiters.delete(onNotify);

--- a/apps/backend/src/agent-core/agent/agent-sse-log.ts
+++ b/apps/backend/src/agent-core/agent/agent-sse-log.ts
@@ -16,44 +16,21 @@ export interface AgentSseLogReaderOptions {
  * can independently iterate over the log via {@link createReader},
  * replaying historical events and then blocking for new ones.
  *
- * Call {@link seal} when no more events will be appended. All waiting
- * readers will drain remaining events and end iteration.
+ * Readers end only via {@link AbortSignal}; the log has no "sealed" state.
  */
 export class AgentSseLog {
   private readonly events: SseEvent[] = [];
   private readonly waiters = new Set<() => void>();
-  private isSealedFlag = false;
 
-  /** Number of events in the log. */
   get length(): number {
     return this.events.length;
   }
 
-  /** Whether the log has been sealed (no more appends allowed). */
-  get sealed(): boolean {
-    return this.isSealedFlag;
-  }
-
-  /** Appends an event to the log and wakes all waiting readers. */
   append(event: SseEvent): void {
-    if (this.isSealedFlag) {
-      throw new Error('Cannot append to a sealed AgentSseLog');
-    }
     this.events.push(event);
     this.notifyWaiters();
   }
 
-  /** Marks the log as complete. No more events can be appended. */
-  seal(): void {
-    this.isSealedFlag = true;
-    this.notifyWaiters();
-  }
-
-  /**
-   * Creates a reader that replays events from {@link startIndex},
-   * then blocks waiting for new events until the log is sealed
-   * or the signal is aborted. Abort ends iteration silently.
-   */
   createReader(options?: AgentSseLogReaderOptions): AsyncIterable<SseEvent> {
     const startIndex = options?.startIndex ?? 0;
     assert(startIndex >= 0, 'startIndex must be non-negative');
@@ -70,26 +47,18 @@ export class AgentSseLog {
     if (signal?.aborted) return;
 
     for (;;) {
-      // Yield all available events from cursor onward.
       while (cursor < this.events.length) {
         yield this.events[cursor];
         cursor++;
         if (signal?.aborted) return;
       }
 
-      // All caught up. If sealed, we're done.
-      if (this.isSealedFlag) return;
-
-      // Wait for new events, seal, or abort.
+      // Wait for new events or abort.
       const aborted = await this.waitForChange(signal);
       if (aborted) return;
     }
   }
 
-  /**
-   * Returns a promise that resolves when a waiter notification fires
-   * or the signal aborts. Returns `true` if aborted, `false` otherwise.
-   */
   private waitForChange(signal?: AbortSignal): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       const cleanup = (): void => {

--- a/apps/backend/src/agent-core/agent/agent-sse-log.ts
+++ b/apps/backend/src/agent-core/agent/agent-sse-log.ts
@@ -18,7 +18,7 @@ export interface AgentSseLogReaderOptions {
  */
 export class AgentSseLog {
   private readonly events: SseEvent[] = [];
-  private readonly waiters = new Set<() => void>();
+  private readonly newEventWaiters = new Set<() => void>();
 
   /** Number of events in the log. */
   get length(): number {
@@ -71,7 +71,7 @@ export class AgentSseLog {
   private waitForAppendOrAbort(signal?: AbortSignal): Promise<boolean> {
     return new Promise<boolean>((resolve) => {
       const cleanup = (): void => {
-        this.waiters.delete(onNotify);
+        this.newEventWaiters.delete(onNotify);
         signal?.removeEventListener('abort', onAbort);
       };
 
@@ -85,7 +85,7 @@ export class AgentSseLog {
         resolve(true);
       };
 
-      this.waiters.add(onNotify);
+      this.newEventWaiters.add(onNotify);
 
       if (signal) {
         if (signal.aborted) {
@@ -99,8 +99,8 @@ export class AgentSseLog {
   }
 
   private notifyWaiters(): void {
-    const current = [...this.waiters];
-    this.waiters.clear();
+    const current = [...this.newEventWaiters];
+    this.newEventWaiters.clear();
     for (const notify of current) {
       notify();
     }

--- a/apps/backend/src/agent-core/agent/agent.ts
+++ b/apps/backend/src/agent-core/agent/agent.ts
@@ -218,7 +218,7 @@ export abstract class Agent {
     } satisfies SseDoneEvent;
   }
 
-  private async *runAgentLoop(
+  protected async *runAgentLoop(
     userMessage: string,
     thinkingLevel: ThinkingLevel,
     signal: AbortSignal,
@@ -330,7 +330,6 @@ export abstract class Agent {
         });
 
       for await (const event of toolSseEventChannel) {
-         
         if (event.type === 'tool-execute-end') {
           inFlightToolCalls.delete(event.callId);
         }

--- a/apps/backend/src/agent-core/agent/agent.ts
+++ b/apps/backend/src/agent-core/agent/agent.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import type {ThinkingLevel} from '@omnicraft/api-schema';
 import type {
   SseDoneEvent,
+  SseEvent,
   SseMessageStartEvent,
   SseSubAgentEvent,
   SseTextDeltaEvent,
@@ -19,6 +20,7 @@ import type {
 import type {AnyToolResultData, ToolName} from '@omnicraft/tool-schemas';
 
 import {AsyncChannel} from '@/helpers/async-channel.js';
+import {Mutex} from '@/helpers/mutex.js';
 
 import {agentEventBus} from '../events/index.js';
 import type {LlmConfig, LlmToolCall} from '../llm-api/index.js';
@@ -34,6 +36,8 @@ import type {
 } from '../tool/index.js';
 import {loadSkillTool} from '../tool/index.js';
 import {UserInteractionBridge} from '../user-interaction/index.js';
+import type {AgentSseLogReaderOptions} from './agent-sse-log.js';
+import {AgentSseLog} from './agent-sse-log.js';
 import {FileContentCache} from './file-content-cache.js';
 import {FileStatTracker} from './file-stat-tracker.js';
 import type {AgentEventStream, AgentOptions, AgentSnapshot} from './types.js';
@@ -77,6 +81,15 @@ export abstract class Agent {
 
   /** Bridge for client-side tools that await user interaction. */
   private readonly userInteractionBridge = new UserInteractionBridge();
+
+  /** Append-only event log. All turns write to the same log. */
+  readonly sseLog = new AgentSseLog();
+
+  /** Serializes turns — only one runs at a time. */
+  private readonly mutex = new Mutex();
+
+  /** Per-turn abort controller. Null when no turn is running. */
+  private abortController: AbortController | null = null;
 
   constructor(
     getConfig: () => Promise<LlmConfig>,
@@ -133,16 +146,84 @@ export abstract class Agent {
   }
 
   /**
-   * Handles a user message by running the full Agent Loop.
-   *
-   * Streams LLM responses, executes tool calls, and repeats until
-   * the LLM produces no tool calls or the maximum round limit is reached.
+   * Handles a user message by running the full Agent Loop in the background.
+   * Events are written to {@link sseLog}. Use {@link subscribe} to read them.
    */
-  async *handleUserMessage(
+  handleUserMessage(userMessage: string, thinkingLevel: ThinkingLevel): void {
+    void this.runTurn(userMessage, thinkingLevel);
+  }
+
+  /** Returns an async iterable of events from this agent's log. */
+  subscribe(options?: AgentSseLogReaderOptions): AsyncIterable<SseEvent> {
+    return this.sseLog.createReader(options);
+  }
+
+  /** Aborts the currently running turn, if any. */
+  abort(): void {
+    this.abortController?.abort();
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private async runTurn(
+    userMessage: string,
+    thinkingLevel: ThinkingLevel,
+  ): Promise<void> {
+    const release = await this.mutex.acquire();
+    try {
+      this.abortController = new AbortController();
+      const stream = this.runAgentLoop(
+        userMessage,
+        thinkingLevel,
+        this.abortController.signal,
+      );
+      await this.pump(stream);
+    } finally {
+      this.abortController = null;
+      release();
+    }
+  }
+
+  private async pump(stream: AgentEventStream): Promise<void> {
+    try {
+      for await (const event of stream) {
+        this.sseLog.append(event);
+      }
+    } catch {
+      this.sseLog.append({
+        type: 'error',
+        message: 'An internal error occurred',
+      });
+    }
+  }
+
+  private async *emitAbortCompletion(
+    inFlightToolCalls: Set<string>,
+  ): AgentEventStream {
+    for (const callId of inFlightToolCalls) {
+      yield {
+        type: 'tool-execute-end',
+        callId,
+        result: 'Aborted',
+        status: 'error',
+        data: {message: 'Aborted'},
+      } satisfies SseToolExecuteEndEvent;
+    }
+    yield {
+      type: 'done',
+      reason: 'aborted',
+      usage: await this.buildSseUsage(),
+    } satisfies SseDoneEvent;
+  }
+
+  private async *runAgentLoop(
     userMessage: string,
     thinkingLevel: ThinkingLevel,
     signal: AbortSignal,
   ): AgentEventStream {
+    const inFlightToolCalls = new Set<string>();
     const maxRounds = await this.getMaxToolRounds();
 
     const {
@@ -162,13 +243,17 @@ export abstract class Agent {
       role: 'user',
       messageId,
       createdAt,
+      content: userMessage,
     } satisfies SseMessageStartEvent;
 
     let toolCalls = yield* this.consumeStream(userStream);
 
     let round = 0;
     while (toolCalls.length > 0) {
-      if (signal.aborted) return;
+      if (signal.aborted) {
+        yield* this.emitAbortCompletion(inFlightToolCalls);
+        return;
+      }
 
       round++;
       if (round > maxRounds) {
@@ -182,10 +267,10 @@ export abstract class Agent {
 
       const availableTools = this.getAvailableTools();
 
-      // Emit all tool-execute-start events up front (skip unknown/suppressed tools)
       for (const toolCall of toolCalls) {
         const tool = availableTools.get(toolCall.toolName);
         if (!tool || tool.suppressToolEvents) continue;
+        inFlightToolCalls.add(toolCall.callId);
         yield {
           type: 'tool-execute-start',
           callId: toolCall.callId,
@@ -195,13 +280,11 @@ export abstract class Agent {
         } satisfies SseToolExecuteStartEvent;
       }
 
-      // Execute all tools in parallel, streaming end events as each completes
       const toolSseEventChannel = new AsyncChannel<
         SseToolExecuteEndEvent | SseToolExecuteDeltaEvent | SseSubAgentEvent
       >();
       const toolResults = new Map<string, ToolResult>();
 
-      // Handle unknown tools immediately — no SSE events, just error for LLM
       for (const toolCall of toolCalls) {
         if (availableTools.has(toolCall.toolName)) continue;
         toolResults.set(toolCall.callId, {
@@ -247,14 +330,23 @@ export abstract class Agent {
         });
 
       for await (const event of toolSseEventChannel) {
+         
+        if (event.type === 'tool-execute-end') {
+          inFlightToolCalls.delete(event.callId);
+        }
         yield event;
+        // signal.aborted may have changed during async tool execution
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (signal.aborted) break;
       }
 
       // signal.aborted may have changed during async tool execution
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (signal.aborted) return;
+      if (signal.aborted) {
+        yield* this.emitAbortCompletion(inFlightToolCalls);
+        return;
+      }
 
-      // Submit results in the same order as the original tool calls
       const orderedResults = toolCalls.flatMap((tc) => {
         const result = toolResults.get(tc.callId);
         return result ? [result] : [];
@@ -277,10 +369,6 @@ export abstract class Agent {
       usage: await this.buildSseUsage(),
     } satisfies SseDoneEvent;
   }
-
-  // -------------------------------------------------------------------------
-  // Private helpers
-  // -------------------------------------------------------------------------
 
   /**
    * Builds the full SseUsage object by combining LLM session token counts
@@ -420,6 +508,7 @@ export abstract class Agent {
             role: 'assistant',
             messageId: event.messageId,
             createdAt: event.createdAt,
+            content: '',
           } satisfies SseMessageStartEvent;
           break;
         case 'tool-call':

--- a/apps/backend/src/agent/agents/coding-sub-agent/coding-sub-agent.ts
+++ b/apps/backend/src/agent/agents/coding-sub-agent/coding-sub-agent.ts
@@ -81,7 +81,7 @@ export class CodingSubAgent extends Agent {
     };
   }
 
-  override async *handleUserMessage(
+  protected override async *runAgentLoop(
     userMessage: string,
     _thinkingLevel: ThinkingLevel,
     signal: AbortSignal,
@@ -89,142 +89,134 @@ export class CodingSubAgent extends Agent {
     // Dynamic import to avoid loading the SDK when no coding subagent is used.
     const {query} = await import('@anthropic-ai/claude-agent-sdk');
 
-    const abortController = new AbortController();
-    const onAbort = (): void => {
-      abortController.abort();
-    };
+    const sdkAbortController = new AbortController();
     if (signal.aborted) {
-      abortController.abort();
+      sdkAbortController.abort();
     } else {
-      signal.addEventListener('abort', onAbort, {once: true});
+      signal.addEventListener('abort', () => { sdkAbortController.abort(); }, {
+        once: true,
+      });
     }
 
-    try {
-      let resultText = '';
-      let usage: SseUsage = {
-        model: 'claude-code',
-        maxInputTokens: 0,
-        inputTokens: 0,
-        outputTokens: 0,
-        cacheReadInputTokens: 0,
-      };
+    let resultText = '';
+    let usage: SseUsage = {
+      model: 'claude-code',
+      maxInputTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadInputTokens: 0,
+    };
 
-      const messageStream = query({
-        prompt: userMessage,
-        options: {
-          cwd: this.cwd,
-          abortController,
-          permissionMode: 'bypassPermissions',
-          allowDangerouslySkipPermissions: true,
-          includePartialMessages: true,
-          ...(this.claudeCodeSessionId
-            ? {resume: this.claudeCodeSessionId}
-            : {}),
-        },
-      });
+    const messageStream = query({
+      prompt: userMessage,
+      options: {
+        cwd: this.cwd,
+        abortController: sdkAbortController,
+        permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
+        includePartialMessages: true,
+        ...(this.claudeCodeSessionId ? {resume: this.claudeCodeSessionId} : {}),
+      },
+    });
 
-      for await (const message of messageStream) {
-        // Capture session ID from the init message for future resumption.
-        if (message.type === 'system' && message.subtype === 'init') {
-          this.claudeCodeSessionId = message.session_id;
-        }
+    for await (const message of messageStream) {
+      // Capture session ID from the init message for future resumption.
+      if (message.type === 'system' && message.subtype === 'init') {
+        this.claudeCodeSessionId = message.session_id;
+      }
 
-        // Stream text deltas from partial messages for real-time frontend display.
-        if (message.type === 'stream_event') {
-          const event = message.event;
+      // Stream text deltas from partial messages for real-time frontend display.
+      if (message.type === 'stream_event') {
+        const event = message.event;
 
-          if (event.type === 'content_block_start') {
-            if (event.content_block.type === 'text') {
-              yield {
-                type: 'message-start',
-                role: 'assistant',
-                messageId: crypto.randomUUID(),
-                createdAt: Date.now(),
-              } satisfies SseMessageStartEvent;
-            }
-
-            if (event.content_block.type === 'tool_use') {
-              yield {
-                type: 'text-delta',
-                content: `\n[Tool: ${event.content_block.name}]\n`,
-              } satisfies SseTextDeltaEvent;
-            }
+        if (event.type === 'content_block_start') {
+          if (event.content_block.type === 'text') {
+            yield {
+              type: 'message-start',
+              role: 'assistant',
+              messageId: crypto.randomUUID(),
+              createdAt: Date.now(),
+              content: '',
+            } satisfies SseMessageStartEvent;
           }
 
-          if (
-            event.type === 'content_block_delta' &&
-            event.delta.type === 'text_delta'
-          ) {
+          if (event.content_block.type === 'tool_use') {
             yield {
               type: 'text-delta',
-              content: event.delta.text,
+              content: `\n[Tool: ${event.content_block.name}]\n`,
             } satisfies SseTextDeltaEvent;
           }
         }
 
-        // Emit tool use summaries as text so the frontend shows tool activity.
-        if (message.type === 'tool_use_summary') {
+        if (
+          event.type === 'content_block_delta' &&
+          event.delta.type === 'text_delta'
+        ) {
           yield {
             type: 'text-delta',
-            content: `\n${message.summary}\n`,
+            content: event.delta.text,
           } satisfies SseTextDeltaEvent;
-        }
-
-        // Capture result and usage from SDK completion.
-        if (message.type === 'result') {
-          const entries = Object.entries(message.modelUsage);
-          assert(
-            entries.length > 0,
-            'Expected at least one model in modelUsage',
-          );
-          const [model, modelUsage] = entries[0];
-          usage = {
-            model,
-            maxInputTokens: modelUsage.contextWindow,
-            inputTokens: modelUsage.inputTokens,
-            outputTokens: modelUsage.outputTokens,
-            cacheReadInputTokens: modelUsage.cacheReadInputTokens,
-          };
-
-          if (message.subtype === 'success') {
-            resultText = message.result;
-          } else {
-            // The throw prevents the `done` event from being yielded, so the
-            // frontend will not receive usage data for failed invocations.
-            // This matches the general subagent behavior — the dispatch tool's
-            // catch block emits `subagent-complete` and returns a failure result.
-            const errors = message.errors.join('; ');
-            throw new Error(
-              `Coding agent failed (${message.subtype}): ${errors || 'unknown error'}`,
-            );
-          }
         }
       }
 
-      // Yield the clean result as the final assistant message so that the
-      // dispatch tool's `lastReplyText` accumulator ends up with just the
-      // summary, not all intermediate streaming text.
-      if (resultText) {
-        yield {
-          type: 'message-start',
-          role: 'assistant',
-          messageId: crypto.randomUUID(),
-          createdAt: Date.now(),
-        } satisfies SseMessageStartEvent;
-
+      // Emit tool use summaries as text so the frontend shows tool activity.
+      if (message.type === 'tool_use_summary') {
         yield {
           type: 'text-delta',
-          content: resultText,
+          content: `\n${message.summary}\n`,
         } satisfies SseTextDeltaEvent;
       }
 
-      yield {
-        type: 'done',
-        reason: 'complete',
-        usage,
-      } satisfies SseDoneEvent;
-    } finally {
-      signal.removeEventListener('abort', onAbort);
+      // Capture result and usage from SDK completion.
+      if (message.type === 'result') {
+        const entries = Object.entries(message.modelUsage);
+        assert(entries.length > 0, 'Expected at least one model in modelUsage');
+        const [model, modelUsage] = entries[0];
+        usage = {
+          model,
+          maxInputTokens: modelUsage.contextWindow,
+          inputTokens: modelUsage.inputTokens,
+          outputTokens: modelUsage.outputTokens,
+          cacheReadInputTokens: modelUsage.cacheReadInputTokens,
+        };
+
+        if (message.subtype === 'success') {
+          resultText = message.result;
+        } else {
+          // The throw prevents the `done` event from being yielded, so the
+          // frontend will not receive usage data for failed invocations.
+          // This matches the general subagent behavior — the dispatch tool's
+          // catch block emits `subagent-complete` and returns a failure result.
+          const errors = message.errors.join('; ');
+          throw new Error(
+            `Coding agent failed (${message.subtype}): ${errors || 'unknown error'}`,
+          );
+        }
+      }
     }
+
+    // Yield the clean result as the final assistant message so that the
+    // dispatch tool's `lastReplyText` accumulator ends up with just the
+    // summary, not all intermediate streaming text.
+    if (resultText) {
+      yield {
+        type: 'message-start',
+        role: 'assistant',
+        messageId: crypto.randomUUID(),
+        createdAt: Date.now(),
+        content: '',
+      } satisfies SseMessageStartEvent;
+
+      yield {
+        type: 'text-delta',
+        content: resultText,
+      } satisfies SseTextDeltaEvent;
+    }
+
+    yield {
+      type: 'done',
+      reason: 'complete',
+      usage,
+    } satisfies SseDoneEvent;
   }
 }

--- a/apps/backend/src/agent/agents/coding-sub-agent/coding-sub-agent.ts
+++ b/apps/backend/src/agent/agents/coding-sub-agent/coding-sub-agent.ts
@@ -93,9 +93,15 @@ export class CodingSubAgent extends Agent {
     if (signal.aborted) {
       sdkAbortController.abort();
     } else {
-      signal.addEventListener('abort', () => { sdkAbortController.abort(); }, {
-        once: true,
-      });
+      signal.addEventListener(
+        'abort',
+        () => {
+          sdkAbortController.abort();
+        },
+        {
+          once: true,
+        },
+      );
     }
 
     let resultText = '';

--- a/apps/backend/src/agent/agents/coding-sub-agent/coding-sub-agent.ts
+++ b/apps/backend/src/agent/agents/coding-sub-agent/coding-sub-agent.ts
@@ -89,6 +89,14 @@ export class CodingSubAgent extends Agent {
     // Dynamic import to avoid loading the SDK when no coding subagent is used.
     const {query} = await import('@anthropic-ai/claude-agent-sdk');
 
+    yield {
+      type: 'message-start',
+      role: 'user',
+      messageId: crypto.randomUUID(),
+      createdAt: Date.now(),
+      content: userMessage,
+    } satisfies SseMessageStartEvent;
+
     const sdkAbortController = new AbortController();
     if (signal.aborted) {
       sdkAbortController.abort();

--- a/apps/backend/src/agent/agents/coding-sub-agent/coding-sub-agent.ts
+++ b/apps/backend/src/agent/agents/coding-sub-agent/coding-sub-agent.ts
@@ -221,7 +221,7 @@ export class CodingSubAgent extends Agent {
 
     yield {
       type: 'done',
-      reason: 'complete',
+      reason: signal.aborted ? 'aborted' : 'complete',
       usage,
     } satisfies SseDoneEvent;
   }

--- a/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
+++ b/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
@@ -165,6 +165,10 @@ export const dispatchAgentTool: ToolDefinition<
         break;
     }
 
+    // Link parent abort signal to subagent
+    const onAbort = () => { subagent.abort(); };
+    context.signal.addEventListener('abort', onAbort, {once: true});
+
     context.onSubAgentEvent({
       type: 'subagent-dispatch',
       agentId: subagent.id,
@@ -175,14 +179,14 @@ export const dispatchAgentTool: ToolDefinition<
     });
 
     try {
-      const eventStream = subagent.handleUserMessage(
-        task,
-        thinkingLevel,
-        context.signal,
-      );
-
+      // Subscribe before starting — ensures the reader is in place before events flow.
       let lastReplyText = '';
-      for await (const event of eventStream) {
+      let completed = false;
+      const eventIter = subagent.subscribe({signal: context.signal});
+
+      subagent.handleUserMessage(task, thinkingLevel);
+
+      for await (const event of eventIter) {
         // Subagents cannot emit subagent events (no SubAgentToolRegistry),
         // so all events are base events. Cast is safe by construction.
         context.onSubAgentEvent({
@@ -197,21 +201,35 @@ export const dispatchAgentTool: ToolDefinition<
         if (event.type === 'text-delta') {
           lastReplyText += event.content;
         }
+        // Subagent's sseLog is never sealed — break on done to end iteration.
+        // If the parent aborts, the reader ends silently (no done seen).
+        if (event.type === 'done') {
+          completed = true;
+          break;
+        }
       }
 
       context.onSubAgentEvent({
         type: 'subagent-complete',
         agentId: subagent.id,
-        status: 'success',
+        status: completed ? 'success' : 'failure',
       });
 
-      const summary =
-        lastReplyText ||
-        'Subagent completed the task but produced no text summary.';
+      if (completed) {
+        const summary =
+          lastReplyText ||
+          'Subagent completed the task but produced no text summary.';
+        return {
+          data: {summary},
+          content: summary,
+          status: 'success',
+        };
+      }
+
       return {
-        data: {summary},
-        content: summary,
-        status: 'success',
+        data: {message: 'Subagent was aborted'},
+        content: 'Subagent was aborted.',
+        status: 'failure',
       };
     } catch (error: unknown) {
       context.onSubAgentEvent({
@@ -226,6 +244,8 @@ export const dispatchAgentTool: ToolDefinition<
         content: `Subagent error: ${message}`,
         status: 'failure',
       };
+    } finally {
+      context.signal.removeEventListener('abort', onAbort);
     }
   },
 };

--- a/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
+++ b/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
@@ -181,7 +181,6 @@ export const dispatchAgentTool: ToolDefinition<
     });
 
     try {
-      // Subscribe before starting — ensures the reader is in place before events flow.
       let lastReplyText = '';
       let completed = false;
       const eventIter = subagent.subscribe({signal: context.signal});

--- a/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
+++ b/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
@@ -166,7 +166,9 @@ export const dispatchAgentTool: ToolDefinition<
     }
 
     // Link parent abort signal to subagent
-    const onAbort = () => { subagent.abort(); };
+    const onAbort = () => {
+      subagent.abort();
+    };
     context.signal.addEventListener('abort', onAbort, {once: true});
 
     context.onSubAgentEvent({

--- a/apps/backend/src/dispatcher/chat/helpers/sse.ts
+++ b/apps/backend/src/dispatcher/chat/helpers/sse.ts
@@ -3,39 +3,10 @@ import {PassThrough} from 'node:stream';
 
 import {sseEventSchema} from '@omnicraft/sse-events';
 
-import {logger} from '@/logger.js';
-
 /** Writes a single SSE event to the stream. Validates against the shared schema. */
 export function writeSseEvent(stream: PassThrough, data: unknown): void {
   if (stream.destroyed || stream.writableEnded) return;
   const result = sseEventSchema.safeParse(data);
   assert(result.success, `Invalid SSE event: ${JSON.stringify(data)}`);
   stream.write(`data: ${JSON.stringify(result.data)}\n\n`);
-}
-
-/**
- * Consumes an async event stream and writes each event as SSE.
- * The agent stream yields its own `done` event on completion.
- * Writes an `error` event on failure.
- * Always ends the stream when finished.
- */
-export async function pumpEventStream(
-  stream: PassThrough,
-  eventStream: AsyncGenerator<unknown, void, undefined>,
-): Promise<void> {
-  try {
-    for await (const event of eventStream) {
-      writeSseEvent(stream, event);
-    }
-  } catch (e) {
-    logger.error({err: e}, 'SSE stream error');
-    writeSseEvent(stream, {
-      type: 'error',
-      message: 'An internal error occurred',
-    });
-  } finally {
-    if (!stream.destroyed && !stream.writableEnded) {
-      stream.end();
-    }
-  }
 }

--- a/apps/backend/src/dispatcher/chat/path.ts
+++ b/apps/backend/src/dispatcher/chat/path.ts
@@ -2,3 +2,5 @@ export const CHAT_SESSION = '/chat/session';
 export const CHAT_SESSION_COMPLETIONS = '/chat/session/:id/completions';
 export const CHAT_SESSION_GENERATE_TITLE = '/chat/session/:id/generate-title';
 export const CHAT_SESSION_TOOL_RESPONSE = '/chat/session/:id/tool-response';
+export const CHAT_SESSION_EVENTS = '/chat/session/:id/events';
+export const CHAT_SESSION_ABORT = '/chat/session/:id/abort';

--- a/apps/backend/src/dispatcher/chat/router.ts
+++ b/apps/backend/src/dispatcher/chat/router.ts
@@ -87,7 +87,7 @@ router.post(CHAT_SESSION_COMPLETIONS, (ctx) => {
 });
 
 /** GET /chat/session/:id/events — SSE stream of agent events. */
-router.get(CHAT_SESSION_EVENTS, async (ctx) => {
+router.get(CHAT_SESSION_EVENTS, (ctx) => {
   const {id} = ctx.params;
   const from = Math.max(0, Number(ctx.query.from) || 0);
 
@@ -119,16 +119,18 @@ router.get(CHAT_SESSION_EVENTS, async (ctx) => {
   };
   ctx.req.on('close', onDisconnect);
 
-  try {
-    for await (const event of eventStream) {
-      writeSseEvent(stream, event);
+  void (async () => {
+    try {
+      for await (const event of eventStream) {
+        writeSseEvent(stream, event);
+      }
+    } finally {
+      ctx.req.off('close', onDisconnect);
+      if (!stream.destroyed) {
+        stream.end();
+      }
     }
-  } finally {
-    ctx.req.off('close', onDisconnect);
-    if (!stream.destroyed) {
-      stream.end();
-    }
-  }
+  })();
 });
 
 /** POST /chat/session/:id/abort — aborts the running agent turn. */

--- a/apps/backend/src/dispatcher/chat/router.ts
+++ b/apps/backend/src/dispatcher/chat/router.ts
@@ -13,10 +13,12 @@ import {ZodError} from 'zod';
 
 import {chatService} from '@/services/chat/index.js';
 
-import {pumpEventStream} from './helpers/sse.js';
+import {writeSseEvent} from './helpers/sse.js';
 import {
   CHAT_SESSION,
+  CHAT_SESSION_ABORT,
   CHAT_SESSION_COMPLETIONS,
+  CHAT_SESSION_EVENTS,
   CHAT_SESSION_GENERATE_TITLE,
   CHAT_SESSION_TOOL_RESPONSE,
 } from './path.js';
@@ -55,7 +57,7 @@ router.post(CHAT_SESSION, async (ctx) => {
   ctx.response.body = {sessionId: result.sessionId};
 });
 
-/** POST /chat/session/:id/completions — streams a chat completion. */
+/** POST /chat/session/:id/completions — starts a chat completion in the background. */
 router.post(CHAT_SESSION_COMPLETIONS, (ctx) => {
   const {id} = ctx.params;
 
@@ -74,14 +76,31 @@ router.post(CHAT_SESSION_COMPLETIONS, (ctx) => {
     throw e;
   }
 
-  const result = chatService.streamCompletion(id, message, thinkingLevel);
-  if (!result) {
+  const found = chatService.sendCompletion(id, message, thinkingLevel);
+  if (!found) {
     ctx.response.status = StatusCodes.NOT_FOUND;
     ctx.response.body = {error: `Session not found: ${id}`};
     return;
   }
 
-  const {eventStream, abort} = result;
+  ctx.response.status = StatusCodes.ACCEPTED;
+});
+
+/** GET /chat/session/:id/events — SSE stream of agent events. */
+router.get(CHAT_SESSION_EVENTS, async (ctx) => {
+  const {id} = ctx.params;
+  const from = Math.max(0, Number(ctx.query.from) || 0);
+
+  const abortController = new AbortController();
+  const eventStream = chatService.subscribe(id, {
+    startIndex: from,
+    signal: abortController.signal,
+  });
+  if (!eventStream) {
+    ctx.response.status = StatusCodes.NOT_FOUND;
+    ctx.response.body = {error: `Session not found: ${id}`};
+    return;
+  }
 
   ctx.response.type = 'text/event-stream';
   ctx.response.set('Cache-Control', 'no-cache');
@@ -93,17 +112,37 @@ router.post(CHAT_SESSION_COMPLETIONS, (ctx) => {
 
   const onDisconnect = () => {
     ctx.req.off('close', onDisconnect);
-    abort();
+    abortController.abort();
     if (!stream.destroyed) {
       stream.destroy();
     }
-    void eventStream.return();
   };
   ctx.req.on('close', onDisconnect);
 
-  void pumpEventStream(stream, eventStream).finally(() => {
+  try {
+    for await (const event of eventStream) {
+      writeSseEvent(stream, event);
+    }
+  } finally {
     ctx.req.off('close', onDisconnect);
-  });
+    if (!stream.destroyed) {
+      stream.end();
+    }
+  }
+});
+
+/** POST /chat/session/:id/abort — aborts the running agent turn. */
+router.post(CHAT_SESSION_ABORT, (ctx) => {
+  const {id} = ctx.params;
+
+  const found = chatService.abortCompletion(id);
+  if (!found) {
+    ctx.response.status = StatusCodes.NOT_FOUND;
+    ctx.response.body = {error: `Session not found: ${id}`};
+    return;
+  }
+
+  ctx.response.status = StatusCodes.NO_CONTENT;
 });
 
 /** POST /chat/session/:id/generate-title — generates a title for a session. */

--- a/apps/backend/src/dispatcher/chat/router.ts
+++ b/apps/backend/src/dispatcher/chat/router.ts
@@ -1,3 +1,4 @@
+import type {IncomingMessage} from 'node:http';
 import {PassThrough} from 'node:stream';
 
 import Router from '@koa/router';
@@ -110,28 +111,40 @@ router.get(CHAT_SESSION_EVENTS, (ctx) => {
   const stream = new PassThrough();
   ctx.body = stream;
 
+  void pumpSseEvents(stream, eventStream, ctx.req, abortController);
+});
+
+/**
+ * Pumps events from an async iterable to a PassThrough SSE stream.
+ * Runs in the background — must not be awaited inside a Koa handler,
+ * otherwise Koa's respond() never fires and the client receives nothing.
+ */
+async function pumpSseEvents(
+  stream: PassThrough,
+  eventStream: AsyncIterable<unknown>,
+  req: IncomingMessage,
+  abortController: AbortController,
+): Promise<void> {
   const onDisconnect = () => {
-    ctx.req.off('close', onDisconnect);
+    req.off('close', onDisconnect);
     abortController.abort();
     if (!stream.destroyed) {
       stream.destroy();
     }
   };
-  ctx.req.on('close', onDisconnect);
+  req.on('close', onDisconnect);
 
-  void (async () => {
-    try {
-      for await (const event of eventStream) {
-        writeSseEvent(stream, event);
-      }
-    } finally {
-      ctx.req.off('close', onDisconnect);
-      if (!stream.destroyed) {
-        stream.end();
-      }
+  try {
+    for await (const event of eventStream) {
+      writeSseEvent(stream, event);
     }
-  })();
-});
+  } finally {
+    req.off('close', onDisconnect);
+    if (!stream.destroyed) {
+      stream.end();
+    }
+  }
+}
 
 /** POST /chat/session/:id/abort — aborts the running agent turn. */
 router.post(CHAT_SESSION_ABORT, (ctx) => {

--- a/apps/backend/src/services/chat/chat-service.ts
+++ b/apps/backend/src/services/chat/chat-service.ts
@@ -3,8 +3,10 @@ import os from 'node:os';
 
 import type {ThinkingLevel} from '@omnicraft/api-schema';
 import type {AllowedPathEntry} from '@omnicraft/settings-schema';
+import type {SseEvent} from '@omnicraft/sse-events';
 
 import {MainAgent} from '@/agent/agents/index.js';
+import type {AgentSseLogReaderOptions} from '@/agent-core/agent/agent-sse-log.js';
 import {logger} from '@/logger.js';
 import {AgentStore} from '@/models/agent-store/index.js';
 import {SettingsManager} from '@/models/settings-manager/index.js';
@@ -14,7 +16,7 @@ import {
   getLlmConfig,
   truncateToTitle,
 } from './helpers.js';
-import type {CreateSessionResult, StreamCompletionResult} from './types.js';
+import type {CreateSessionResult} from './types.js';
 import {CreateSessionError} from './types.js';
 import {validateSessionPaths} from './validation.js';
 
@@ -88,28 +90,42 @@ export const chatService = {
   },
 
   /**
-   * Streams a completion for the given agent.
-   * Returns undefined if the agent does not exist.
+   * Sends a user message to the agent. The agent runs in the background;
+   * use {@link subscribe} to read events. Returns false if agent not found.
    */
-  streamCompletion(
+  sendCompletion(
     agentId: string,
     userMessage: string,
     thinkingLevel: ThinkingLevel,
-  ): StreamCompletionResult | undefined {
+  ): boolean {
+    const agent = AgentStore.getInstance().get(agentId);
+    if (!agent) return false;
+    agent.handleUserMessage(userMessage, thinkingLevel);
+    return true;
+  },
+
+  /**
+   * Returns an async iterable of SSE events for the given agent.
+   * Returns undefined if agent not found.
+   */
+  subscribe(
+    agentId: string,
+    options?: AgentSseLogReaderOptions,
+  ): AsyncIterable<SseEvent> | undefined {
     const agent = AgentStore.getInstance().get(agentId);
     if (!agent) return undefined;
-    const abortController = new AbortController();
-    const eventStream = agent.handleUserMessage(
-      userMessage,
-      thinkingLevel,
-      abortController.signal,
-    );
-    return {
-      eventStream,
-      abort: () => {
-        abortController.abort();
-      },
-    };
+    return agent.subscribe(options);
+  },
+
+  /**
+   * Aborts the currently running turn for the given agent.
+   * Returns false if agent not found.
+   */
+  abortCompletion(agentId: string): boolean {
+    const agent = AgentStore.getInstance().get(agentId);
+    if (!agent) return false;
+    agent.abort();
+    return true;
   },
 
   /**

--- a/apps/backend/src/services/chat/index.ts
+++ b/apps/backend/src/services/chat/index.ts
@@ -1,4 +1,4 @@
 export {chatService} from './chat-service.js';
 export {getLightLlmConfig} from './helpers.js';
-export type {CreateSessionResult, StreamCompletionResult} from './types.js';
+export type {CreateSessionResult} from './types.js';
 export {CreateSessionError} from './types.js';

--- a/apps/backend/src/services/chat/types.ts
+++ b/apps/backend/src/services/chat/types.ts
@@ -1,5 +1,3 @@
-import type {AgentEventStream} from '@/agent-core/agent/index.js';
-
 /** Reasons why session creation can fail. */
 export enum CreateSessionError {
   BASE_URL_NOT_CONFIGURED = 'BASE_URL_NOT_CONFIGURED',
@@ -19,9 +17,3 @@ export enum CreateSessionError {
 export type CreateSessionResult =
   | {success: true; sessionId: string}
   | {success: false; error: CreateSessionError};
-
-/** Result of streamCompletion: the event stream and an abort handle. */
-export interface StreamCompletionResult {
-  eventStream: AgentEventStream;
-  abort: () => void;
-}

--- a/apps/frontend/src/api/chat/chat.ts
+++ b/apps/frontend/src/api/chat/chat.ts
@@ -38,30 +38,62 @@ export async function createSession(
 }
 
 /**
- * Sends a message to a chat session and yields SSE events.
- * Uses fetch() + ReadableStream since EventSource does not support POST.
+ * Sends a message to a chat session. The agent processes it in the background.
+ * Use {@link subscribeEvents} to receive events.
  */
-export async function* streamChatCompletion(
+export async function sendMessage(
   sessionId: string,
   message: string,
   thinkingLevel: ThinkingLevel,
-  signal?: AbortSignal,
-): AsyncGenerator<SseEvent, void, undefined> {
+): Promise<void> {
   const res = await fetch(`${BASE}/session/${sessionId}/completions`, {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({message, thinkingLevel}),
-    signal,
   });
 
   if (!res.ok) {
     const body = await res.text();
     throw new Error(`Chat request failed (${res.status.toString()}): ${body}`);
   }
+}
+
+/**
+ * Subscribes to SSE events from a chat session.
+ * Replays from {@link from} index, then tails live events.
+ */
+export async function* subscribeEvents(
+  sessionId: string,
+  from: number,
+  signal?: AbortSignal,
+): AsyncGenerator<SseEvent, void, undefined> {
+  const url = `${BASE}/session/${sessionId}/events?from=${from.toString()}`;
+  const res = await fetch(url, {signal});
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `Event subscription failed (${res.status.toString()}): ${body}`,
+    );
+  }
 
   for await (const data of parseSseStream(res)) {
     const parsed: unknown = JSON.parse(data);
     yield sseEventSchema.parse(parsed);
+  }
+}
+
+/** Aborts the currently running agent turn. */
+export async function abortCompletion(sessionId: string): Promise<void> {
+  const res = await fetch(`${BASE}/session/${sessionId}/abort`, {
+    method: 'POST',
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `Failed to abort completion (${res.status.toString()}): ${body}`,
+    );
   }
 }
 

--- a/apps/frontend/src/api/chat/index.ts
+++ b/apps/frontend/src/api/chat/index.ts
@@ -1,6 +1,8 @@
 export {
+  abortCompletion,
   createSession,
   generateTitle,
-  streamChatCompletion,
+  sendMessage,
   submitToolResponse,
+  subscribeEvents,
 } from './chat.js';

--- a/apps/frontend/src/pages/chat/components/StreamingMessageDisplay/hooks/useMessages.ts
+++ b/apps/frontend/src/pages/chat/components/StreamingMessageDisplay/hooks/useMessages.ts
@@ -152,16 +152,32 @@ function finishThinking(prev: ChatMessage[]): ChatMessage[] {
 
 function applyUserMessageStart(
   prev: ChatMessage[],
-  messageId: string,
+  event: SseMessageStartEvent,
 ): ChatMessage[] {
+  // Look for a user message without an ID (created by user-message-sent)
   for (let i = prev.length - 1; i >= 0; i--) {
-    if (prev[i].role === 'user') {
+    if (prev[i].role === 'user' && prev[i].id === null) {
       const updated = [...prev];
-      updated[i] = {...updated[i], id: messageId};
+      updated[i] = {...updated[i], id: event.messageId};
       return updated;
     }
   }
-  throw new Error('message-start(user) received but no user message found');
+  // Replay: no user-message-sent was fired. Create from event content.
+  return [
+    ...prev,
+    {
+      id: event.messageId,
+      createdAt: event.createdAt,
+      role: 'user' as const,
+      content: {type: 'text' as const, content: event.content},
+    },
+    {
+      id: null,
+      createdAt: null,
+      role: 'assistant' as const,
+      content: {type: 'text' as const, content: ''},
+    },
+  ];
 }
 
 function applyAssistantMessageStart(
@@ -226,46 +242,6 @@ function pushSubagentStart(
   ];
 }
 
-/**
- * Appends synthetic tool-execute-end messages for any tool-execute-start
- * that has no matching end event (e.g. stream was aborted mid-execution).
- */
-function completeUnfinishedTools(prev: ChatMessage[]): ChatMessage[] {
-  const completedCallIds = new Set<string>();
-  for (const msg of prev) {
-    if (msg.content.type === 'tool-execute-end') {
-      completedCallIds.add(msg.content.callId);
-    }
-  }
-
-  const unfinishedCallIds: string[] = [];
-  for (const msg of prev) {
-    if (
-      msg.content.type === 'tool-execute-start' &&
-      !completedCallIds.has(msg.content.callId)
-    ) {
-      unfinishedCallIds.push(msg.content.callId);
-    }
-  }
-
-  if (unfinishedCallIds.length === 0) return prev;
-
-  const syntheticEnds: ChatMessage[] = unfinishedCallIds.map((callId) => ({
-    id: null,
-    createdAt: null,
-    role: 'assistant' as const,
-    content: {
-      type: 'tool-execute-end' as const,
-      callId,
-      result: 'Aborted',
-      status: 'error' as const,
-      data: {message: 'Aborted'},
-    },
-  }));
-
-  return [...prev, ...syntheticEnds];
-}
-
 function updateSubagentStatus(
   prev: ChatMessage[],
   data: {agentId: string; status: 'success' | 'failure'},
@@ -308,20 +284,12 @@ export function useMessages() {
     const onToolExecuteEnd = (data: SseToolExecuteEndEvent) => {
       setMessages((prev) => pushToolEnd(prev, data));
     };
-    const onStreamEnd = () => {
-      // When the user stops generation, the SSE connection is severed and
-      // backend completion events (tool-execute-end, thinking-end) will
-      // never arrive. Finalize any in-progress items so the UI does not
-      // stay stuck in a "running" state.
-      setMessages((prev) => {
-        const withThinking = finishThinking(prev);
-        const withTools = completeUnfinishedTools(withThinking);
-        return removeTrailingAssistantMessageIfEmpty(withTools);
-      });
+    const onDone = () => {
+      setMessages(removeTrailingAssistantMessageIfEmpty);
     };
     const onMessageStart = (data: SseMessageStartEvent) => {
       if (data.role === 'user') {
-        setMessages((prev) => applyUserMessageStart(prev, data.messageId));
+        setMessages((prev) => applyUserMessageStart(prev, data));
       } else {
         setMessages((prev) =>
           applyAssistantMessageStart(prev, data.messageId, data.createdAt),
@@ -361,7 +329,7 @@ export function useMessages() {
     eventBus.on('text-delta', onTextDelta);
     eventBus.on('tool-execute-start', onToolExecuteStart);
     eventBus.on('tool-execute-end', onToolExecuteEnd);
-    eventBus.on('stream-end', onStreamEnd);
+    eventBus.on('done', onDone);
     eventBus.on('message-start', onMessageStart);
     eventBus.on('thinking-start', onThinkingStart);
     eventBus.on('thinking-delta', onThinkingDelta);
@@ -375,7 +343,7 @@ export function useMessages() {
       eventBus.off('text-delta', onTextDelta);
       eventBus.off('tool-execute-start', onToolExecuteStart);
       eventBus.off('tool-execute-end', onToolExecuteEnd);
-      eventBus.off('stream-end', onStreamEnd);
+      eventBus.off('done', onDone);
       eventBus.off('message-start', onMessageStart);
       eventBus.off('thinking-start', onThinkingStart);
       eventBus.off('thinking-delta', onThinkingDelta);

--- a/apps/frontend/src/pages/chat/components/StreamingMessageDisplay/types.ts
+++ b/apps/frontend/src/pages/chat/components/StreamingMessageDisplay/types.ts
@@ -88,8 +88,6 @@ export interface ChatEventMap {
   };
   /** An error occurred during streaming. */
   'stream-error': {message: string};
-  /** The stream ended (always fires in finally, regardless of outcome). */
-  'stream-end': undefined;
   /** Reset all display state (messages, tool output). */
   reset: undefined;
   /** A subagent was dispatched. */

--- a/apps/frontend/src/pages/chat/contexts/SessionIdContext/SessionIdProvider.tsx
+++ b/apps/frontend/src/pages/chat/contexts/SessionIdContext/SessionIdProvider.tsx
@@ -1,61 +1,59 @@
-import {type ReactNode, useCallback, useMemo, useState} from 'react';
+import {useCallback, useState} from 'react';
+import {useNavigate, useParams} from 'react-router';
 
 import {createSession} from '@/api/chat/index.js';
+import {ROUTES} from '@/routes.js';
 
-import {
-  SessionIdContext,
-  type SessionIdContextValue,
-} from './SessionIdContext.js';
+import {SessionIdContext} from './SessionIdContext.js';
 
-interface SessionConfig {
-  workspace?: string;
-  extraAllowedPaths?: readonly string[];
+interface SessionIdProviderProps {
+  children: React.ReactNode;
 }
 
-export function SessionIdProvider({children}: {children: ReactNode}) {
-  const [sessionId, setSessionId] = useState<string | null>(null);
+export function SessionIdProvider({children}: SessionIdProviderProps) {
+  const {sessionId} = useParams();
+  const navigate = useNavigate();
   const [error, setError] = useState<string | null>(null);
 
-  const createNewSessionId = useCallback(async (config: SessionConfig = {}) => {
-    setError(null);
-    try {
-      const id = await createSession(config);
-      setSessionId(id);
-      return id;
-    } catch (e) {
-      console.error('Failed to create session', e);
-      const message =
-        e instanceof Error ? e.message : 'Failed to create session';
-      setError(message);
-      return null;
-    }
-  }, []);
+  const createNewSessionId = useCallback(
+    async (config?: {
+      workspace?: string;
+      extraAllowedPaths?: readonly string[];
+    }) => {
+      try {
+        const id = await createSession(config);
+        void navigate(`/chat/${id}`, {replace: true});
+        return id;
+      } catch (e: unknown) {
+        const message =
+          e instanceof Error ? e.message : 'Failed to create session';
+        setError(message);
+        return null;
+      }
+    },
+    [navigate],
+  );
 
   const clearSessionId = useCallback(() => {
-    setSessionId(null);
     setError(null);
-  }, []);
+    void navigate(ROUTES.chat(), {replace: true});
+  }, [navigate]);
 
   const clearCreateNewSessionIdError = useCallback(() => {
     setError(null);
   }, []);
 
-  const value: SessionIdContextValue = useMemo(
-    () => ({
-      sessionId,
-      createNewSessionIdError: error,
-      createNewSessionId,
-      clearSessionId,
-      clearCreateNewSessionIdError,
-    }),
-    [
-      sessionId,
-      error,
-      createNewSessionId,
-      clearSessionId,
-      clearCreateNewSessionIdError,
-    ],
+  return (
+    <SessionIdContext
+      value={{
+        sessionId: sessionId ?? null,
+        createNewSessionIdError: error,
+        createNewSessionId,
+        clearSessionId,
+        clearCreateNewSessionIdError,
+      }}
+    >
+      {children}
+    </SessionIdContext>
   );
-
-  return <SessionIdContext value={value}>{children}</SessionIdContext>;
 }

--- a/apps/frontend/src/pages/chat/hooks/useStreamChat.ts
+++ b/apps/frontend/src/pages/chat/hooks/useStreamChat.ts
@@ -39,8 +39,6 @@ export function useStreamChat({
     const controller = new AbortController();
     const subagentBusMap = subagentBusMapRef.current;
 
-    eventBus.emit('reset');
-
     async function consume(): Promise<void> {
       let lastUserMessage = '';
       let assistantText = '';

--- a/apps/frontend/src/pages/chat/hooks/useStreamChat.ts
+++ b/apps/frontend/src/pages/chat/hooks/useStreamChat.ts
@@ -1,7 +1,12 @@
 import type {ThinkingLevel} from '@omnicraft/api-schema';
-import {useCallback, useRef, useState} from 'react';
+import type {SseEvent} from '@omnicraft/sse-events';
+import {useCallback, useEffect, useRef, useState} from 'react';
 
-import {streamChatCompletion} from '@/api/chat/index.js';
+import {
+  abortCompletion,
+  sendMessage as apiSendMessage,
+  subscribeEvents,
+} from '@/api/chat/index.js';
 import {EventBus} from '@/helpers/event-bus.js';
 
 import type {ChatEventMap} from '../components/StreamingMessageDisplay/index.js';
@@ -16,7 +21,7 @@ interface UseStreamChatOptions {
   createNewSessionId: SessionIdHook['createNewSessionId'];
 }
 
-/** Orchestrates sending a message and consuming the SSE stream. */
+/** Orchestrates the persistent SSE connection and message sending. */
 export function useStreamChat({
   sessionId,
   createNewSessionId,
@@ -24,9 +29,71 @@ export function useStreamChat({
   const [isStreaming, setIsStreaming] = useState(false);
   const [streamError, setStreamError] = useState<string | null>(null);
   const [maxRoundsReached, setMaxRoundsReached] = useState(false);
-  const abortControllerRef = useRef<AbortController | null>(null);
   const subagentBusMapRef = useRef(new Map<string, EventBus<ChatEventMap>>());
   const eventBus = useChatEventBus();
+
+  // Persistent SSE connection — connects when sessionId is set.
+  useEffect(() => {
+    if (!sessionId) return;
+
+    const controller = new AbortController();
+    let lastUserMessage = '';
+    let assistantText = '';
+
+    const subagentBusMap = subagentBusMapRef.current;
+
+    eventBus.emit('reset');
+
+    void (async () => {
+      try {
+        for await (const event of subscribeEvents(
+          sessionId,
+          0,
+          controller.signal,
+        )) {
+          routeEvent(
+            event,
+            eventBus,
+            subagentBusMap,
+            setIsStreaming,
+            setStreamError,
+            setMaxRoundsReached,
+          );
+
+          // Track turn context for title generation
+          if (event.type === 'message-start' && event.role === 'user') {
+            lastUserMessage = event.content;
+            assistantText = '';
+          }
+          if (event.type === 'text-delta') {
+            assistantText += event.content;
+          }
+          if (event.type === 'done') {
+            if (assistantText) {
+              eventBus.emit('turn-done', {
+                sessionId,
+                userMessage: lastUserMessage,
+                assistantMessage: assistantText,
+              });
+            }
+            lastUserMessage = '';
+            assistantText = '';
+          }
+        }
+      } catch (e: unknown) {
+        if (e instanceof DOMException && e.name === 'AbortError') return;
+        console.error('SSE connection failed', e);
+        const message =
+          e instanceof Error ? e.message : 'An unexpected error occurred';
+        setStreamError(message);
+      }
+    })();
+
+    return () => {
+      controller.abort();
+      subagentBusMap.clear();
+    };
+  }, [sessionId, eventBus]);
 
   const sendMessage = useCallback(
     async (content: string, thinkingLevel: ThinkingLevel) => {
@@ -42,103 +109,16 @@ export function useStreamChat({
       setMaxRoundsReached(false);
       setIsStreaming(true);
 
-      const abortController = new AbortController();
-      abortControllerRef.current = abortController;
-
       eventBus.emit('user-message-sent', {content: trimmed});
 
-      let assistantText = '';
-
       try {
-        const stream = streamChatCompletion(
-          activeSessionId,
-          trimmed,
-          thinkingLevel,
-          abortController.signal,
-        );
-
-        for await (const event of stream) {
-          switch (event.type) {
-            case 'text-delta':
-              assistantText += event.content;
-              routeBaseEventToBus(event, eventBus);
-              break;
-            case 'done':
-              if (event.reason === 'max_rounds_reached') {
-                setMaxRoundsReached(true);
-              }
-              routeBaseEventToBus(event, eventBus);
-              break;
-            case 'message-start':
-            case 'tool-execute-start':
-            case 'tool-execute-end':
-            case 'tool-execute-delta':
-            case 'thinking-start':
-            case 'thinking-delta':
-            case 'thinking-end':
-              routeBaseEventToBus(event, eventBus);
-              break;
-            case 'error':
-              eventBus.emit('stream-error', {message: event.message});
-              setStreamError(event.message);
-              break;
-            case 'subagent-dispatch': {
-              const bus = new EventBus<ChatEventMap>();
-              subagentBusMapRef.current.set(event.agentId, bus);
-              eventBus.emit('subagent-dispatched', {
-                agentId: event.agentId,
-                task: event.task,
-                agentType: event.agentType,
-                thinkingLevel: event.thinkingLevel,
-                workingDirectory: event.workingDirectory,
-                eventBus: bus,
-              });
-              break;
-            }
-            case 'subagent-output': {
-              const bus = subagentBusMapRef.current.get(event.agentId);
-              if (bus) routeBaseEventToBus(event.event, bus);
-              break;
-            }
-            case 'subagent-complete': {
-              const bus = subagentBusMapRef.current.get(event.agentId);
-              if (bus) bus.emit('stream-end');
-              eventBus.emit('subagent-completed', {
-                agentId: event.agentId,
-                status: event.status,
-              });
-              subagentBusMapRef.current.delete(event.agentId);
-              break;
-            }
-          }
-        }
+        await apiSendMessage(activeSessionId, trimmed, thinkingLevel);
       } catch (e: unknown) {
-        if (e instanceof DOMException && e.name === 'AbortError') {
-          // Intentional stop — not an error. Keep partial content.
-        } else {
-          console.error('Chat completion failed', e);
-          const message =
-            e instanceof Error ? e.message : 'An unexpected error occurred';
-          eventBus.emit('stream-error', {message});
-          setStreamError(message);
-        }
-      } finally {
-        // Complete any subagents still running (e.g. after user stops generation).
-        for (const [agentId, bus] of subagentBusMapRef.current) {
-          bus.emit('stream-end');
-          eventBus.emit('subagent-completed', {agentId, status: 'failure'});
-        }
-        subagentBusMapRef.current.clear();
-
-        if (assistantText) {
-          eventBus.emit('turn-done', {
-            sessionId: activeSessionId,
-            userMessage: trimmed,
-            assistantMessage: assistantText,
-          });
-        }
-        abortControllerRef.current = null;
-        eventBus.emit('stream-end');
+        console.error('Failed to send message', e);
+        const message =
+          e instanceof Error ? e.message : 'Failed to send message';
+        eventBus.emit('stream-error', {message});
+        setStreamError(message);
         setIsStreaming(false);
       }
     },
@@ -146,8 +126,9 @@ export function useStreamChat({
   );
 
   const stopGeneration = useCallback(() => {
-    abortControllerRef.current?.abort();
-  }, []);
+    if (!sessionId) return;
+    void abortCompletion(sessionId);
+  }, [sessionId]);
 
   const clearStreamError = useCallback(() => {
     setStreamError(null);
@@ -166,4 +147,71 @@ export function useStreamChat({
     clearStreamError,
     clearMaxRoundsReached,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Event routing — extracted to keep the hook body readable
+// ---------------------------------------------------------------------------
+
+function routeEvent(
+  event: SseEvent,
+  eventBus: EventBus<ChatEventMap>,
+  subagentBusMap: Map<string, EventBus<ChatEventMap>>,
+  setIsStreaming: (v: boolean) => void,
+  setStreamError: (v: string | null) => void,
+  setMaxRoundsReached: (v: boolean) => void,
+): void {
+  switch (event.type) {
+    case 'text-delta':
+    case 'tool-execute-start':
+    case 'tool-execute-end':
+    case 'tool-execute-delta':
+    case 'message-start':
+    case 'thinking-start':
+    case 'thinking-delta':
+    case 'thinking-end':
+      if (event.type === 'message-start' && event.role === 'assistant') {
+        setIsStreaming(true);
+      }
+      routeBaseEventToBus(event, eventBus);
+      break;
+    case 'done':
+      if (event.reason === 'max_rounds_reached') {
+        setMaxRoundsReached(true);
+      }
+      routeBaseEventToBus(event, eventBus);
+      setIsStreaming(false);
+      break;
+    case 'error':
+      eventBus.emit('stream-error', {message: event.message});
+      setStreamError(event.message);
+      setIsStreaming(false);
+      break;
+    case 'subagent-dispatch': {
+      const bus = new EventBus<ChatEventMap>();
+      subagentBusMap.set(event.agentId, bus);
+      eventBus.emit('subagent-dispatched', {
+        agentId: event.agentId,
+        task: event.task,
+        agentType: event.agentType,
+        thinkingLevel: event.thinkingLevel,
+        workingDirectory: event.workingDirectory,
+        eventBus: bus,
+      });
+      break;
+    }
+    case 'subagent-output': {
+      const bus = subagentBusMap.get(event.agentId);
+      if (bus) routeBaseEventToBus(event.event, bus);
+      break;
+    }
+    case 'subagent-complete': {
+      eventBus.emit('subagent-completed', {
+        agentId: event.agentId,
+        status: event.status,
+      });
+      subagentBusMap.delete(event.agentId);
+      break;
+    }
+  }
 }

--- a/apps/frontend/src/pages/chat/hooks/useStreamChat.ts
+++ b/apps/frontend/src/pages/chat/hooks/useStreamChat.ts
@@ -1,5 +1,4 @@
 import type {ThinkingLevel} from '@omnicraft/api-schema';
-import type {SseEvent} from '@omnicraft/sse-events';
 import {useCallback, useEffect, useRef, useState} from 'react';
 
 import {
@@ -54,32 +53,75 @@ export function useStreamChat({
         );
 
         for await (const event of eventStream) {
-          routeEvent(
-            event,
-            eventBus,
-            subagentBusMap,
-            setIsStreaming,
-            setStreamError,
-            setMaxRoundsReached,
-          );
-
-          if (event.type === 'message-start' && event.role === 'user') {
-            lastUserMessage = event.content;
-            assistantText = '';
-          }
-          if (event.type === 'text-delta') {
-            assistantText += event.content;
-          }
-          if (event.type === 'done') {
-            if (assistantText) {
-              eventBus.emit('turn-done', {
-                sessionId: activeSessionId,
-                userMessage: lastUserMessage,
-                assistantMessage: assistantText,
+          switch (event.type) {
+            case 'message-start':
+              if (event.role === 'user') {
+                lastUserMessage = event.content;
+                assistantText = '';
+              } else {
+                setIsStreaming(true);
+              }
+              routeBaseEventToBus(event, eventBus);
+              break;
+            case 'text-delta':
+              assistantText += event.content;
+              routeBaseEventToBus(event, eventBus);
+              break;
+            case 'tool-execute-start':
+            case 'tool-execute-end':
+            case 'tool-execute-delta':
+            case 'thinking-start':
+            case 'thinking-delta':
+            case 'thinking-end':
+              routeBaseEventToBus(event, eventBus);
+              break;
+            case 'done':
+              if (event.reason === 'max_rounds_reached') {
+                setMaxRoundsReached(true);
+              }
+              routeBaseEventToBus(event, eventBus);
+              setIsStreaming(false);
+              if (assistantText) {
+                eventBus.emit('turn-done', {
+                  sessionId: activeSessionId,
+                  userMessage: lastUserMessage,
+                  assistantMessage: assistantText,
+                });
+              }
+              lastUserMessage = '';
+              assistantText = '';
+              break;
+            case 'error':
+              eventBus.emit('stream-error', {message: event.message});
+              setStreamError(event.message);
+              setIsStreaming(false);
+              break;
+            case 'subagent-dispatch': {
+              const bus = new EventBus<ChatEventMap>();
+              subagentBusMap.set(event.agentId, bus);
+              eventBus.emit('subagent-dispatched', {
+                agentId: event.agentId,
+                task: event.task,
+                agentType: event.agentType,
+                thinkingLevel: event.thinkingLevel,
+                workingDirectory: event.workingDirectory,
+                eventBus: bus,
               });
+              break;
             }
-            lastUserMessage = '';
-            assistantText = '';
+            case 'subagent-output': {
+              const bus = subagentBusMap.get(event.agentId);
+              if (bus) routeBaseEventToBus(event.event, bus);
+              break;
+            }
+            case 'subagent-complete': {
+              eventBus.emit('subagent-completed', {
+                agentId: event.agentId,
+                status: event.status,
+              });
+              subagentBusMap.delete(event.agentId);
+              break;
+            }
           }
         }
       } catch (e: unknown) {
@@ -151,71 +193,4 @@ export function useStreamChat({
     clearStreamError,
     clearMaxRoundsReached,
   };
-}
-
-// ---------------------------------------------------------------------------
-// Event routing
-// ---------------------------------------------------------------------------
-
-function routeEvent(
-  event: SseEvent,
-  eventBus: EventBus<ChatEventMap>,
-  subagentBusMap: Map<string, EventBus<ChatEventMap>>,
-  setIsStreaming: (v: boolean) => void,
-  setStreamError: (v: string | null) => void,
-  setMaxRoundsReached: (v: boolean) => void,
-): void {
-  switch (event.type) {
-    case 'text-delta':
-    case 'tool-execute-start':
-    case 'tool-execute-end':
-    case 'tool-execute-delta':
-    case 'message-start':
-    case 'thinking-start':
-    case 'thinking-delta':
-    case 'thinking-end':
-      if (event.type === 'message-start' && event.role === 'assistant') {
-        setIsStreaming(true);
-      }
-      routeBaseEventToBus(event, eventBus);
-      break;
-    case 'done':
-      if (event.reason === 'max_rounds_reached') {
-        setMaxRoundsReached(true);
-      }
-      routeBaseEventToBus(event, eventBus);
-      setIsStreaming(false);
-      break;
-    case 'error':
-      eventBus.emit('stream-error', {message: event.message});
-      setStreamError(event.message);
-      setIsStreaming(false);
-      break;
-    case 'subagent-dispatch': {
-      const bus = new EventBus<ChatEventMap>();
-      subagentBusMap.set(event.agentId, bus);
-      eventBus.emit('subagent-dispatched', {
-        agentId: event.agentId,
-        task: event.task,
-        agentType: event.agentType,
-        thinkingLevel: event.thinkingLevel,
-        workingDirectory: event.workingDirectory,
-        eventBus: bus,
-      });
-      break;
-    }
-    case 'subagent-output': {
-      const bus = subagentBusMap.get(event.agentId);
-      if (bus) routeBaseEventToBus(event.event, bus);
-      break;
-    }
-    case 'subagent-complete': {
-      eventBus.emit('subagent-completed', {
-        agentId: event.agentId,
-        status: event.status,
-      });
-      subagentBusMap.delete(event.agentId);
-      break;
-    }
-  }
 }

--- a/apps/frontend/src/pages/chat/hooks/useStreamChat.ts
+++ b/apps/frontend/src/pages/chat/hooks/useStreamChat.ts
@@ -36,20 +36,62 @@ export function useStreamChat({
   useEffect(() => {
     if (!sessionId) return;
 
+    const activeSessionId = sessionId;
     const controller = new AbortController();
     const subagentBusMap = subagentBusMapRef.current;
 
     eventBus.emit('reset');
 
-    void consumeEventStream(
-      sessionId,
-      controller.signal,
-      eventBus,
-      subagentBusMap,
-      setIsStreaming,
-      setStreamError,
-      setMaxRoundsReached,
-    );
+    async function consume(): Promise<void> {
+      let lastUserMessage = '';
+      let assistantText = '';
+
+      try {
+        const eventStream = subscribeEvents(
+          activeSessionId,
+          0,
+          controller.signal,
+        );
+
+        for await (const event of eventStream) {
+          routeEvent(
+            event,
+            eventBus,
+            subagentBusMap,
+            setIsStreaming,
+            setStreamError,
+            setMaxRoundsReached,
+          );
+
+          if (event.type === 'message-start' && event.role === 'user') {
+            lastUserMessage = event.content;
+            assistantText = '';
+          }
+          if (event.type === 'text-delta') {
+            assistantText += event.content;
+          }
+          if (event.type === 'done') {
+            if (assistantText) {
+              eventBus.emit('turn-done', {
+                sessionId: activeSessionId,
+                userMessage: lastUserMessage,
+                assistantMessage: assistantText,
+              });
+            }
+            lastUserMessage = '';
+            assistantText = '';
+          }
+        }
+      } catch (e: unknown) {
+        if (e instanceof DOMException && e.name === 'AbortError') return;
+        console.error('SSE connection failed', e);
+        const message =
+          e instanceof Error ? e.message : 'An unexpected error occurred';
+        setStreamError(message);
+      }
+    }
+
+    void consume();
 
     return () => {
       controller.abort();
@@ -112,65 +154,7 @@ export function useStreamChat({
 }
 
 // ---------------------------------------------------------------------------
-// SSE connection — consumes the event stream and routes events to the bus
-// ---------------------------------------------------------------------------
-
-async function consumeEventStream(
-  sessionId: string,
-  signal: AbortSignal,
-  eventBus: EventBus<ChatEventMap>,
-  subagentBusMap: Map<string, EventBus<ChatEventMap>>,
-  setIsStreaming: (v: boolean) => void,
-  setStreamError: (v: string | null) => void,
-  setMaxRoundsReached: (v: boolean) => void,
-): Promise<void> {
-  let lastUserMessage = '';
-  let assistantText = '';
-
-  try {
-    const eventStream = subscribeEvents(sessionId, 0, signal);
-
-    for await (const event of eventStream) {
-      routeEvent(
-        event,
-        eventBus,
-        subagentBusMap,
-        setIsStreaming,
-        setStreamError,
-        setMaxRoundsReached,
-      );
-
-      // Track turn context for title generation
-      if (event.type === 'message-start' && event.role === 'user') {
-        lastUserMessage = event.content;
-        assistantText = '';
-      }
-      if (event.type === 'text-delta') {
-        assistantText += event.content;
-      }
-      if (event.type === 'done') {
-        if (assistantText) {
-          eventBus.emit('turn-done', {
-            sessionId,
-            userMessage: lastUserMessage,
-            assistantMessage: assistantText,
-          });
-        }
-        lastUserMessage = '';
-        assistantText = '';
-      }
-    }
-  } catch (e: unknown) {
-    if (e instanceof DOMException && e.name === 'AbortError') return;
-    console.error('SSE connection failed', e);
-    const message =
-      e instanceof Error ? e.message : 'An unexpected error occurred';
-    setStreamError(message);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Event routing — extracted to keep the hook body readable
+// Event routing
 // ---------------------------------------------------------------------------
 
 function routeEvent(

--- a/apps/frontend/src/pages/chat/hooks/useStreamChat.ts
+++ b/apps/frontend/src/pages/chat/hooks/useStreamChat.ts
@@ -37,57 +37,19 @@ export function useStreamChat({
     if (!sessionId) return;
 
     const controller = new AbortController();
-    let lastUserMessage = '';
-    let assistantText = '';
-
     const subagentBusMap = subagentBusMapRef.current;
 
     eventBus.emit('reset');
 
-    void (async () => {
-      try {
-        for await (const event of subscribeEvents(
-          sessionId,
-          0,
-          controller.signal,
-        )) {
-          routeEvent(
-            event,
-            eventBus,
-            subagentBusMap,
-            setIsStreaming,
-            setStreamError,
-            setMaxRoundsReached,
-          );
-
-          // Track turn context for title generation
-          if (event.type === 'message-start' && event.role === 'user') {
-            lastUserMessage = event.content;
-            assistantText = '';
-          }
-          if (event.type === 'text-delta') {
-            assistantText += event.content;
-          }
-          if (event.type === 'done') {
-            if (assistantText) {
-              eventBus.emit('turn-done', {
-                sessionId,
-                userMessage: lastUserMessage,
-                assistantMessage: assistantText,
-              });
-            }
-            lastUserMessage = '';
-            assistantText = '';
-          }
-        }
-      } catch (e: unknown) {
-        if (e instanceof DOMException && e.name === 'AbortError') return;
-        console.error('SSE connection failed', e);
-        const message =
-          e instanceof Error ? e.message : 'An unexpected error occurred';
-        setStreamError(message);
-      }
-    })();
+    void consumeEventStream(
+      sessionId,
+      controller.signal,
+      eventBus,
+      subagentBusMap,
+      setIsStreaming,
+      setStreamError,
+      setMaxRoundsReached,
+    );
 
     return () => {
       controller.abort();
@@ -147,6 +109,64 @@ export function useStreamChat({
     clearStreamError,
     clearMaxRoundsReached,
   };
+}
+
+// ---------------------------------------------------------------------------
+// SSE connection — consumes the event stream and routes events to the bus
+// ---------------------------------------------------------------------------
+
+async function consumeEventStream(
+  sessionId: string,
+  signal: AbortSignal,
+  eventBus: EventBus<ChatEventMap>,
+  subagentBusMap: Map<string, EventBus<ChatEventMap>>,
+  setIsStreaming: (v: boolean) => void,
+  setStreamError: (v: string | null) => void,
+  setMaxRoundsReached: (v: boolean) => void,
+): Promise<void> {
+  let lastUserMessage = '';
+  let assistantText = '';
+
+  try {
+    const eventStream = subscribeEvents(sessionId, 0, signal);
+
+    for await (const event of eventStream) {
+      routeEvent(
+        event,
+        eventBus,
+        subagentBusMap,
+        setIsStreaming,
+        setStreamError,
+        setMaxRoundsReached,
+      );
+
+      // Track turn context for title generation
+      if (event.type === 'message-start' && event.role === 'user') {
+        lastUserMessage = event.content;
+        assistantText = '';
+      }
+      if (event.type === 'text-delta') {
+        assistantText += event.content;
+      }
+      if (event.type === 'done') {
+        if (assistantText) {
+          eventBus.emit('turn-done', {
+            sessionId,
+            userMessage: lastUserMessage,
+            assistantMessage: assistantText,
+          });
+        }
+        lastUserMessage = '';
+        assistantText = '';
+      }
+    }
+  } catch (e: unknown) {
+    if (e instanceof DOMException && e.name === 'AbortError') return;
+    console.error('SSE connection failed', e);
+    const message =
+      e instanceof Error ? e.message : 'An unexpected error occurred';
+    setStreamError(message);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/frontend/src/router/router.tsx
+++ b/apps/frontend/src/router/router.tsx
@@ -26,7 +26,7 @@ export const router = createBrowserRouter([
         element: null,
       },
       {
-        path: ROUTES.chat(),
+        path: `${ROUTES.chat()}/:sessionId?`,
         element: <ChatPage />,
       },
       {

--- a/docs/superpowers/plans/2026-04-14-session-decoupling.md
+++ b/docs/superpowers/plans/2026-04-14-session-decoupling.md
@@ -51,9 +51,9 @@ reason: z.enum(['complete', 'max_rounds_reached']),
 reason: z.enum(['complete', 'max_rounds_reached', 'aborted']),
 ```
 
-- [ ] **Step 2: Add optional `content` to message-start event**
+- [ ] **Step 2: Add required `content` to message-start event**
 
-The `content` field carries user message text, enabling session replay without the frontend-only `user-message-sent` event.
+The `content` field carries message text. For user messages it's the full text (enables session replay). For assistant messages it's an empty string (content arrives via `text-delta`).
 
 ```typescript
 // packages/sse-events/src/schema.ts — lines 37-42
@@ -70,8 +70,7 @@ export const sseMessageStartEventSchema = z.object({
   role: z.enum(['user', 'assistant']),
   messageId: z.string(),
   createdAt: z.number(),
-  /** User message text. Present only for role='user', used for session replay. */
-  content: z.string().optional(),
+  content: z.string(),
 });
 ```
 
@@ -544,7 +543,23 @@ private async *runAgentLoop(
 }
 ```
 
-- [ ] **Step 6: Replace `handleUserMessage` with fire-and-forget**
+- [ ] **Step 6: Update `consumeStream` — add `content` to assistant message-start**
+
+In the existing `consumeStream` private method, update the `message-start` case to include the required `content` field (empty string for assistant):
+
+```typescript
+case 'message-start':
+  yield {
+    type: 'message-start',
+    role: 'assistant',
+    messageId: event.messageId,
+    createdAt: event.createdAt,
+    content: '',
+  } satisfies SseMessageStartEvent;
+  break;
+```
+
+- [ ] **Step 7: Replace `handleUserMessage` with fire-and-forget**
 
 ```typescript
 /**
@@ -561,12 +576,12 @@ handleUserMessage(
 
 Remove `signal` from the method's JSDoc and parameter list. The method no longer returns `AgentEventStream`.
 
-- [ ] **Step 7: Verify typecheck**
+- [ ] **Step 8: Verify typecheck**
 
 Run: `cd apps/backend && bun run typecheck`
 Expected: Errors in chat-service.ts, router.ts, dispatch-agent-tool.ts (they still use the old signature). These will be fixed in subsequent tasks.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 9: Commit**
 
 ```
 refactor(backend): convert Agent to push-based execution with sseLog
@@ -1085,24 +1100,21 @@ function applyUserMessageStart(
     }
   }
   // Replay: no user-message-sent was fired. Create from event content.
-  if (event.content !== undefined) {
-    return [
-      ...prev,
-      {
-        id: event.messageId,
-        createdAt: event.createdAt,
-        role: 'user' as const,
-        content: {type: 'text' as const, content: event.content},
-      },
-      {
-        id: null,
-        createdAt: null,
-        role: 'assistant' as const,
-        content: {type: 'text' as const, content: ''},
-      },
-    ];
-  }
-  return prev;
+  return [
+    ...prev,
+    {
+      id: event.messageId,
+      createdAt: event.createdAt,
+      role: 'user' as const,
+      content: {type: 'text' as const, content: event.content},
+    },
+    {
+      id: null,
+      createdAt: null,
+      role: 'assistant' as const,
+      content: {type: 'text' as const, content: ''},
+    },
+  ];
 }
 ```
 
@@ -1204,7 +1216,7 @@ export function useStreamChat({
 
           // Track turn context for title generation
           if (event.type === 'message-start' && event.role === 'user') {
-            lastUserMessage = event.content ?? '';
+            lastUserMessage = event.content;
             assistantText = '';
           }
           if (event.type === 'text-delta') {
@@ -1472,7 +1484,7 @@ Expected: PASS
 
 ## Notes
 
-**Spec addition (not in original spec):** `SseMessageStartEvent.content` was added for user role messages. Without it, session replay cannot reconstruct user message text because `user-message-sent` is a frontend-only event that doesn't flow through the SSE stream. This is the minimal change to make replay work.
+**Spec addition (not in original spec):** `SseMessageStartEvent.content` was added as a required `string` field. For user messages, it carries the full message text (enables session replay without the frontend-only `user-message-sent` event). For assistant messages, it is an empty string (content arrives via `text-delta`).
 
 **Subagent abort behavior:** When the parent aborts, the subagent's subscribe reader ends silently (via the parent's AbortSignal). The subagent's abort completion events (written to the subagent's sseLog) may not reach the parent's event stream. The dispatch tool detects this (no `done` event seen) and emits `subagent-complete(failure)`. The subagent display may appear incomplete in the abort scenario — acceptable since the entire conversation is in an aborted state.
 

--- a/docs/superpowers/plans/2026-04-14-session-decoupling.md
+++ b/docs/superpowers/plans/2026-04-14-session-decoupling.md
@@ -1,0 +1,1479 @@
+# Session Decoupling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Decouple Agent execution from frontend SSE connections so sessions persist independently and support reconnection via session ID.
+
+**Architecture:** Convert Agent from pull-based (async generator consumed by HTTP handler) to push-based (internal background pump writing to AgentSseLog). Frontend connects via a persistent `GET /events` SSE endpoint that replays historical events and tails new ones. Turns are serialized via Mutex; abort writes proper completion events to the log.
+
+**Tech Stack:** Bun, Koa, Zod, React, React Router, SSE
+
+**Spec:** `docs/superpowers/specs/2026-04-14-session-decoupling-design.md`
+
+---
+
+## File Structure
+
+**Modified:**
+
+- `packages/sse-events/src/schema.ts` — Add `'aborted'` to done reason; add optional `content` to message-start (for replay)
+- `apps/backend/src/agent-core/agent/agent-sse-log.ts` — Remove `seal()`/`get sealed`; readers end via AbortSignal only
+- `apps/backend/src/agent-core/agent/agent-sse-log.test.ts` — Update tests for no-seal behavior
+- `apps/backend/src/agent-core/agent/agent.ts` — Push-based refactor: add `sseLog`, `mutex`, `runTurn`, `pump`, `subscribe`, `abort`; extract `runAgentLoop` with abort completion
+- `apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts` — Use `subscribe()` + `abort()` instead of generator iteration
+- `apps/backend/src/services/chat/chat-service.ts` — Update `streamCompletion`; add `subscribe`, `abortCompletion`
+- `apps/backend/src/dispatcher/chat/router.ts` — Modify completions (202, no SSE); add `GET /events`, `POST /abort`
+- `apps/backend/src/dispatcher/chat/path.ts` — Add path constants for new endpoints
+- `apps/backend/src/dispatcher/chat/helpers/sse.ts` — Export `writeSseEvent` (currently used only internally)
+- `apps/frontend/src/api/chat/chat.ts` — Replace `streamChatCompletion` with `sendMessage` + `subscribeEvents` + `abortCompletion`
+- `apps/frontend/src/router/router.tsx` — Add `:sessionId?` parameter to chat route
+- `apps/frontend/src/pages/chat/ChatPage.tsx` — Read URL param, pass `initialSessionId` to provider, navigate on creation
+- `apps/frontend/src/pages/chat/hooks/useStreamChat.ts` — Persistent SSE connection effect, POST-only `sendMessage`/`stopGeneration`
+- `apps/frontend/src/pages/chat/components/StreamingMessageDisplay/hooks/useMessages.ts` — Remove `completeUnfinishedTools`, `stream-end` handler; add `done` handler; update `message-start` handler for replay
+- `apps/frontend/src/pages/chat/components/StreamingMessageDisplay/types.ts` — Remove `stream-end` from `ChatEventMap`
+- `apps/frontend/src/pages/chat/contexts/SessionIdContext/SessionIdProvider.tsx` — Accept `initialSessionId` prop
+
+---
+
+### Task 1: SSE Event Schema Changes
+
+**Files:**
+
+- Modify: `packages/sse-events/src/schema.ts`
+
+- [ ] **Step 1: Add `'aborted'` to done reason enum**
+
+```typescript
+// packages/sse-events/src/schema.ts — line 68
+// Change:
+reason: z.enum(['complete', 'max_rounds_reached']),
+// To:
+reason: z.enum(['complete', 'max_rounds_reached', 'aborted']),
+```
+
+- [ ] **Step 2: Add optional `content` to message-start event**
+
+The `content` field carries user message text, enabling session replay without the frontend-only `user-message-sent` event.
+
+```typescript
+// packages/sse-events/src/schema.ts — lines 37-42
+// Change:
+export const sseMessageStartEventSchema = z.object({
+  type: z.literal('message-start'),
+  role: z.enum(['user', 'assistant']),
+  messageId: z.string(),
+  createdAt: z.number(),
+});
+// To:
+export const sseMessageStartEventSchema = z.object({
+  type: z.literal('message-start'),
+  role: z.enum(['user', 'assistant']),
+  messageId: z.string(),
+  createdAt: z.number(),
+  /** User message text. Present only for role='user', used for session replay. */
+  content: z.string().optional(),
+});
+```
+
+- [ ] **Step 3: Verify typecheck**
+
+Run: `cd packages/sse-events && bun run typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```
+feat(sse-events): add 'aborted' done reason and content to message-start
+```
+
+---
+
+### Task 2: AgentSseLog — Remove Seal
+
+**Files:**
+
+- Modify: `apps/backend/src/agent-core/agent/agent-sse-log.ts`
+- Modify: `apps/backend/src/agent-core/agent/agent-sse-log.test.ts`
+
+- [ ] **Step 1: Update tests — remove seal-based tests, add no-seal tests**
+
+Remove or update test cases that use `seal()`. Add a test verifying that `append` works indefinitely and readers end only via `AbortSignal`.
+
+In `agent-sse-log.test.ts`, remove tests that call `log.seal()` or assert `log.sealed`. Replace the "reader ends when log is sealed" test with:
+
+```typescript
+describe('reader ends only via AbortSignal', () => {
+  it('reader blocks indefinitely when not aborted', async () => {
+    const log = new AgentSseLog();
+    log.append(textDelta('a'));
+
+    const reader = log.createReader();
+    const iter = reader[Symbol.asyncIterator]();
+
+    // First event is available immediately
+    const first = await iter.next();
+    expect(first.value).toEqual(textDelta('a'));
+
+    // Next call blocks — resolve a race to prove it
+    const timeout = new Promise<'timeout'>((r) =>
+      setTimeout(() => r('timeout'), 50),
+    );
+    const next = iter.next().then(() => 'resolved' as const);
+    expect(await Promise.race([next, timeout])).toBe('timeout');
+  });
+
+  it('reader ends when signal is aborted after draining', async () => {
+    const log = new AgentSseLog();
+    log.append(textDelta('a'));
+    log.append(textDelta('b'));
+
+    const controller = new AbortController();
+    const collected = collect(log.createReader({signal: controller.signal}));
+
+    // Let the reader drain existing events, then abort
+    await new Promise((r) => setTimeout(r, 10));
+    controller.abort();
+
+    const events = await collected;
+    expect(events).toEqual([textDelta('a'), textDelta('b')]);
+  });
+});
+```
+
+Remove the `'append and seal basics'` test assertions about sealed state and throwing on sealed append. Replace with:
+
+```typescript
+it('append always works (no seal)', () => {
+  const log = new AgentSseLog();
+  log.append(textDelta('a'));
+  log.append(textDelta('b'));
+  log.append(textDelta('c'));
+  expect(log.length).toBe(3);
+  // Can keep appending indefinitely
+  log.append(doneEvent());
+  expect(log.length).toBe(4);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && bun test agent-sse-log`
+Expected: FAIL (seal still exists, removed tests reference it)
+
+- [ ] **Step 3: Remove seal from AgentSseLog**
+
+In `agent-sse-log.ts`:
+
+1. Remove `private isSealedFlag = false;`
+2. Remove `get sealed(): boolean` getter
+3. Remove `seal(): void` method
+4. Remove `if (this.isSealedFlag)` guard from `append()`
+5. Remove `if (this.isSealedFlag) return;` from `readerIterator()`
+
+The resulting class:
+
+```typescript
+export class AgentSseLog {
+  private readonly events: SseEvent[] = [];
+  private readonly waiters = new Set<() => void>();
+
+  get length(): number {
+    return this.events.length;
+  }
+
+  append(event: SseEvent): void {
+    this.events.push(event);
+    this.notifyWaiters();
+  }
+
+  createReader(options?: AgentSseLogReaderOptions): AsyncIterable<SseEvent> {
+    const startIndex = options?.startIndex ?? 0;
+    assert(startIndex >= 0, 'startIndex must be non-negative');
+    const signal = options?.signal;
+    return {
+      [Symbol.asyncIterator]: () => this.readerIterator(startIndex, signal),
+    };
+  }
+
+  private async *readerIterator(
+    cursor: number,
+    signal?: AbortSignal,
+  ): AsyncIterableIterator<SseEvent> {
+    if (signal?.aborted) return;
+
+    for (;;) {
+      while (cursor < this.events.length) {
+        yield this.events[cursor];
+        cursor++;
+        if (signal?.aborted) return;
+      }
+
+      // Wait for new events or abort.
+      const aborted = await this.waitForChange(signal);
+      if (aborted) return;
+    }
+  }
+
+  private waitForChange(signal?: AbortSignal): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      const cleanup = (): void => {
+        this.waiters.delete(onNotify);
+        signal?.removeEventListener('abort', onAbort);
+      };
+
+      const onNotify = (): void => {
+        cleanup();
+        resolve(false);
+      };
+
+      const onAbort = (): void => {
+        cleanup();
+        resolve(true);
+      };
+
+      this.waiters.add(onNotify);
+
+      if (signal) {
+        if (signal.aborted) {
+          cleanup();
+          resolve(true);
+          return;
+        }
+        signal.addEventListener('abort', onAbort, {once: true});
+      }
+    });
+  }
+
+  private notifyWaiters(): void {
+    const current = [...this.waiters];
+    this.waiters.clear();
+    for (const notify of current) {
+      notify();
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/backend && bun test agent-sse-log`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```
+refactor(backend): remove seal from AgentSseLog
+```
+
+---
+
+### Task 3: Agent Class Refactor
+
+**Files:**
+
+- Modify: `apps/backend/src/agent-core/agent/agent.ts`
+- Modify: `apps/backend/src/agent-core/agent/types.ts` (if needed for export)
+
+This is the largest task. It restructures the Agent from pull-based to push-based execution.
+
+- [ ] **Step 1: Add new imports and properties**
+
+Add imports at top of `agent.ts`:
+
+```typescript
+import {Mutex} from '@/helpers/mutex.js';
+
+import {AgentSseLog} from './agent-sse-log.js';
+```
+
+Add new properties to the `Agent` class (after `userInteractionBridge`):
+
+```typescript
+/** Append-only event log. All turns write to the same log. */
+readonly sseLog = new AgentSseLog();
+
+/** Serializes turns — only one runs at a time. */
+private readonly mutex = new Mutex();
+
+/** Per-turn abort controller. Null when no turn is running. */
+private abortController: AbortController | null = null;
+```
+
+- [ ] **Step 2: Add `subscribe()` and `abort()` methods**
+
+Add after `submitUserResponse()`:
+
+```typescript
+/** Returns an async iterable of events from this agent's log. */
+subscribe(options?: AgentSseLogReaderOptions): AsyncIterable<SseEvent> {
+  return this.sseLog.createReader(options);
+}
+
+/** Aborts the currently running turn, if any. */
+abort(): void {
+  this.abortController?.abort();
+}
+```
+
+Add necessary imports:
+
+```typescript
+import type {SseEvent} from '@omnicraft/sse-events';
+
+import type {AgentSseLogReaderOptions} from './agent-sse-log.js';
+```
+
+- [ ] **Step 3: Add `runTurn()` and `pump()` private methods**
+
+```typescript
+/**
+ * Acquires the turn mutex, runs the agent loop, and pumps events to sseLog.
+ * Multiple calls queue safely behind the mutex.
+ */
+private async runTurn(
+  userMessage: string,
+  thinkingLevel: ThinkingLevel,
+): Promise<void> {
+  const release = await this.mutex.acquire();
+  try {
+    this.abortController = new AbortController();
+    const stream = this.runAgentLoop(
+      userMessage,
+      thinkingLevel,
+      this.abortController.signal,
+    );
+    await this.pump(stream);
+  } finally {
+    this.abortController = null;
+    release();
+  }
+}
+
+/** Consumes an event stream and appends each event to sseLog. */
+private async pump(stream: AgentEventStream): Promise<void> {
+  try {
+    for await (const event of stream) {
+      this.sseLog.append(event);
+    }
+  } catch {
+    this.sseLog.append({type: 'error', message: 'An internal error occurred'});
+  }
+}
+```
+
+- [ ] **Step 4: Add `emitAbortCompletion()` private method**
+
+```typescript
+/**
+ * Yields tool-execute-end events for any in-flight tools,
+ * then yields done(aborted). Ensures the sseLog always has
+ * a complete event sequence after abort.
+ */
+private async *emitAbortCompletion(
+  inFlightToolCalls: Set<string>,
+): AgentEventStream {
+  for (const callId of inFlightToolCalls) {
+    yield {
+      type: 'tool-execute-end',
+      callId,
+      result: 'Aborted',
+      status: 'error',
+      data: {message: 'Aborted'},
+    } satisfies SseToolExecuteEndEvent;
+  }
+  yield {
+    type: 'done',
+    reason: 'aborted',
+    usage: await this.buildSseUsage(),
+  } satisfies SseDoneEvent;
+}
+```
+
+- [ ] **Step 5: Rename `handleUserMessage` to `runAgentLoop` (private), add abort completion**
+
+Rename the existing `handleUserMessage` generator to `private async *runAgentLoop`. Keep the same body with these changes:
+
+1. Add `inFlightToolCalls` tracking set at the top of the method.
+2. At each `tool-execute-start` yield, add the callId to the set.
+3. When yielding events from the tool channel, delete callIds for `tool-execute-end` events. Add `if (signal.aborted) break;` to exit the channel loop early.
+4. At each abort checkpoint, replace bare `return` with `yield* this.emitAbortCompletion(inFlightToolCalls); return;`.
+
+```typescript
+private async *runAgentLoop(
+  userMessage: string,
+  thinkingLevel: ThinkingLevel,
+  signal: AbortSignal,
+): AgentEventStream {
+  const inFlightToolCalls = new Set<string>();
+  const maxRounds = await this.getMaxToolRounds();
+
+  const {
+    stream: userStream,
+    messageId,
+    createdAt,
+  } = this.llmSession.sendUserMessage(
+    userMessage,
+    [...this.getAvailableTools().values()],
+    this.buildSystemPrompt(),
+    thinkingLevel,
+    signal,
+  );
+
+  yield {
+    type: 'message-start',
+    role: 'user',
+    messageId,
+    createdAt,
+    content: userMessage,
+  } satisfies SseMessageStartEvent;
+
+  let toolCalls = yield* this.consumeStream(userStream);
+
+  let round = 0;
+  while (toolCalls.length > 0) {
+    if (signal.aborted) {
+      yield* this.emitAbortCompletion(inFlightToolCalls);
+      return;
+    }
+
+    round++;
+    if (round > maxRounds) {
+      yield {
+        type: 'done',
+        reason: 'max_rounds_reached',
+        usage: await this.buildSseUsage(),
+      } satisfies SseDoneEvent;
+      return;
+    }
+
+    const availableTools = this.getAvailableTools();
+
+    for (const toolCall of toolCalls) {
+      const tool = availableTools.get(toolCall.toolName);
+      if (!tool || tool.suppressToolEvents) continue;
+      inFlightToolCalls.add(toolCall.callId);
+      yield {
+        type: 'tool-execute-start',
+        callId: toolCall.callId,
+        toolName: tool.name as ToolName,
+        displayName: tool.displayName,
+        arguments: toolCall.arguments,
+      } satisfies SseToolExecuteStartEvent;
+    }
+
+    const toolSseEventChannel = new AsyncChannel<
+      SseToolExecuteEndEvent | SseToolExecuteDeltaEvent | SseSubAgentEvent
+    >();
+    const toolResults = new Map<string, ToolResult>();
+
+    for (const toolCall of toolCalls) {
+      if (availableTools.has(toolCall.toolName)) continue;
+      toolResults.set(toolCall.callId, {
+        callId: toolCall.callId,
+        content: `Error: Unknown tool: ${toolCall.toolName}`,
+      });
+    }
+
+    const executions = toolCalls
+      .filter((tc) => availableTools.has(tc.toolName))
+      .map(async (toolCall) => {
+        const result = await this.executeTool(
+          toolCall,
+          availableTools,
+          toolSseEventChannel,
+          signal,
+        );
+
+        const tool = availableTools.get(toolCall.toolName);
+        if (!tool?.suppressToolEvents) {
+          toolSseEventChannel.push({
+            type: 'tool-execute-end' as const,
+            callId: toolCall.callId,
+            result: result.content,
+            status: result.status,
+            data: result.data,
+          } satisfies SseToolExecuteEndEvent);
+        }
+
+        toolResults.set(toolCall.callId, {
+          callId: toolCall.callId,
+          content: result.content,
+        });
+      });
+
+    void Promise.all(executions)
+      .catch(() => {})
+      .finally(() => {
+        toolSseEventChannel.close();
+      });
+
+    for await (const event of toolSseEventChannel) {
+      if (event.type === 'tool-execute-end') {
+        inFlightToolCalls.delete(event.callId);
+      }
+      yield event;
+      if (signal.aborted) break;
+    }
+
+    if (signal.aborted) {
+      yield* this.emitAbortCompletion(inFlightToolCalls);
+      return;
+    }
+
+    const orderedResults = toolCalls.flatMap((tc) => {
+      const result = toolResults.get(tc.callId);
+      return result ? [result] : [];
+    });
+
+    toolCalls = yield* this.consumeStream(
+      this.llmSession.submitToolResults(
+        orderedResults,
+        [...this.getAvailableTools().values()],
+        this.buildSystemPrompt(),
+        thinkingLevel,
+        signal,
+      ),
+    );
+  }
+
+  yield {
+    type: 'done',
+    reason: 'complete',
+    usage: await this.buildSseUsage(),
+  } satisfies SseDoneEvent;
+}
+```
+
+- [ ] **Step 6: Replace `handleUserMessage` with fire-and-forget**
+
+```typescript
+/**
+ * Handles a user message by running the full Agent Loop in the background.
+ * Events are written to {@link sseLog}. Use {@link subscribe} to read them.
+ */
+handleUserMessage(
+  userMessage: string,
+  thinkingLevel: ThinkingLevel,
+): void {
+  void this.runTurn(userMessage, thinkingLevel);
+}
+```
+
+Remove `signal` from the method's JSDoc and parameter list. The method no longer returns `AgentEventStream`.
+
+- [ ] **Step 7: Verify typecheck**
+
+Run: `cd apps/backend && bun run typecheck`
+Expected: Errors in chat-service.ts, router.ts, dispatch-agent-tool.ts (they still use the old signature). These will be fixed in subsequent tasks.
+
+- [ ] **Step 8: Commit**
+
+```
+refactor(backend): convert Agent to push-based execution with sseLog
+```
+
+---
+
+### Task 4: Subagent Dispatch Tool Adaptation
+
+**Files:**
+
+- Modify: `apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts`
+
+- [ ] **Step 1: Update dispatch tool to use push-based pattern**
+
+Replace the try block (lines 177-229) with:
+
+```typescript
+// Link parent abort signal to subagent
+const onAbort = () => subagent.abort();
+context.signal.addEventListener('abort', onAbort, {once: true});
+
+context.onSubAgentEvent({
+  type: 'subagent-dispatch',
+  agentId: subagent.id,
+  task,
+  agentType,
+  thinkingLevel,
+  workingDirectory,
+});
+
+try {
+  subagent.handleUserMessage(task, thinkingLevel);
+
+  let lastReplyText = '';
+  let completed = false;
+  for await (const event of subagent.subscribe({signal: context.signal})) {
+    // Subagents cannot emit subagent events (no SubAgentToolRegistry),
+    // so all events are base events. Cast is safe by construction.
+    context.onSubAgentEvent({
+      type: 'subagent-output',
+      agentId: subagent.id,
+      event: event as SseBaseEvent,
+    });
+
+    if (event.type === 'message-start' && event.role === 'assistant') {
+      lastReplyText = '';
+    }
+    if (event.type === 'text-delta') {
+      lastReplyText += event.content;
+    }
+    // Subagent's sseLog is never sealed — break on done to end iteration.
+    // If the parent aborts, the reader ends silently (no done seen).
+    if (event.type === 'done') {
+      completed = true;
+      break;
+    }
+  }
+
+  context.onSubAgentEvent({
+    type: 'subagent-complete',
+    agentId: subagent.id,
+    status: completed ? 'success' : 'failure',
+  });
+
+  if (completed) {
+    const summary =
+      lastReplyText ||
+      'Subagent completed the task but produced no text summary.';
+    return {
+      data: {summary},
+      content: summary,
+      status: 'success',
+    };
+  }
+
+  return {
+    data: {message: 'Subagent was aborted'},
+    content: 'Subagent was aborted.',
+    status: 'failure',
+  };
+} catch (error: unknown) {
+  context.onSubAgentEvent({
+    type: 'subagent-complete',
+    agentId: subagent.id,
+    status: 'failure',
+  });
+
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    data: {message: `Subagent error: ${message}`},
+    content: `Subagent error: ${message}`,
+    status: 'failure',
+  };
+} finally {
+  context.signal.removeEventListener('abort', onAbort);
+}
+```
+
+Remove the `SseBaseEvent` type import if not already present; add it:
+
+```typescript
+import type {SseBaseEvent} from '@omnicraft/sse-events';
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `cd apps/backend && bun run typecheck`
+Expected: PASS for this file (agent.ts errors remain from Task 3)
+
+- [ ] **Step 3: Commit**
+
+```
+refactor(backend): adapt dispatch-agent-tool to push-based Agent
+```
+
+---
+
+### Task 5: Chat Service Layer Updates
+
+**Files:**
+
+- Modify: `apps/backend/src/services/chat/chat-service.ts`
+
+- [ ] **Step 1: Update `streamCompletion` and add new methods**
+
+Replace `streamCompletion` (currently returns `{eventStream, abort}`):
+
+```typescript
+/**
+ * Sends a user message to the agent. The agent runs in the background;
+ * use {@link subscribe} to read events. Returns false if agent not found.
+ */
+sendCompletion(
+  agentId: string,
+  userMessage: string,
+  thinkingLevel: ThinkingLevel,
+): boolean {
+  const agent = AgentStore.getInstance().get(agentId);
+  if (!agent) return false;
+  agent.handleUserMessage(userMessage, thinkingLevel);
+  return true;
+}
+
+/**
+ * Returns an async iterable of SSE events for the given agent.
+ * Returns undefined if agent not found.
+ */
+subscribe(
+  agentId: string,
+  options?: AgentSseLogReaderOptions,
+): AsyncIterable<SseEvent> | undefined {
+  const agent = AgentStore.getInstance().get(agentId);
+  if (!agent) return undefined;
+  return agent.subscribe(options);
+}
+
+/**
+ * Aborts the currently running turn for the given agent.
+ * Returns false if agent not found.
+ */
+abortCompletion(agentId: string): boolean {
+  const agent = AgentStore.getInstance().get(agentId);
+  if (!agent) return false;
+  agent.abort();
+  return true;
+}
+```
+
+Add imports:
+
+```typescript
+import type {SseEvent} from '@omnicraft/sse-events';
+
+import type {AgentSseLogReaderOptions} from '@/agent-core/agent/agent-sse-log.js';
+```
+
+Remove the old `StreamCompletionResult` type and the `AbortController` usage from the old `streamCompletion`.
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `cd apps/backend && bun run typecheck`
+Expected: Errors only in router.ts (still uses old API)
+
+- [ ] **Step 3: Commit**
+
+```
+refactor(backend): update chat service for push-based agent
+```
+
+---
+
+### Task 6: Backend API Changes
+
+**Files:**
+
+- Modify: `apps/backend/src/dispatcher/chat/path.ts`
+- Modify: `apps/backend/src/dispatcher/chat/router.ts`
+- Modify: `apps/backend/src/dispatcher/chat/helpers/sse.ts`
+
+- [ ] **Step 1: Add path constants**
+
+```typescript
+// path.ts — add:
+export const CHAT_SESSION_EVENTS = '/chat/session/:id/events';
+export const CHAT_SESSION_ABORT = '/chat/session/:id/abort';
+```
+
+- [ ] **Step 2: Export `writeSseEvent` from sse.ts**
+
+Change `function writeSseEvent` to `export function writeSseEvent` in `apps/backend/src/dispatcher/chat/helpers/sse.ts`.
+
+- [ ] **Step 3: Modify POST /completions — return 202, no SSE**
+
+Replace the completions handler (lines 59-107 in router.ts):
+
+```typescript
+/** POST /chat/session/:id/completions — starts a chat completion in the background. */
+router.post(CHAT_SESSION_COMPLETIONS, (ctx) => {
+  const {id} = ctx.params;
+
+  let message: string;
+  let thinkingLevel: ThinkingLevel;
+  try {
+    const body = chatCompletionsRequestSchema.parse(ctx.request.body);
+    message = body.message;
+    thinkingLevel = body.thinkingLevel;
+  } catch (e) {
+    if (e instanceof ZodError) {
+      ctx.response.status = StatusCodes.BAD_REQUEST;
+      ctx.response.body = {error: e.issues};
+      return;
+    }
+    throw e;
+  }
+
+  const found = chatService.sendCompletion(id, message, thinkingLevel);
+  if (!found) {
+    ctx.response.status = StatusCodes.NOT_FOUND;
+    ctx.response.body = {error: `Session not found: ${id}`};
+    return;
+  }
+
+  ctx.response.status = StatusCodes.ACCEPTED;
+});
+```
+
+- [ ] **Step 4: Add GET /events endpoint**
+
+```typescript
+/** GET /chat/session/:id/events — SSE stream of agent events. */
+router.get(CHAT_SESSION_EVENTS, async (ctx) => {
+  const {id} = ctx.params;
+  const from = Math.max(0, Number(ctx.query['from']) || 0);
+
+  const abortController = new AbortController();
+  const eventStream = chatService.subscribe(id, {
+    startIndex: from,
+    signal: abortController.signal,
+  });
+  if (!eventStream) {
+    ctx.response.status = StatusCodes.NOT_FOUND;
+    ctx.response.body = {error: `Session not found: ${id}`};
+    return;
+  }
+
+  ctx.response.type = 'text/event-stream';
+  ctx.response.set('Cache-Control', 'no-cache');
+  ctx.response.set('Connection', 'keep-alive');
+  ctx.response.set('X-Accel-Buffering', 'no');
+
+  const stream = new PassThrough();
+  ctx.body = stream;
+
+  const onDisconnect = () => {
+    ctx.req.off('close', onDisconnect);
+    abortController.abort();
+    if (!stream.destroyed) {
+      stream.destroy();
+    }
+  };
+  ctx.req.on('close', onDisconnect);
+
+  try {
+    for await (const event of eventStream) {
+      writeSseEvent(stream, event);
+    }
+  } finally {
+    ctx.req.off('close', onDisconnect);
+    if (!stream.destroyed) {
+      stream.end();
+    }
+  }
+});
+```
+
+Add imports:
+
+```typescript
+import {writeSseEvent} from './helpers/sse.js';
+import {CHAT_SESSION_EVENTS, CHAT_SESSION_ABORT} from './path.js';
+```
+
+Remove imports of `pumpEventStream` if no longer used.
+
+- [ ] **Step 5: Add POST /abort endpoint**
+
+```typescript
+/** POST /chat/session/:id/abort — aborts the running agent turn. */
+router.post(CHAT_SESSION_ABORT, (ctx) => {
+  const {id} = ctx.params;
+
+  const found = chatService.abortCompletion(id);
+  if (!found) {
+    ctx.response.status = StatusCodes.NOT_FOUND;
+    ctx.response.body = {error: `Session not found: ${id}`};
+    return;
+  }
+
+  ctx.response.status = StatusCodes.NO_CONTENT;
+});
+```
+
+- [ ] **Step 6: Verify backend typecheck and lint**
+
+Run: `cd apps/backend && bun run typecheck && bun run lint`
+Expected: PASS
+
+- [ ] **Step 7: Verify backend tests**
+
+Run: `cd apps/backend && bun test`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```
+feat(backend): add /events SSE and /abort endpoints, update /completions to 202
+```
+
+---
+
+### Task 7: Frontend API Layer
+
+**Files:**
+
+- Modify: `apps/frontend/src/api/chat/chat.ts`
+
+- [ ] **Step 1: Replace `streamChatCompletion` with `sendMessage` + `subscribeEvents` + `abortCompletion`**
+
+```typescript
+/**
+ * Sends a message to a chat session. The agent processes it in the background.
+ * Use {@link subscribeEvents} to receive events.
+ */
+export async function sendMessage(
+  sessionId: string,
+  message: string,
+  thinkingLevel: ThinkingLevel,
+): Promise<void> {
+  const res = await fetch(`${BASE}/session/${sessionId}/completions`, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({message, thinkingLevel}),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Chat request failed (${res.status.toString()}): ${body}`);
+  }
+}
+
+/**
+ * Subscribes to SSE events from a chat session.
+ * Replays from {@link from} index, then tails live events.
+ */
+export async function* subscribeEvents(
+  sessionId: string,
+  from: number,
+  signal?: AbortSignal,
+): AsyncGenerator<SseEvent, void, undefined> {
+  const url = `${BASE}/session/${sessionId}/events?from=${from.toString()}`;
+  const res = await fetch(url, {signal});
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `Event subscription failed (${res.status.toString()}): ${body}`,
+    );
+  }
+
+  for await (const data of parseSseStream(res)) {
+    const parsed: unknown = JSON.parse(data);
+    yield sseEventSchema.parse(parsed);
+  }
+}
+
+/** Aborts the currently running agent turn. */
+export async function abortCompletion(sessionId: string): Promise<void> {
+  const res = await fetch(`${BASE}/session/${sessionId}/abort`, {
+    method: 'POST',
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `Failed to abort completion (${res.status.toString()}): ${body}`,
+    );
+  }
+}
+```
+
+Remove the old `streamChatCompletion` function.
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `cd apps/frontend && bun run typecheck`
+Expected: Errors in `useStreamChat.ts` (still imports old function). Will be fixed in Task 9.
+
+- [ ] **Step 3: Commit**
+
+```
+feat(frontend): add sendMessage, subscribeEvents, abortCompletion API functions
+```
+
+---
+
+### Task 8: Frontend Routing & Session ID
+
+**Files:**
+
+- Modify: `apps/frontend/src/router/router.tsx`
+- Modify: `apps/frontend/src/pages/chat/contexts/SessionIdContext/SessionIdProvider.tsx`
+
+- [ ] **Step 1: Add `:sessionId?` parameter to chat route**
+
+In `router.tsx`, change the chat route:
+
+```typescript
+// From:
+{
+  path: ROUTES.chat(),
+  element: <ChatPage />,
+},
+// To:
+{
+  path: `${ROUTES.chat()}/:sessionId?`,
+  element: <ChatPage />,
+},
+```
+
+- [ ] **Step 2: Update SessionIdProvider to accept `initialSessionId` prop**
+
+```typescript
+interface SessionIdProviderProps {
+  initialSessionId?: string | null;
+  children: React.ReactNode;
+}
+
+export function SessionIdProvider({
+  initialSessionId,
+  children,
+}: SessionIdProviderProps) {
+  const [sessionId, setSessionId] = useState<string | null>(
+    initialSessionId ?? null,
+  );
+  // ... rest stays the same
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```
+feat(frontend): add sessionId route parameter and provider prop
+```
+
+---
+
+### Task 9: Frontend Chat Page Refactor
+
+**Files:**
+
+- Modify: `apps/frontend/src/pages/chat/ChatPage.tsx`
+- Modify: `apps/frontend/src/pages/chat/hooks/useStreamChat.ts`
+- Modify: `apps/frontend/src/pages/chat/components/StreamingMessageDisplay/hooks/useMessages.ts`
+- Modify: `apps/frontend/src/pages/chat/components/StreamingMessageDisplay/types.ts`
+
+- [ ] **Step 1: Update ChatEventMap — remove `stream-end`**
+
+In `types.ts`, remove the `'stream-end'` entry:
+
+```typescript
+// Remove:
+/** The stream ended (always fires in finally, regardless of outcome). */
+'stream-end': undefined;
+```
+
+- [ ] **Step 2: Update `useMessages` — replace `stream-end` with `done`, update `message-start` for replay, remove `completeUnfinishedTools`**
+
+In `useMessages.ts`:
+
+**Remove** the `completeUnfinishedTools` function entirely (lines 233-267).
+
+**Replace** `applyUserMessageStart` to handle both live and replay scenarios:
+
+```typescript
+function applyUserMessageStart(
+  prev: ChatMessage[],
+  event: SseMessageStartEvent,
+): ChatMessage[] {
+  // Look for a user message without an ID (created by user-message-sent)
+  for (let i = prev.length - 1; i >= 0; i--) {
+    if (prev[i].role === 'user' && prev[i].id === null) {
+      const updated = [...prev];
+      updated[i] = {...updated[i], id: event.messageId};
+      return updated;
+    }
+  }
+  // Replay: no user-message-sent was fired. Create from event content.
+  if (event.content !== undefined) {
+    return [
+      ...prev,
+      {
+        id: event.messageId,
+        createdAt: event.createdAt,
+        role: 'user' as const,
+        content: {type: 'text' as const, content: event.content},
+      },
+      {
+        id: null,
+        createdAt: null,
+        role: 'assistant' as const,
+        content: {type: 'text' as const, content: ''},
+      },
+    ];
+  }
+  return prev;
+}
+```
+
+**Replace** the `onStreamEnd` handler and subscription with a `done` handler:
+
+```typescript
+// Remove:
+const onStreamEnd = () => { ... };
+eventBus.on('stream-end', onStreamEnd);
+eventBus.off('stream-end', onStreamEnd);
+
+// Add:
+const onDone = () => {
+  setMessages(removeTrailingAssistantMessageIfEmpty);
+};
+eventBus.on('done', onDone);
+// In cleanup:
+eventBus.off('done', onDone);
+```
+
+**Update** the `onMessageStart` call to pass the full event:
+
+```typescript
+const onMessageStart = (data: SseMessageStartEvent) => {
+  if (data.role === 'user') {
+    setMessages((prev) => applyUserMessageStart(prev, data));
+  } else {
+    setMessages((prev) =>
+      applyAssistantMessageStart(prev, data.messageId, data.createdAt),
+    );
+  }
+};
+```
+
+- [ ] **Step 3: Rewrite `useStreamChat` for persistent SSE connection**
+
+Replace the entire `useStreamChat.ts` file:
+
+```typescript
+import type {ThinkingLevel} from '@omnicraft/api-schema';
+import type {SseDoneEvent, SseEvent} from '@omnicraft/sse-events';
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+import {
+  abortCompletion,
+  sendMessage as apiSendMessage,
+  subscribeEvents,
+} from '@/api/chat/index.js';
+import {EventBus} from '@/helpers/event-bus.js';
+
+import type {ChatEventMap} from '../components/StreamingMessageDisplay/index.js';
+import {routeBaseEventToBus} from '../helpers/route-base-event-to-bus.js';
+import {useChatEventBus} from './useChatEventBus.js';
+import type {useSessionId} from './useSessionId.js';
+
+type SessionIdHook = ReturnType<typeof useSessionId>;
+
+interface UseStreamChatOptions {
+  sessionId: SessionIdHook['sessionId'];
+  createNewSessionId: SessionIdHook['createNewSessionId'];
+}
+
+/** Orchestrates the persistent SSE connection and message sending. */
+export function useStreamChat({
+  sessionId,
+  createNewSessionId,
+}: UseStreamChatOptions) {
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [streamError, setStreamError] = useState<string | null>(null);
+  const [maxRoundsReached, setMaxRoundsReached] = useState(false);
+  const subagentBusMapRef = useRef(new Map<string, EventBus<ChatEventMap>>());
+  const eventBus = useChatEventBus();
+
+  // Persistent SSE connection — connects when sessionId is set.
+  useEffect(() => {
+    if (!sessionId) return;
+
+    const controller = new AbortController();
+    let lastUserMessage = '';
+    let assistantText = '';
+
+    eventBus.emit('reset');
+
+    void (async () => {
+      try {
+        for await (const event of subscribeEvents(
+          sessionId,
+          0,
+          controller.signal,
+        )) {
+          routeEvent(
+            event,
+            eventBus,
+            subagentBusMapRef.current,
+            setIsStreaming,
+            setStreamError,
+            setMaxRoundsReached,
+          );
+
+          // Track turn context for title generation
+          if (event.type === 'message-start' && event.role === 'user') {
+            lastUserMessage = event.content ?? '';
+            assistantText = '';
+          }
+          if (event.type === 'text-delta') {
+            assistantText += event.content;
+          }
+          if (event.type === 'done') {
+            if (assistantText) {
+              eventBus.emit('turn-done', {
+                sessionId,
+                userMessage: lastUserMessage,
+                assistantMessage: assistantText,
+              });
+            }
+            lastUserMessage = '';
+            assistantText = '';
+          }
+        }
+      } catch (e: unknown) {
+        if (e instanceof DOMException && e.name === 'AbortError') return;
+        console.error('SSE connection failed', e);
+        const message =
+          e instanceof Error ? e.message : 'An unexpected error occurred';
+        setStreamError(message);
+      }
+    })();
+
+    return () => {
+      controller.abort();
+      subagentBusMapRef.current.clear();
+    };
+  }, [sessionId, eventBus]);
+
+  const sendMessage = useCallback(
+    async (content: string, thinkingLevel: ThinkingLevel) => {
+      if (isStreaming) return;
+
+      const trimmed = content.trim();
+      if (!trimmed) return;
+
+      const activeSessionId = sessionId ?? (await createNewSessionId());
+      if (!activeSessionId) return;
+
+      setStreamError(null);
+      setMaxRoundsReached(false);
+      setIsStreaming(true);
+
+      eventBus.emit('user-message-sent', {content: trimmed});
+
+      try {
+        await apiSendMessage(activeSessionId, trimmed, thinkingLevel);
+      } catch (e: unknown) {
+        console.error('Failed to send message', e);
+        const message =
+          e instanceof Error ? e.message : 'Failed to send message';
+        eventBus.emit('stream-error', {message});
+        setStreamError(message);
+        setIsStreaming(false);
+      }
+    },
+    [isStreaming, sessionId, createNewSessionId, eventBus],
+  );
+
+  const stopGeneration = useCallback(() => {
+    if (!sessionId) return;
+    void abortCompletion(sessionId);
+  }, [sessionId]);
+
+  const clearStreamError = useCallback(() => {
+    setStreamError(null);
+  }, []);
+
+  const clearMaxRoundsReached = useCallback(() => {
+    setMaxRoundsReached(false);
+  }, []);
+
+  return {
+    isStreaming,
+    streamError,
+    maxRoundsReached,
+    sendMessage,
+    stopGeneration,
+    clearStreamError,
+    clearMaxRoundsReached,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Event routing — extracted to keep the hook body readable
+// ---------------------------------------------------------------------------
+
+function routeEvent(
+  event: SseEvent,
+  eventBus: EventBus<ChatEventMap>,
+  subagentBusMap: Map<string, EventBus<ChatEventMap>>,
+  setIsStreaming: (v: boolean) => void,
+  setStreamError: (v: string | null) => void,
+  setMaxRoundsReached: (v: boolean) => void,
+): void {
+  switch (event.type) {
+    case 'text-delta':
+    case 'tool-execute-start':
+    case 'tool-execute-end':
+    case 'tool-execute-delta':
+    case 'message-start':
+    case 'thinking-start':
+    case 'thinking-delta':
+    case 'thinking-end':
+      if (event.type === 'message-start' && event.role === 'assistant') {
+        setIsStreaming(true);
+      }
+      routeBaseEventToBus(event, eventBus);
+      break;
+    case 'done':
+      if ((event as SseDoneEvent).reason === 'max_rounds_reached') {
+        setMaxRoundsReached(true);
+      }
+      routeBaseEventToBus(event, eventBus);
+      setIsStreaming(false);
+      break;
+    case 'error':
+      eventBus.emit('stream-error', {message: event.message});
+      setStreamError(event.message);
+      setIsStreaming(false);
+      break;
+    case 'subagent-dispatch': {
+      const bus = new EventBus<ChatEventMap>();
+      subagentBusMap.set(event.agentId, bus);
+      eventBus.emit('subagent-dispatched', {
+        agentId: event.agentId,
+        task: event.task,
+        agentType: event.agentType,
+        thinkingLevel: event.thinkingLevel,
+        workingDirectory: event.workingDirectory,
+        eventBus: bus,
+      });
+      break;
+    }
+    case 'subagent-output': {
+      const bus = subagentBusMap.get(event.agentId);
+      if (bus) routeBaseEventToBus(event.event, bus);
+      break;
+    }
+    case 'subagent-complete': {
+      eventBus.emit('subagent-completed', {
+        agentId: event.agentId,
+        status: event.status,
+      });
+      subagentBusMap.delete(event.agentId);
+      break;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Update ChatPage — read URL param, navigate on session creation**
+
+In `ChatPage.tsx`, add imports and read the route param:
+
+```typescript
+import {useNavigate, useParams} from 'react-router';
+
+export function ChatPage() {
+  const {sessionId: urlSessionId} = useParams();
+
+  return (
+    <SessionIdProvider initialSessionId={urlSessionId ?? null}>
+      <ChatEventBusProvider>
+        <SessionConfigProvider>
+          <ChatPageContent />
+        </SessionConfigProvider>
+      </ChatEventBusProvider>
+    </SessionIdProvider>
+  );
+}
+```
+
+In `ChatPageContent`, add navigation on session creation:
+
+```typescript
+const navigate = useNavigate();
+const {sessionId: urlSessionId} = useParams();
+
+// Navigate to include sessionId in URL after lazy session creation
+useEffect(() => {
+  if (sessionId && !urlSessionId) {
+    navigate(`/chat/${sessionId}`, {replace: true});
+  }
+}, [sessionId, urlSessionId, navigate]);
+```
+
+Add `useParams` and `useNavigate` imports from `react-router`.
+
+- [ ] **Step 5: Update `useSessionLifecycle` — navigate to /chat on new session**
+
+In `useSessionLifecycle.ts`, add navigation:
+
+```typescript
+import {useNavigate} from 'react-router';
+import {ROUTES} from '@/routes.js';
+
+export function useSessionLifecycle({...}: UseSessionLifecycleOptions) {
+  const navigate = useNavigate();
+
+  const startNewSession = useCallback(() => {
+    stopGeneration();
+    clearSessionId();
+    resetDisplay();
+    clearTitle();
+    clearStreamError();
+    clearMaxRoundsReached();
+    navigate(ROUTES.chat(), {replace: true});
+  }, [
+    stopGeneration,
+    clearSessionId,
+    resetDisplay,
+    clearTitle,
+    clearStreamError,
+    clearMaxRoundsReached,
+    navigate,
+  ]);
+
+  return {startNewSession};
+}
+```
+
+- [ ] **Step 6: Verify frontend typecheck and lint**
+
+Run: `cd apps/frontend && bun run typecheck && bun run lint`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```
+feat(frontend): persistent SSE connection, POST-only messaging, session URL routing
+```
+
+---
+
+### Task 10: Full Verification
+
+- [ ] **Step 1: Run all backend tests**
+
+Run: `cd apps/backend && bun test`
+Expected: PASS
+
+- [ ] **Step 2: Run all frontend checks**
+
+Run: `cd apps/frontend && bun run typecheck && bun run lint`
+Expected: PASS
+
+- [ ] **Step 3: Run backend lint**
+
+Run: `cd apps/backend && bun run lint`
+Expected: PASS
+
+- [ ] **Step 4: Manual E2E testing**
+
+1. Start a conversation, verify events flow through `/events`
+2. Click stop mid-execution, verify `tool-execute-end` and `done(aborted)` events arrive via SSE
+3. Refresh the page with sessionId in URL, verify conversation replays correctly
+4. Open two tabs with same sessionId, verify both receive events
+5. Send a message in one tab, verify the other tab also sees events
+
+---
+
+## Notes
+
+**Spec addition (not in original spec):** `SseMessageStartEvent.content` was added for user role messages. Without it, session replay cannot reconstruct user message text because `user-message-sent` is a frontend-only event that doesn't flow through the SSE stream. This is the minimal change to make replay work.
+
+**Subagent abort behavior:** When the parent aborts, the subagent's subscribe reader ends silently (via the parent's AbortSignal). The subagent's abort completion events (written to the subagent's sseLog) may not reach the parent's event stream. The dispatch tool detects this (no `done` event seen) and emits `subagent-complete(failure)`. The subagent display may appear incomplete in the abort scenario — acceptable since the entire conversation is in an aborted state.
+
+**Subagent `done` delivery in normal flow:** The subagent's `done` event reaches the frontend via `subagent-output(done)`, routed to the subagent's event bus through `routeBaseEventToBus`. No synthetic `done` emission is needed on `subagent-complete` — the event bus already received it naturally.

--- a/docs/superpowers/plans/2026-04-14-session-decoupling.md
+++ b/docs/superpowers/plans/2026-04-14-session-decoupling.md
@@ -614,11 +614,14 @@ context.onSubAgentEvent({
 });
 
 try {
-  subagent.handleUserMessage(task, thinkingLevel);
-
+  // Subscribe before starting — ensures the reader is in place before events flow.
   let lastReplyText = '';
   let completed = false;
-  for await (const event of subagent.subscribe({signal: context.signal})) {
+  const eventIter = subagent.subscribe({signal: context.signal});
+
+  subagent.handleUserMessage(task, thinkingLevel);
+
+  for await (const event of eventIter) {
     // Subagents cannot emit subagent events (no SubAgentToolRegistry),
     // so all events are base events. Cast is safe by construction.
     context.onSubAgentEvent({

--- a/docs/superpowers/plans/2026-04-14-session-decoupling.md
+++ b/docs/superpowers/plans/2026-04-14-session-decoupling.md
@@ -27,11 +27,11 @@
 - `apps/backend/src/dispatcher/chat/helpers/sse.ts` — Export `writeSseEvent` (currently used only internally)
 - `apps/frontend/src/api/chat/chat.ts` — Replace `streamChatCompletion` with `sendMessage` + `subscribeEvents` + `abortCompletion`
 - `apps/frontend/src/router/router.tsx` — Add `:sessionId?` parameter to chat route
-- `apps/frontend/src/pages/chat/ChatPage.tsx` — Read URL param, pass `initialSessionId` to provider, navigate on creation
+- `apps/frontend/src/pages/chat/ChatPage.tsx` — Remove `useParams` / `initialSessionId` prop wiring (provider reads param internally)
 - `apps/frontend/src/pages/chat/hooks/useStreamChat.ts` — Persistent SSE connection effect, POST-only `sendMessage`/`stopGeneration`
 - `apps/frontend/src/pages/chat/components/StreamingMessageDisplay/hooks/useMessages.ts` — Remove `completeUnfinishedTools`, `stream-end` handler; add `done` handler; update `message-start` handler for replay
 - `apps/frontend/src/pages/chat/components/StreamingMessageDisplay/types.ts` — Remove `stream-end` from `ChatEventMap`
-- `apps/frontend/src/pages/chat/contexts/SessionIdContext/SessionIdProvider.tsx` — Accept `initialSessionId` prop
+- `apps/frontend/src/pages/chat/contexts/SessionIdContext/SessionIdProvider.tsx` — Replace `useState` with `useParams`; `createNewSessionId` navigates after creation; `clearSessionId` navigates to `/chat`
 
 ---
 
@@ -1035,22 +1035,69 @@ In `router.tsx`, change the chat route:
 },
 ```
 
-- [ ] **Step 2: Update SessionIdProvider to accept `initialSessionId` prop**
+- [ ] **Step 2: Update SessionIdProvider — URL as source of truth**
+
+Replace `useState` with `useParams` for sessionId. `createNewSessionId` navigates after creation. `clearSessionId` navigates to `/chat`.
 
 ```typescript
+import {useCallback, useState} from 'react';
+import {useNavigate, useParams} from 'react-router';
+
+import {createSession} from '@/api/chat/index.js';
+import {ROUTES} from '@/routes.js';
+
+import {SessionIdContext} from './SessionIdContext.js';
+
 interface SessionIdProviderProps {
-  initialSessionId?: string | null;
   children: React.ReactNode;
 }
 
-export function SessionIdProvider({
-  initialSessionId,
-  children,
-}: SessionIdProviderProps) {
-  const [sessionId, setSessionId] = useState<string | null>(
-    initialSessionId ?? null,
+export function SessionIdProvider({children}: SessionIdProviderProps) {
+  const {sessionId} = useParams();
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+
+  const createNewSessionId = useCallback(
+    async (config?: {
+      workspace?: string;
+      extraAllowedPaths?: readonly string[];
+    }) => {
+      try {
+        const id = await createSession(config);
+        navigate(`/chat/${id}`, {replace: true});
+        return id;
+      } catch (e: unknown) {
+        const message =
+          e instanceof Error ? e.message : 'Failed to create session';
+        setError(message);
+        return null;
+      }
+    },
+    [navigate],
   );
-  // ... rest stays the same
+
+  const clearSessionId = useCallback(() => {
+    setError(null);
+    navigate(ROUTES.chat(), {replace: true});
+  }, [navigate]);
+
+  const clearCreateNewSessionIdError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return (
+    <SessionIdContext
+      value={{
+        sessionId: sessionId ?? null,
+        createNewSessionIdError: error,
+        createNewSessionId,
+        clearSessionId,
+        clearCreateNewSessionIdError,
+      }}
+    >
+      {children}
+    </SessionIdContext>
+  );
 }
 ```
 
@@ -1374,18 +1421,14 @@ function routeEvent(
 }
 ```
 
-- [ ] **Step 4: Update ChatPage — read URL param, navigate on session creation**
+- [ ] **Step 4: Simplify ChatPage — provider reads URL param internally**
 
-In `ChatPage.tsx`, add imports and read the route param:
+`ChatPage.tsx` no longer needs to read `useParams` or pass `initialSessionId`. The provider handles it. Revert `ChatPage` to its original shape (no changes needed from current code, just verify no `initialSessionId` prop is passed):
 
 ```typescript
-import {useNavigate, useParams} from 'react-router';
-
 export function ChatPage() {
-  const {sessionId: urlSessionId} = useParams();
-
   return (
-    <SessionIdProvider initialSessionId={urlSessionId ?? null}>
+    <SessionIdProvider>
       <ChatEventBusProvider>
         <SessionConfigProvider>
           <ChatPageContent />
@@ -1396,54 +1439,13 @@ export function ChatPage() {
 }
 ```
 
-In `ChatPageContent`, add navigation on session creation:
+`ChatPageContent` also needs no navigation effect — the provider's `createNewSessionId` navigates after creation.
 
-```typescript
-const navigate = useNavigate();
-const {sessionId: urlSessionId} = useParams();
-
-// Navigate to include sessionId in URL after lazy session creation
-useEffect(() => {
-  if (sessionId && !urlSessionId) {
-    navigate(`/chat/${sessionId}`, {replace: true});
-  }
-}, [sessionId, urlSessionId, navigate]);
-```
-
-Add `useParams` and `useNavigate` imports from `react-router`.
-
-- [ ] **Step 5: Update `useSessionLifecycle` — navigate to /chat on new session**
+- [ ] **Step 5: Update `useSessionLifecycle` — use `clearSessionId` (which now navigates)**
 
 In `useSessionLifecycle.ts`, add navigation:
 
-```typescript
-import {useNavigate} from 'react-router';
-import {ROUTES} from '@/routes.js';
-
-export function useSessionLifecycle({...}: UseSessionLifecycleOptions) {
-  const navigate = useNavigate();
-
-  const startNewSession = useCallback(() => {
-    stopGeneration();
-    clearSessionId();
-    resetDisplay();
-    clearTitle();
-    clearStreamError();
-    clearMaxRoundsReached();
-    navigate(ROUTES.chat(), {replace: true});
-  }, [
-    stopGeneration,
-    clearSessionId,
-    resetDisplay,
-    clearTitle,
-    clearStreamError,
-    clearMaxRoundsReached,
-    navigate,
-  ]);
-
-  return {startNewSession};
-}
-```
+`clearSessionId` now navigates to `/chat` internally, so `useSessionLifecycle` no longer needs its own `useNavigate`. No changes needed — `startNewSession` calls `clearSessionId()` which handles navigation.
 
 - [ ] **Step 6: Verify frontend typecheck and lint**
 

--- a/docs/superpowers/specs/2026-04-14-session-decoupling-design.md
+++ b/docs/superpowers/specs/2026-04-14-session-decoupling-design.md
@@ -25,6 +25,18 @@ Add `'aborted'` to the `done` event's `reason` enum:
 reason: z.enum(['complete', 'max_rounds_reached', 'aborted']);
 ```
 
+Add required `content` field to `message-start` event. For user messages, this is the full message text (enables session replay). For assistant messages, this is an empty string (content arrives via `text-delta`).
+
+```typescript
+export const sseMessageStartEventSchema = z.object({
+  type: z.literal('message-start'),
+  role: z.enum(['user', 'assistant']),
+  messageId: z.string(),
+  createdAt: z.number(),
+  content: z.string(),
+});
+```
+
 **File:** `packages/sse-events/src/schema.ts`
 
 ### 3. Agent Class Refactor

--- a/docs/superpowers/specs/2026-04-14-session-decoupling-design.md
+++ b/docs/superpowers/specs/2026-04-14-session-decoupling-design.md
@@ -34,14 +34,15 @@ reason: z.enum(['complete', 'max_rounds_reached', 'aborted']);
 #### New properties
 
 - `readonly sseLog: AgentSseLog` — created in constructor, lives for the Agent's lifetime. All turns append to the same log.
-- `private abortController: AbortController | null` — created per-turn in `handleUserMessage()`, cleared when turn ends.
+- `private abortController: AbortController | null` — created per-turn, cleared when turn ends.
+- `private readonly mutex: Mutex` — serializes turns. Only one turn runs at a time; subsequent calls queue behind it.
 
 #### Method changes
 
 **`handleUserMessage(message, thinkingLevel)`**
 
 - Signature: remove `signal` parameter. Return `void` instead of `AgentEventStream`.
-- Behavior: create `AbortController`, launch background pump (`void this.pump(...)`).
+- Behavior: fire-and-forget — calls `void this.runTurn(message, thinkingLevel)`.
 - The current generator logic moves to a private method `runAgentLoop(message, thinkingLevel, signal)`.
 
 **`subscribe(options?): AsyncIterable<SseEvent>`** (new)
@@ -53,6 +54,24 @@ reason: z.enum(['complete', 'max_rounds_reached', 'aborted']);
 - Calls `this.abortController?.abort()`.
 - Does NOT close readers or write events directly. The pump handles event completion (see below).
 
+#### Turn serialization
+
+```typescript
+private async runTurn(message: string, thinkingLevel: ThinkingLevel): Promise<void> {
+  await this.mutex.acquire();
+  try {
+    this.abortController = new AbortController();
+    const stream = this.runAgentLoop(message, thinkingLevel, this.abortController.signal);
+    await this.pump(stream);
+  } finally {
+    this.abortController = null;
+    this.mutex.release();
+  }
+}
+```
+
+Multiple `handleUserMessage()` calls are safe — each fires `void this.runTurn()` which queues behind the Mutex. No 409 rejection needed; turns execute sequentially.
+
 #### Background pump
 
 ```typescript
@@ -63,8 +82,6 @@ private async pump(stream: AgentEventStream): Promise<void> {
     }
   } catch (e) {
     this.sseLog.append({ type: 'error', message: 'An internal error occurred' });
-  } finally {
-    this.abortController = null;
   }
 }
 ```
@@ -73,7 +90,7 @@ private async pump(stream: AgentEventStream): Promise<void> {
 
 When the Agent is aborted, `signal.aborted` becomes true. The `runAgentLoop` generator checks this at each iteration and returns early. Before returning, it must:
 
-1. Emit `tool-execute-end` events (status: `'error'`, result: `'Aborted'`) for any in-flight tool calls that have emitted `tool-execute-start` but not yet `tool-execute-end`.
+1. Emit `tool-execute-end` events (status: `'error'`, result: `'Aborted'`) for any in-flight tool calls that have emitted `tool-execute-start` but not yet `tool-execute-end`. This requires tracking emitted start callIds and removing them as end events are yielded.
 2. Emit `done` with `reason: 'aborted'`.
 
 This ensures the sseLog always contains a complete, consistent event sequence — no dangling tool starts, and always a `done` event to signal turn completion.
@@ -86,7 +103,7 @@ This ensures the sseLog always contains a complete, consistent event sequence �
 
 - No longer returns SSE. Calls `chatService.streamCompletion()` which calls `agent.handleUserMessage()`.
 - Returns `202 Accepted` with empty body.
-- Rejects with `409 Conflict` if Agent is already running (abortController is not null).
+- No concurrent rejection — the Agent's internal Mutex serializes turns. Multiple calls queue safely.
 
 #### `GET /session/:id/events` (new)
 
@@ -105,7 +122,7 @@ This ensures the sseLog always contains a complete, consistent event sequence �
 
 **File:** `apps/backend/src/services/chat/chat-service.ts`
 
-- `streamCompletion()`: no longer returns `{eventStream, abort}`. Calls `agent.handleUserMessage(message, thinkingLevel)`. Returns void (or a result indicating success/already-running).
+- `streamCompletion()`: no longer returns `{eventStream, abort}`. Calls `agent.handleUserMessage(message, thinkingLevel)`. Returns void.
 - Add `subscribe(agentId, options)`: retrieves Agent, returns `agent.subscribe(options)`.
 - Add `abortCompletion(agentId)`: retrieves Agent, calls `agent.abort()`.
 
@@ -152,10 +169,25 @@ This ensures the sseLog always contains a complete, consistent event sequence �
   - Last event is `done` → show send button (idle)
   - Receiving non-done events → show stop button (running)
   - No events yet → show send button (new conversation)
+- The `stream-end` event is removed. `done` is the authoritative signal for turn completion.
 
 #### Restoring a session
 
 - User navigates to `/chat/:sessionId` → connect `/events?from=0` → replay all historical events → UI rebuilds the full conversation → if last event is `done`, show send button; if Agent is still running, events keep flowing, show stop button.
+
+### 9. Subagent Dispatch Tool Adaptation
+
+**File:** `apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts`
+
+The dispatch tool currently iterates the subagent's generator directly. After the refactor, it adapts to the push-based pattern:
+
+1. Call `subagent.handleUserMessage(task, thinkingLevel)` — starts background pump.
+2. Link parent abort signal to subagent: `context.signal.addEventListener('abort', () => subagent.abort())`.
+3. Subscribe to subagent events: iterate `subagent.subscribe({ signal })`.
+4. Forward events via `context.onSubAgentEvent()` as before.
+5. Break out of the reader when a `done` event is received — since the sseLog is never sealed, the reader would otherwise wait forever.
+
+On abort: the parent's signal fires → `subagent.abort()` is called → subagent's `runAgentLoop` emits abort completion events (`tool-execute-end` + `done(aborted)`) → dispatch tool sees `done` and breaks → dispatch tool emits `subagent-complete` with appropriate status.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-04-14-session-decoupling-design.md
+++ b/docs/superpowers/specs/2026-04-14-session-decoupling-design.md
@@ -1,0 +1,169 @@
+# Session Decoupling: Push-Based Agent + SSE Events API
+
+**Date:** 2026-04-14
+**Issue:** [#129](https://github.com/Soulike/OmniCraft/issues/129) (Phase 2+3 merged)
+
+## Context
+
+The current execution model tightly couples Agent execution to the frontend SSE connection. The SSE response stream is the only consumer of the Agent's async generator — when the frontend disconnects, the Agent stops. There is no event history, no reconnection, and no way to resume a session.
+
+This design decouples execution from consumption. The Agent writes events to an in-memory log (`AgentSseLog`). The frontend reads from the log via a separate SSE endpoint. Disconnecting the reader does not affect execution. Users can reconnect and replay the full conversation.
+
+## Design
+
+### 1. AgentSseLog Changes
+
+Remove `seal()` and `get sealed`. The log lives as long as the Agent — it is never "finished". `append()` is always valid. Readers end only via `AbortSignal`.
+
+**Files:** `apps/backend/src/agent-core/agent/agent-sse-log.ts`, `agent-sse-log.test.ts`
+
+### 2. SSE Event Schema Change
+
+Add `'aborted'` to the `done` event's `reason` enum:
+
+```typescript
+reason: z.enum(['complete', 'max_rounds_reached', 'aborted']);
+```
+
+**File:** `packages/sse-events/src/schema.ts`
+
+### 3. Agent Class Refactor
+
+**File:** `apps/backend/src/agent-core/agent/agent.ts`
+
+#### New properties
+
+- `readonly sseLog: AgentSseLog` — created in constructor, lives for the Agent's lifetime. All turns append to the same log.
+- `private abortController: AbortController | null` — created per-turn in `handleUserMessage()`, cleared when turn ends.
+
+#### Method changes
+
+**`handleUserMessage(message, thinkingLevel)`**
+
+- Signature: remove `signal` parameter. Return `void` instead of `AgentEventStream`.
+- Behavior: create `AbortController`, launch background pump (`void this.pump(...)`).
+- The current generator logic moves to a private method `runAgentLoop(message, thinkingLevel, signal)`.
+
+**`subscribe(options?): AsyncIterable<SseEvent>`** (new)
+
+- Delegates to `this.sseLog.createReader(options)`.
+
+**`abort()`** (new)
+
+- Calls `this.abortController?.abort()`.
+- Does NOT close readers or write events directly. The pump handles event completion (see below).
+
+#### Background pump
+
+```typescript
+private async pump(stream: AgentEventStream): Promise<void> {
+  try {
+    for await (const event of stream) {
+      this.sseLog.append(event);
+    }
+  } catch (e) {
+    this.sseLog.append({ type: 'error', message: 'An internal error occurred' });
+  } finally {
+    this.abortController = null;
+  }
+}
+```
+
+#### Abort event completion
+
+When the Agent is aborted, `signal.aborted` becomes true. The `runAgentLoop` generator checks this at each iteration and returns early. Before returning, it must:
+
+1. Emit `tool-execute-end` events (status: `'error'`, result: `'Aborted'`) for any in-flight tool calls that have emitted `tool-execute-start` but not yet `tool-execute-end`.
+2. Emit `done` with `reason: 'aborted'`.
+
+This ensures the sseLog always contains a complete, consistent event sequence — no dangling tool starts, and always a `done` event to signal turn completion.
+
+### 4. API Changes
+
+**File:** `apps/backend/src/dispatcher/chat/router.ts`, `path.ts`
+
+#### `POST /session/:id/completions` (modified)
+
+- No longer returns SSE. Calls `chatService.streamCompletion()` which calls `agent.handleUserMessage()`.
+- Returns `202 Accepted` with empty body.
+- Rejects with `409 Conflict` if Agent is already running (abortController is not null).
+
+#### `GET /session/:id/events` (new)
+
+- SSE endpoint. Sets `text/event-stream` headers.
+- Calls `agent.subscribe({ startIndex: from, signal })` where `from` is from query string (default 0).
+- Pumps reader output to response as SSE.
+- `signal` is tied to `ctx.req.on('close')` — when the HTTP connection closes, the reader ends.
+
+#### `POST /session/:id/abort` (new)
+
+- Calls `agent.abort()`.
+- Returns `204 No Content`.
+- Returns `404` if session not found.
+
+### 5. Chat Service Layer
+
+**File:** `apps/backend/src/services/chat/chat-service.ts`
+
+- `streamCompletion()`: no longer returns `{eventStream, abort}`. Calls `agent.handleUserMessage(message, thinkingLevel)`. Returns void (or a result indicating success/already-running).
+- Add `subscribe(agentId, options)`: retrieves Agent, returns `agent.subscribe(options)`.
+- Add `abortCompletion(agentId)`: retrieves Agent, calls `agent.abort()`.
+
+### 6. Frontend API Layer
+
+**File:** `apps/frontend/src/api/chat/chat.ts`
+
+- `streamChatCompletion()` is replaced by two functions:
+  - `sendMessage(sessionId, message, thinkingLevel)` — POST to `/completions`, returns void.
+  - `subscribeEvents(sessionId, from, signal)` — GET `/events?from=N`, returns `AsyncGenerator<SseEvent>` (parses SSE stream same as before).
+- Add `abortCompletion(sessionId)` — POST to `/abort`.
+
+### 7. Frontend Routing
+
+**Files:** `apps/frontend/src/routes.ts`, `apps/frontend/src/router/router.tsx`, `apps/frontend/src/router/lazy-pages.tsx`
+
+- Add route: `/chat/:sessionId` → `ChatPage` (same component, reads param).
+- Keep `/chat` for new conversations (no sessionId).
+- After first message creates a session, navigate to `/chat/:sessionId`.
+
+### 8. Frontend Chat Page
+
+**Files under:** `apps/frontend/src/pages/chat/`
+
+#### SSE connection lifecycle = page lifecycle
+
+- When `ChatPage` mounts with a `sessionId` (from route param or after creation), connect `GET /events?from=0`.
+- Connection stays open for the entire page lifetime. Page unmount → abort signal → reader ends.
+- No manual connection management. Frontend just reads events and updates UI.
+
+#### Sending messages
+
+- `useStreamChat` changes: instead of calling `streamChatCompletion()` (which was POST + SSE combined), call `sendMessage()` (POST only). Events arrive via the already-open `/events` connection.
+
+#### Stop button
+
+- Currently: aborts the fetch request (closes SSE connection), then `completeUnfinishedTools()` creates synthetic events.
+- New: calls `POST /abort`. Does NOT close the `/events` connection. Backend writes the completion events (tool-execute-end for unfinished tools, done with reason 'aborted') to sseLog. Frontend receives them through the live `/events` reader — no synthetic events needed.
+- Remove `completeUnfinishedTools()` and related abort-patching code from `useMessages.ts`.
+
+#### State inference from events
+
+- Frontend determines UI state purely from the event stream:
+  - Last event is `done` → show send button (idle)
+  - Receiving non-done events → show stop button (running)
+  - No events yet → show send button (new conversation)
+
+#### Restoring a session
+
+- User navigates to `/chat/:sessionId` → connect `/events?from=0` → replay all historical events → UI rebuilds the full conversation → if last event is `done`, show send button; if Agent is still running, events keep flowing, show stop button.
+
+## Verification
+
+1. **Backend tests:** `bun test` in `apps/backend` — AgentSseLog tests (updated for no-seal), Agent tests if applicable.
+2. **Lint + typecheck:** `bun run lint && bun run typecheck` in both apps.
+3. **Manual E2E:**
+   - Start a conversation, verify events flow through `/events`.
+   - Click stop mid-execution, verify tool-execute-end and done(aborted) events arrive.
+   - Refresh the page with sessionId in URL, verify conversation replays correctly.
+   - Open two tabs with same sessionId, verify both receive events.
+   - Send a message in one tab, verify the other tab also receives events.

--- a/packages/sse-events/src/schema.ts
+++ b/packages/sse-events/src/schema.ts
@@ -39,6 +39,7 @@ export const sseMessageStartEventSchema = z.object({
   role: z.enum(['user', 'assistant']),
   messageId: z.string(),
   createdAt: z.number(),
+  content: z.string(),
 });
 export type SseMessageStartEvent = z.infer<typeof sseMessageStartEventSchema>;
 
@@ -65,7 +66,7 @@ export type SseUsage = z.infer<typeof sseUsageSchema>;
 /** Stream completed. Reason indicates whether it finished normally or was capped. */
 export const sseDoneEventSchema = z.object({
   type: z.literal('done'),
-  reason: z.enum(['complete', 'max_rounds_reached']),
+  reason: z.enum(['complete', 'max_rounds_reached', 'aborted']),
   usage: sseUsageSchema,
 });
 export type SseDoneEvent = z.infer<typeof sseDoneEventSchema>;


### PR DESCRIPTION
## Summary

Decouples Agent execution from frontend SSE connections so sessions persist independently and support reconnection via session ID. Implements [Phase 2+3 of #129](https://github.com/Soulike/OmniCraft/issues/129).

**Backend:**
- Agent refactored from pull-based (async generator) to push-based (internal pump → `AgentSseLog`)
- New `subscribe()` / `abort()` API on Agent; turns serialized via Mutex
- Abort writes proper completion events (`tool-execute-end` + `done(aborted)`) — no dangling state
- `POST /completions` returns 202 (fire-and-forget); new `GET /events?from=N` SSE endpoint; new `POST /abort`
- `CodingSubAgent` adapted to override `runAgentLoop` instead of `handleUserMessage`
- `AgentSseLog.seal()` removed — readers end via AbortSignal only

**Frontend:**
- Persistent SSE connection tied to page lifecycle (not per-message)
- `sendMessage` (POST only) + `subscribeEvents` (GET SSE) + `abortCompletion` (POST)
- Stop button calls `POST /abort` instead of closing SSE — backend writes completion events
- Synthetic event generation removed (`completeUnfinishedTools`, `stream-end`)
- `done` event is the authoritative turn completion signal
- Session ID driven by URL (`/chat/:sessionId?`) — `SessionIdProvider` reads `useParams()`
- Session replay: `message-start` now carries required `content` field for user messages

**Schema:**
- `SseMessageStartEvent` gains required `content: string` field
- `SseDoneEvent.reason` gains `'aborted'` variant

## Test plan

- [x] Backend typecheck passes
- [x] Frontend typecheck passes  
- [x] Backend lint passes
- [x] Frontend lint passes
- [x] Backend tests pass (393/394 — 1 pre-existing failure in settings-manager)
- [ ] Manual: start conversation, verify events flow through `/events`
- [ ] Manual: click stop mid-execution, verify `tool-execute-end` + `done(aborted)` arrive
- [ ] Manual: refresh page with sessionId in URL, verify conversation replays
- [ ] Manual: open two tabs with same sessionId, verify both receive events

Closes #129 (Phase 2+3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)