### PR TITLE
fix(frontend): batch message state updates per frame to prevent replay animation

### DIFF
--- a/apps/frontend/src/hooks/useFrameBatchedState.test.ts
+++ b/apps/frontend/src/hooks/useFrameBatchedState.test.ts
@@ -1,0 +1,169 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {createFrameBatchScheduler} from './useFrameBatchedState.js';
+
+// ---------------------------------------------------------------------------
+// rAF mock — vitest runs in Node where rAF is unavailable.
+// ---------------------------------------------------------------------------
+let rafCallbacks: Map<number, () => void>;
+let nextRafId: number;
+
+function mockRaf(cb: () => void): number {
+  const id = nextRafId++;
+  rafCallbacks.set(id, cb);
+  return id;
+}
+
+function mockCancelRaf(id: number): void {
+  rafCallbacks.delete(id);
+}
+
+/** Simulates advancing one animation frame — fires all pending rAF callbacks. */
+function flushRaf(): void {
+  const cbs = [...rafCallbacks.values()];
+  rafCallbacks.clear();
+  for (const cb of cbs) {
+    cb();
+  }
+}
+
+beforeEach(() => {
+  rafCallbacks = new Map();
+  nextRafId = 1;
+  vi.stubGlobal('requestAnimationFrame', mockRaf);
+  vi.stubGlobal('cancelAnimationFrame', mockCancelRaf);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('createFrameBatchScheduler', () => {
+  it('does not flush synchronously', () => {
+    const onFlush = vi.fn();
+    const scheduler = createFrameBatchScheduler<number>(onFlush);
+
+    scheduler.enqueue((n) => n + 1);
+
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it('flushes enqueued transforms on the next frame', () => {
+    let state = 0;
+    const scheduler = createFrameBatchScheduler<number>((composed) => {
+      state = composed(state);
+    });
+
+    scheduler.enqueue((n) => n + 1);
+    flushRaf();
+
+    expect(state).toBe(1);
+  });
+
+  it('composes multiple transforms into a single flush', () => {
+    let state = 0;
+    const onFlush = vi.fn((composed: (prev: number) => number) => {
+      state = composed(state);
+    });
+    const scheduler = createFrameBatchScheduler<number>(onFlush);
+
+    scheduler.enqueue((n) => n + 1);
+    scheduler.enqueue((n) => n + 10);
+    scheduler.enqueue((n) => n * 2);
+    flushRaf();
+
+    // (0 + 1 + 10) * 2 = 22
+    expect(state).toBe(22);
+    // onFlush should be called exactly once (batched)
+    expect(onFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it('schedules only one rAF per batch', () => {
+    const scheduler = createFrameBatchScheduler<number>(vi.fn());
+
+    scheduler.enqueue((n) => n + 1);
+    scheduler.enqueue((n) => n + 2);
+    scheduler.enqueue((n) => n + 3);
+
+    expect(rafCallbacks.size).toBe(1);
+  });
+
+  it('allows new batches after a flush', () => {
+    let state = 0;
+    const scheduler = createFrameBatchScheduler<number>((composed) => {
+      state = composed(state);
+    });
+
+    scheduler.enqueue((n) => n + 1);
+    flushRaf();
+    expect(state).toBe(1);
+
+    scheduler.enqueue((n) => n + 5);
+    flushRaf();
+    expect(state).toBe(6);
+  });
+
+  it('does nothing when flushing an empty queue', () => {
+    const onFlush = vi.fn();
+    createFrameBatchScheduler<number>(onFlush);
+
+    flushRaf();
+
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it('cancel prevents the pending flush', () => {
+    const onFlush = vi.fn();
+    const scheduler = createFrameBatchScheduler<number>(onFlush);
+
+    scheduler.enqueue((n) => n + 1);
+    scheduler.cancel();
+    flushRaf();
+
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it('can enqueue again after cancel', () => {
+    let state = 0;
+    const scheduler = createFrameBatchScheduler<number>((composed) => {
+      state = composed(state);
+    });
+
+    scheduler.enqueue((n) => n + 1);
+    scheduler.cancel();
+    flushRaf();
+    expect(state).toBe(0);
+
+    scheduler.enqueue((n) => n + 5);
+    flushRaf();
+    expect(state).toBe(5);
+  });
+
+  it('applies transforms in enqueue order', () => {
+    const order: string[] = [];
+    let state = '';
+    const scheduler = createFrameBatchScheduler<string>((composed) => {
+      state = composed(state);
+    });
+
+    scheduler.enqueue((s) => {
+      order.push('a');
+      return s + 'a';
+    });
+    scheduler.enqueue((s) => {
+      order.push('b');
+      return s + 'b';
+    });
+    scheduler.enqueue((s) => {
+      order.push('c');
+      return s + 'c';
+    });
+    flushRaf();
+
+    expect(state).toBe('abc');
+    expect(order).toEqual(['a', 'b', 'c']);
+  });
+});

--- a/apps/frontend/src/hooks/useFrameBatchedState.test.ts
+++ b/apps/frontend/src/hooks/useFrameBatchedState.test.ts
@@ -1,6 +1,9 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
-import {createFrameBatchScheduler} from './useFrameBatchedState.js';
+import {
+  createFrameBatchScheduler,
+  resolveAction,
+} from './useFrameBatchedState.js';
 
 // ---------------------------------------------------------------------------
 // rAF mock — vitest runs in Node where rAF is unavailable.
@@ -39,69 +42,107 @@ afterEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests
+// resolveAction
+// ---------------------------------------------------------------------------
+describe('resolveAction', () => {
+  it('returns the value directly when given a non-function', () => {
+    expect(resolveAction(42, 0)).toBe(42);
+  });
+
+  it('calls the updater with prev when given a function', () => {
+    expect(resolveAction((prev: number) => prev + 1, 10)).toBe(11);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createFrameBatchScheduler
 // ---------------------------------------------------------------------------
 describe('createFrameBatchScheduler', () => {
   it('does not flush synchronously', () => {
     const onFlush = vi.fn();
     const scheduler = createFrameBatchScheduler<number>(onFlush);
 
-    scheduler.enqueue((n) => n + 1);
+    scheduler.setState((n) => n + 1);
 
     expect(onFlush).not.toHaveBeenCalled();
   });
 
-  it('flushes enqueued transforms on the next frame', () => {
+  it('flushes updaters on the next frame', () => {
     let state = 0;
-    const scheduler = createFrameBatchScheduler<number>((composed) => {
-      state = composed(state);
+    const scheduler = createFrameBatchScheduler<number>((action) => {
+      state = resolveAction(action, state);
     });
 
-    scheduler.enqueue((n) => n + 1);
+    scheduler.setState((n) => n + 1);
     flushRaf();
 
     expect(state).toBe(1);
   });
 
-  it('composes multiple transforms into a single flush', () => {
+  it('composes multiple updaters into a single flush', () => {
     let state = 0;
-    const onFlush = vi.fn((composed: (prev: number) => number) => {
-      state = composed(state);
+    const onFlush = vi.fn((action: number | ((prev: number) => number)) => {
+      state = resolveAction(action, state);
     });
     const scheduler = createFrameBatchScheduler<number>(onFlush);
 
-    scheduler.enqueue((n) => n + 1);
-    scheduler.enqueue((n) => n + 10);
-    scheduler.enqueue((n) => n * 2);
+    scheduler.setState((n) => n + 1);
+    scheduler.setState((n) => n + 10);
+    scheduler.setState((n) => n * 2);
     flushRaf();
 
     // (0 + 1 + 10) * 2 = 22
     expect(state).toBe(22);
-    // onFlush should be called exactly once (batched)
     expect(onFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts direct values alongside updaters', () => {
+    let state = 0;
+    const scheduler = createFrameBatchScheduler<number>((action) => {
+      state = resolveAction(action, state);
+    });
+
+    scheduler.setState((n) => n + 5); // 0 + 5 = 5
+    scheduler.setState(100); // replace with 100
+    scheduler.setState((n) => n + 1); // 100 + 1 = 101
+    flushRaf();
+
+    expect(state).toBe(101);
+  });
+
+  it('handles direct value as the only action', () => {
+    let state = 'old';
+    const scheduler = createFrameBatchScheduler<string>((action) => {
+      state = resolveAction(action, state);
+    });
+
+    scheduler.setState('new');
+    flushRaf();
+
+    expect(state).toBe('new');
   });
 
   it('schedules only one rAF per batch', () => {
     const scheduler = createFrameBatchScheduler<number>(vi.fn());
 
-    scheduler.enqueue((n) => n + 1);
-    scheduler.enqueue((n) => n + 2);
-    scheduler.enqueue((n) => n + 3);
+    scheduler.setState((n) => n + 1);
+    scheduler.setState((n) => n + 2);
+    scheduler.setState((n) => n + 3);
 
     expect(rafCallbacks.size).toBe(1);
   });
 
   it('allows new batches after a flush', () => {
     let state = 0;
-    const scheduler = createFrameBatchScheduler<number>((composed) => {
-      state = composed(state);
+    const scheduler = createFrameBatchScheduler<number>((action) => {
+      state = resolveAction(action, state);
     });
 
-    scheduler.enqueue((n) => n + 1);
+    scheduler.setState((n) => n + 1);
     flushRaf();
     expect(state).toBe(1);
 
-    scheduler.enqueue((n) => n + 5);
+    scheduler.setState((n) => n + 5);
     flushRaf();
     expect(state).toBe(6);
   });
@@ -119,7 +160,7 @@ describe('createFrameBatchScheduler', () => {
     const onFlush = vi.fn();
     const scheduler = createFrameBatchScheduler<number>(onFlush);
 
-    scheduler.enqueue((n) => n + 1);
+    scheduler.setState((n) => n + 1);
     scheduler.cancel();
     flushRaf();
 
@@ -128,36 +169,36 @@ describe('createFrameBatchScheduler', () => {
 
   it('can enqueue again after cancel', () => {
     let state = 0;
-    const scheduler = createFrameBatchScheduler<number>((composed) => {
-      state = composed(state);
+    const scheduler = createFrameBatchScheduler<number>((action) => {
+      state = resolveAction(action, state);
     });
 
-    scheduler.enqueue((n) => n + 1);
+    scheduler.setState((n) => n + 1);
     scheduler.cancel();
     flushRaf();
     expect(state).toBe(0);
 
-    scheduler.enqueue((n) => n + 5);
+    scheduler.setState((n) => n + 5);
     flushRaf();
     expect(state).toBe(5);
   });
 
-  it('applies transforms in enqueue order', () => {
+  it('applies actions in order', () => {
     const order: string[] = [];
     let state = '';
-    const scheduler = createFrameBatchScheduler<string>((composed) => {
-      state = composed(state);
+    const scheduler = createFrameBatchScheduler<string>((action) => {
+      state = resolveAction(action, state);
     });
 
-    scheduler.enqueue((s) => {
+    scheduler.setState((s) => {
       order.push('a');
       return s + 'a';
     });
-    scheduler.enqueue((s) => {
+    scheduler.setState((s) => {
       order.push('b');
       return s + 'b';
     });
-    scheduler.enqueue((s) => {
+    scheduler.setState((s) => {
       order.push('c');
       return s + 'c';
     });

--- a/apps/frontend/src/hooks/useFrameBatchedState.test.ts
+++ b/apps/frontend/src/hooks/useFrameBatchedState.test.ts
@@ -1,8 +1,8 @@
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {
+  applySetStateAction,
   createFrameBatchScheduler,
-  resolveAction,
 } from './useFrameBatchedState.js';
 
 // ---------------------------------------------------------------------------
@@ -44,13 +44,13 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 // resolveAction
 // ---------------------------------------------------------------------------
-describe('resolveAction', () => {
+describe('applySetStateAction', () => {
   it('returns the value directly when given a non-function', () => {
-    expect(resolveAction(42, 0)).toBe(42);
+    expect(applySetStateAction(42, 0)).toBe(42);
   });
 
   it('calls the updater with prev when given a function', () => {
-    expect(resolveAction((prev: number) => prev + 1, 10)).toBe(11);
+    expect(applySetStateAction((prev: number) => prev + 1, 10)).toBe(11);
   });
 });
 
@@ -62,7 +62,7 @@ describe('createFrameBatchScheduler', () => {
     const onFlush = vi.fn();
     const scheduler = createFrameBatchScheduler<number>(onFlush);
 
-    scheduler.setState((n) => n + 1);
+    scheduler.pushSetStateAction((n) => n + 1);
 
     expect(onFlush).not.toHaveBeenCalled();
   });
@@ -70,10 +70,10 @@ describe('createFrameBatchScheduler', () => {
   it('flushes updaters on the next frame', () => {
     let state = 0;
     const scheduler = createFrameBatchScheduler<number>((action) => {
-      state = resolveAction(action, state);
+      state = applySetStateAction(action, state);
     });
 
-    scheduler.setState((n) => n + 1);
+    scheduler.pushSetStateAction((n) => n + 1);
     flushRaf();
 
     expect(state).toBe(1);
@@ -82,13 +82,13 @@ describe('createFrameBatchScheduler', () => {
   it('composes multiple updaters into a single flush', () => {
     let state = 0;
     const onFlush = vi.fn((action: number | ((prev: number) => number)) => {
-      state = resolveAction(action, state);
+      state = applySetStateAction(action, state);
     });
     const scheduler = createFrameBatchScheduler<number>(onFlush);
 
-    scheduler.setState((n) => n + 1);
-    scheduler.setState((n) => n + 10);
-    scheduler.setState((n) => n * 2);
+    scheduler.pushSetStateAction((n) => n + 1);
+    scheduler.pushSetStateAction((n) => n + 10);
+    scheduler.pushSetStateAction((n) => n * 2);
     flushRaf();
 
     // (0 + 1 + 10) * 2 = 22
@@ -99,12 +99,12 @@ describe('createFrameBatchScheduler', () => {
   it('accepts direct values alongside updaters', () => {
     let state = 0;
     const scheduler = createFrameBatchScheduler<number>((action) => {
-      state = resolveAction(action, state);
+      state = applySetStateAction(action, state);
     });
 
-    scheduler.setState((n) => n + 5); // 0 + 5 = 5
-    scheduler.setState(100); // replace with 100
-    scheduler.setState((n) => n + 1); // 100 + 1 = 101
+    scheduler.pushSetStateAction((n) => n + 5); // 0 + 5 = 5
+    scheduler.pushSetStateAction(100); // replace with 100
+    scheduler.pushSetStateAction((n) => n + 1); // 100 + 1 = 101
     flushRaf();
 
     expect(state).toBe(101);
@@ -113,10 +113,10 @@ describe('createFrameBatchScheduler', () => {
   it('handles direct value as the only action', () => {
     let state = 'old';
     const scheduler = createFrameBatchScheduler<string>((action) => {
-      state = resolveAction(action, state);
+      state = applySetStateAction(action, state);
     });
 
-    scheduler.setState('new');
+    scheduler.pushSetStateAction('new');
     flushRaf();
 
     expect(state).toBe('new');
@@ -125,9 +125,9 @@ describe('createFrameBatchScheduler', () => {
   it('schedules only one rAF per batch', () => {
     const scheduler = createFrameBatchScheduler<number>(vi.fn());
 
-    scheduler.setState((n) => n + 1);
-    scheduler.setState((n) => n + 2);
-    scheduler.setState((n) => n + 3);
+    scheduler.pushSetStateAction((n) => n + 1);
+    scheduler.pushSetStateAction((n) => n + 2);
+    scheduler.pushSetStateAction((n) => n + 3);
 
     expect(rafCallbacks.size).toBe(1);
   });
@@ -135,14 +135,14 @@ describe('createFrameBatchScheduler', () => {
   it('allows new batches after a flush', () => {
     let state = 0;
     const scheduler = createFrameBatchScheduler<number>((action) => {
-      state = resolveAction(action, state);
+      state = applySetStateAction(action, state);
     });
 
-    scheduler.setState((n) => n + 1);
+    scheduler.pushSetStateAction((n) => n + 1);
     flushRaf();
     expect(state).toBe(1);
 
-    scheduler.setState((n) => n + 5);
+    scheduler.pushSetStateAction((n) => n + 5);
     flushRaf();
     expect(state).toBe(6);
   });
@@ -160,7 +160,7 @@ describe('createFrameBatchScheduler', () => {
     const onFlush = vi.fn();
     const scheduler = createFrameBatchScheduler<number>(onFlush);
 
-    scheduler.setState((n) => n + 1);
+    scheduler.pushSetStateAction((n) => n + 1);
     scheduler.cancel();
     flushRaf();
 
@@ -170,15 +170,15 @@ describe('createFrameBatchScheduler', () => {
   it('can enqueue again after cancel', () => {
     let state = 0;
     const scheduler = createFrameBatchScheduler<number>((action) => {
-      state = resolveAction(action, state);
+      state = applySetStateAction(action, state);
     });
 
-    scheduler.setState((n) => n + 1);
+    scheduler.pushSetStateAction((n) => n + 1);
     scheduler.cancel();
     flushRaf();
     expect(state).toBe(0);
 
-    scheduler.setState((n) => n + 5);
+    scheduler.pushSetStateAction((n) => n + 5);
     flushRaf();
     expect(state).toBe(5);
   });
@@ -187,18 +187,18 @@ describe('createFrameBatchScheduler', () => {
     const order: string[] = [];
     let state = '';
     const scheduler = createFrameBatchScheduler<string>((action) => {
-      state = resolveAction(action, state);
+      state = applySetStateAction(action, state);
     });
 
-    scheduler.setState((s) => {
+    scheduler.pushSetStateAction((s) => {
       order.push('a');
       return s + 'a';
     });
-    scheduler.setState((s) => {
+    scheduler.pushSetStateAction((s) => {
       order.push('b');
       return s + 'b';
     });
-    scheduler.setState((s) => {
+    scheduler.pushSetStateAction((s) => {
       order.push('c');
       return s + 'c';
     });

--- a/apps/frontend/src/hooks/useFrameBatchedState.test.ts
+++ b/apps/frontend/src/hooks/useFrameBatchedState.test.ts
@@ -42,7 +42,7 @@ afterEach(() => {
 });
 
 // ---------------------------------------------------------------------------
-// resolveAction
+// applySetStateAction
 // ---------------------------------------------------------------------------
 describe('applySetStateAction', () => {
   it('returns the value directly when given a non-function', () => {

--- a/apps/frontend/src/hooks/useFrameBatchedState.ts
+++ b/apps/frontend/src/hooks/useFrameBatchedState.ts
@@ -43,10 +43,10 @@ export function createFrameBatchScheduler<T>(
   onFlush: Dispatch<SetStateAction<T>>,
 ): FrameBatchScheduler<T> {
   let queue: SetStateAction<T>[] = [];
-  let rafId = 0;
+  let rafId: number | null = null;
 
   function flush(): void {
-    rafId = 0;
+    rafId = null;
     const actions = queue;
     if (actions.length === 0) return;
     queue = [];
@@ -61,14 +61,14 @@ export function createFrameBatchScheduler<T>(
 
   function setState(action: SetStateAction<T>): void {
     queue.push(action);
-    if (rafId === 0) {
-      rafId = requestAnimationFrame(flush);
-    }
+    rafId ??= requestAnimationFrame(flush);
   }
 
   function cancel(): void {
-    cancelAnimationFrame(rafId);
-    rafId = 0;
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+    }
+    rafId = null;
     queue = [];
   }
 

--- a/apps/frontend/src/hooks/useFrameBatchedState.ts
+++ b/apps/frontend/src/hooks/useFrameBatchedState.ts
@@ -1,0 +1,92 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+type Transform<T> = (prev: T) => T;
+
+export interface FrameBatchScheduler<T> {
+  /**
+   * Enqueues a state transform. All transforms enqueued within the same
+   * animation frame are composed and applied as a single state update.
+   */
+  enqueue: (fn: Transform<T>) => void;
+  /** Cancels any pending flush. */
+  cancel: () => void;
+}
+
+/**
+ * Creates a scheduler that coalesces {@link Transform} functions within a
+ * single `requestAnimationFrame` window and flushes them as one composed
+ * transform.
+ *
+ * Exported for testing — consumers should prefer {@link useFrameBatchedState}.
+ */
+export function createFrameBatchScheduler<T>(
+  onFlush: (composed: Transform<T>) => void,
+): FrameBatchScheduler<T> {
+  let queue: Transform<T>[] = [];
+  let rafId = 0;
+
+  function flush(): void {
+    rafId = 0;
+    const transforms = queue;
+    if (transforms.length === 0) return;
+    queue = [];
+    onFlush((prev) => {
+      let state = prev;
+      for (const fn of transforms) {
+        state = fn(state);
+      }
+      return state;
+    });
+  }
+
+  function enqueue(fn: Transform<T>): void {
+    queue.push(fn);
+    if (rafId === 0) {
+      rafId = requestAnimationFrame(flush);
+    }
+  }
+
+  function cancel(): void {
+    cancelAnimationFrame(rafId);
+    rafId = 0;
+    queue = [];
+  }
+
+  return {enqueue, cancel};
+}
+
+/**
+ * Like `useState`, but batches state updates per animation frame.
+ *
+ * Instead of calling the setter on every event (which may cause intermediate
+ * renders during rapid updates), transforms are queued and flushed once per
+ * `requestAnimationFrame`. When updates arrive faster than the frame rate
+ * (e.g. replaying historical events), they are composed into a single state
+ * transition — the component sees only the final result in one render.
+ * When updates are sparse (e.g. live streaming tokens), each frame contains
+ * at most one transform and behaviour is equivalent to a direct `setState`.
+ */
+export function useFrameBatchedState<T>(
+  initialState: T | (() => T),
+): [T, (fn: Transform<T>) => void] {
+  const [state, setState] = useState(initialState);
+
+  const schedulerRef = useRef<FrameBatchScheduler<T> | null>(null);
+  schedulerRef.current ??= createFrameBatchScheduler<T>(setState);
+  const scheduler = schedulerRef.current;
+
+  const enqueue = useCallback(
+    (fn: Transform<T>) => {
+      scheduler.enqueue(fn);
+    },
+    [scheduler],
+  );
+
+  useEffect(() => {
+    return () => {
+      scheduler.cancel();
+    };
+  }, [scheduler]);
+
+  return [state, enqueue];
+}

--- a/apps/frontend/src/hooks/useFrameBatchedState.ts
+++ b/apps/frontend/src/hooks/useFrameBatchedState.ts
@@ -1,46 +1,66 @@
-import {useCallback, useEffect, useRef, useState} from 'react';
-
-type Transform<T> = (prev: T) => T;
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 export interface FrameBatchScheduler<T> {
   /**
-   * Enqueues a state transform. All transforms enqueued within the same
-   * animation frame are composed and applied as a single state update.
+   * Accepts the same argument as React's `setState` — either a new value
+   * or an updater function `(prev) => next`. All actions enqueued within
+   * the same animation frame are composed and applied as a single state
+   * update.
    */
-  enqueue: (fn: Transform<T>) => void;
-  /** Cancels any pending flush. */
+  setState: Dispatch<SetStateAction<T>>;
+  /** Cancels any pending flush and discards queued actions. */
   cancel: () => void;
 }
 
 /**
- * Creates a scheduler that coalesces {@link Transform} functions within a
+ * Resolves a {@link SetStateAction} against the current state.
+ *
+ * Exported for testing — consumers should prefer {@link useFrameBatchedState}.
+ */
+export function resolveAction<T>(action: SetStateAction<T>, prev: T): T {
+  // React uses the same `typeof` check internally.  When `T` is itself
+  // a function type the caller must always use the updater form.
+  return typeof action === 'function'
+    ? (action as (prev: T) => T)(prev)
+    : action;
+}
+
+/**
+ * Creates a scheduler that coalesces {@link SetStateAction}s within a
  * single `requestAnimationFrame` window and flushes them as one composed
- * transform.
+ * update.
  *
  * Exported for testing — consumers should prefer {@link useFrameBatchedState}.
  */
 export function createFrameBatchScheduler<T>(
-  onFlush: (composed: Transform<T>) => void,
+  onFlush: Dispatch<SetStateAction<T>>,
 ): FrameBatchScheduler<T> {
-  let queue: Transform<T>[] = [];
+  let queue: SetStateAction<T>[] = [];
   let rafId = 0;
 
   function flush(): void {
     rafId = 0;
-    const transforms = queue;
-    if (transforms.length === 0) return;
+    const actions = queue;
+    if (actions.length === 0) return;
     queue = [];
     onFlush((prev) => {
       let state = prev;
-      for (const fn of transforms) {
-        state = fn(state);
+      for (const action of actions) {
+        state = resolveAction(action, state);
       }
       return state;
     });
   }
 
-  function enqueue(fn: Transform<T>): void {
-    queue.push(fn);
+  function setState(action: SetStateAction<T>): void {
+    queue.push(action);
     if (rafId === 0) {
       rafId = requestAnimationFrame(flush);
     }
@@ -52,32 +72,33 @@ export function createFrameBatchScheduler<T>(
     queue = [];
   }
 
-  return {enqueue, cancel};
+  return {setState, cancel};
 }
 
 /**
- * Like `useState`, but batches state updates per animation frame.
+ * Drop-in replacement for `useState` that batches updates per animation
+ * frame.
  *
- * Instead of calling the setter on every event (which may cause intermediate
- * renders during rapid updates), transforms are queued and flushed once per
- * `requestAnimationFrame`. When updates arrive faster than the frame rate
- * (e.g. replaying historical events), they are composed into a single state
- * transition — the component sees only the final result in one render.
- * When updates are sparse (e.g. live streaming tokens), each frame contains
- * at most one transform and behaviour is equivalent to a direct `setState`.
+ * The returned setter has the same signature as React's `setState` —
+ * it accepts either a new value or an updater `(prev) => next`. When
+ * updates arrive faster than the frame rate (e.g. replaying historical
+ * SSE events), they are composed into a single state transition so the
+ * component sees only the final result in one render. When updates are
+ * sparse (e.g. live streaming tokens), each frame contains at most one
+ * update and behaviour is equivalent to a direct `setState`.
  */
 export function useFrameBatchedState<T>(
   initialState: T | (() => T),
-): [T, (fn: Transform<T>) => void] {
+): [T, Dispatch<SetStateAction<T>>] {
   const [state, setState] = useState(initialState);
 
   const schedulerRef = useRef<FrameBatchScheduler<T> | null>(null);
   schedulerRef.current ??= createFrameBatchScheduler<T>(setState);
   const scheduler = schedulerRef.current;
 
-  const enqueue = useCallback(
-    (fn: Transform<T>) => {
-      scheduler.enqueue(fn);
+  const batchedSetState: Dispatch<SetStateAction<T>> = useCallback(
+    (action: SetStateAction<T>) => {
+      scheduler.setState(action);
     },
     [scheduler],
   );
@@ -88,5 +109,5 @@ export function useFrameBatchedState<T>(
     };
   }, [scheduler]);
 
-  return [state, enqueue];
+  return [state, batchedSetState];
 }

--- a/apps/frontend/src/hooks/useFrameBatchedState.ts
+++ b/apps/frontend/src/hooks/useFrameBatchedState.ts
@@ -14,7 +14,7 @@ export interface FrameBatchScheduler<T> {
    * the same animation frame are composed and applied as a single state
    * update.
    */
-  setState: Dispatch<SetStateAction<T>>;
+  pushSetStateAction: Dispatch<SetStateAction<T>>;
   /** Cancels any pending flush and discards queued actions. */
   cancel: () => void;
 }
@@ -24,7 +24,7 @@ export interface FrameBatchScheduler<T> {
  *
  * Exported for testing — consumers should prefer {@link useFrameBatchedState}.
  */
-export function resolveAction<T>(action: SetStateAction<T>, prev: T): T {
+export function applySetStateAction<T>(action: SetStateAction<T>, prev: T): T {
   // React uses the same `typeof` check internally.  When `T` is itself
   // a function type the caller must always use the updater form.
   return typeof action === 'function'
@@ -53,13 +53,13 @@ export function createFrameBatchScheduler<T>(
     onFlush((prev) => {
       let state = prev;
       for (const action of actions) {
-        state = resolveAction(action, state);
+        state = applySetStateAction(action, state);
       }
       return state;
     });
   }
 
-  function setState(action: SetStateAction<T>): void {
+  function pushSetStateAction(action: SetStateAction<T>): void {
     queue.push(action);
     rafId ??= requestAnimationFrame(flush);
   }
@@ -72,7 +72,7 @@ export function createFrameBatchScheduler<T>(
     queue = [];
   }
 
-  return {setState, cancel};
+  return {pushSetStateAction, cancel};
 }
 
 /**
@@ -98,7 +98,7 @@ export function useFrameBatchedState<T>(
 
   const batchedSetState: Dispatch<SetStateAction<T>> = useCallback(
     (action: SetStateAction<T>) => {
-      scheduler.setState(action);
+      scheduler.pushSetStateAction(action);
     },
     [scheduler],
   );

--- a/apps/frontend/src/pages/chat/components/StreamingMessageDisplay/hooks/useMessages.ts
+++ b/apps/frontend/src/pages/chat/components/StreamingMessageDisplay/hooks/useMessages.ts
@@ -308,7 +308,7 @@ export function useMessages() {
       setMessages(finishThinking);
     };
     const onReset = () => {
-      setMessages(() => []);
+      setMessages([]);
     };
     const onSubagentDispatched = (data: {
       agentId: string;

--- a/apps/frontend/src/pages/chat/components/StreamingMessageDisplay/hooks/useMessages.ts
+++ b/apps/frontend/src/pages/chat/components/StreamingMessageDisplay/hooks/useMessages.ts
@@ -6,7 +6,9 @@ import type {
   SseToolExecuteEndEvent,
   SseToolExecuteStartEvent,
 } from '@omnicraft/sse-events';
-import {useEffect, useState} from 'react';
+import {useEffect} from 'react';
+
+import {useFrameBatchedState} from '@/hooks/useFrameBatchedState.js';
 
 import type {ChatEventBus, ChatMessage} from '../types.js';
 import {useChatEventBus} from './useChatEventBus.js';
@@ -268,45 +270,45 @@ function updateSubagentStatus(
 
 /** Manages the chat message history, subscribing to chat events. */
 export function useMessages() {
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [messages, enqueue] = useFrameBatchedState<ChatMessage[]>([]);
   const eventBus = useChatEventBus();
 
   useEffect(() => {
     const onUserMessageSent = (data: {content: string}) => {
-      setMessages((prev) => addUserMessage(prev, data.content));
+      enqueue((prev) => addUserMessage(prev, data.content));
     };
     const onTextDelta = (data: SseTextDeltaEvent) => {
-      setMessages((prev) => appendAssistantText(prev, data.content));
+      enqueue((prev) => appendAssistantText(prev, data.content));
     };
     const onToolExecuteStart = (data: SseToolExecuteStartEvent) => {
-      setMessages((prev) => pushToolStart(prev, data));
+      enqueue((prev) => pushToolStart(prev, data));
     };
     const onToolExecuteEnd = (data: SseToolExecuteEndEvent) => {
-      setMessages((prev) => pushToolEnd(prev, data));
+      enqueue((prev) => pushToolEnd(prev, data));
     };
     const onDone = () => {
-      setMessages(removeTrailingAssistantMessageIfEmpty);
+      enqueue(removeTrailingAssistantMessageIfEmpty);
     };
     const onMessageStart = (data: SseMessageStartEvent) => {
       if (data.role === 'user') {
-        setMessages((prev) => applyUserMessageStart(prev, data));
+        enqueue((prev) => applyUserMessageStart(prev, data));
       } else {
-        setMessages((prev) =>
+        enqueue((prev) =>
           applyAssistantMessageStart(prev, data.messageId, data.createdAt),
         );
       }
     };
     const onThinkingStart = () => {
-      setMessages(pushThinkingStart);
+      enqueue(pushThinkingStart);
     };
     const onThinkingDelta = (data: SseThinkingDeltaEvent) => {
-      setMessages((prev) => appendThinkingDelta(prev, data.content));
+      enqueue((prev) => appendThinkingDelta(prev, data.content));
     };
     const onThinkingEnd = () => {
-      setMessages(finishThinking);
+      enqueue(finishThinking);
     };
     const onReset = () => {
-      setMessages([]);
+      enqueue(() => []);
     };
     const onSubagentDispatched = (data: {
       agentId: string;
@@ -316,13 +318,13 @@ export function useMessages() {
       workingDirectory: string;
       eventBus: ChatEventBus;
     }) => {
-      setMessages((prev) => pushSubagentStart(prev, data));
+      enqueue((prev) => pushSubagentStart(prev, data));
     };
     const onSubagentCompleted = (data: {
       agentId: string;
       status: 'success' | 'failure';
     }) => {
-      setMessages((prev) => updateSubagentStatus(prev, data));
+      enqueue((prev) => updateSubagentStatus(prev, data));
     };
 
     eventBus.on('user-message-sent', onUserMessageSent);
@@ -352,7 +354,7 @@ export function useMessages() {
       eventBus.off('subagent-dispatched', onSubagentDispatched);
       eventBus.off('subagent-completed', onSubagentCompleted);
     };
-  }, [eventBus]);
+  }, [eventBus, enqueue]);
 
   return {messages};
 }

--- a/apps/frontend/src/pages/chat/components/StreamingMessageDisplay/hooks/useMessages.ts
+++ b/apps/frontend/src/pages/chat/components/StreamingMessageDisplay/hooks/useMessages.ts
@@ -270,45 +270,45 @@ function updateSubagentStatus(
 
 /** Manages the chat message history, subscribing to chat events. */
 export function useMessages() {
-  const [messages, enqueue] = useFrameBatchedState<ChatMessage[]>([]);
+  const [messages, setMessages] = useFrameBatchedState<ChatMessage[]>([]);
   const eventBus = useChatEventBus();
 
   useEffect(() => {
     const onUserMessageSent = (data: {content: string}) => {
-      enqueue((prev) => addUserMessage(prev, data.content));
+      setMessages((prev) => addUserMessage(prev, data.content));
     };
     const onTextDelta = (data: SseTextDeltaEvent) => {
-      enqueue((prev) => appendAssistantText(prev, data.content));
+      setMessages((prev) => appendAssistantText(prev, data.content));
     };
     const onToolExecuteStart = (data: SseToolExecuteStartEvent) => {
-      enqueue((prev) => pushToolStart(prev, data));
+      setMessages((prev) => pushToolStart(prev, data));
     };
     const onToolExecuteEnd = (data: SseToolExecuteEndEvent) => {
-      enqueue((prev) => pushToolEnd(prev, data));
+      setMessages((prev) => pushToolEnd(prev, data));
     };
     const onDone = () => {
-      enqueue(removeTrailingAssistantMessageIfEmpty);
+      setMessages(removeTrailingAssistantMessageIfEmpty);
     };
     const onMessageStart = (data: SseMessageStartEvent) => {
       if (data.role === 'user') {
-        enqueue((prev) => applyUserMessageStart(prev, data));
+        setMessages((prev) => applyUserMessageStart(prev, data));
       } else {
-        enqueue((prev) =>
+        setMessages((prev) =>
           applyAssistantMessageStart(prev, data.messageId, data.createdAt),
         );
       }
     };
     const onThinkingStart = () => {
-      enqueue(pushThinkingStart);
+      setMessages(pushThinkingStart);
     };
     const onThinkingDelta = (data: SseThinkingDeltaEvent) => {
-      enqueue((prev) => appendThinkingDelta(prev, data.content));
+      setMessages((prev) => appendThinkingDelta(prev, data.content));
     };
     const onThinkingEnd = () => {
-      enqueue(finishThinking);
+      setMessages(finishThinking);
     };
     const onReset = () => {
-      enqueue(() => []);
+      setMessages(() => []);
     };
     const onSubagentDispatched = (data: {
       agentId: string;
@@ -318,13 +318,13 @@ export function useMessages() {
       workingDirectory: string;
       eventBus: ChatEventBus;
     }) => {
-      enqueue((prev) => pushSubagentStart(prev, data));
+      setMessages((prev) => pushSubagentStart(prev, data));
     };
     const onSubagentCompleted = (data: {
       agentId: string;
       status: 'success' | 'failure';
     }) => {
-      enqueue((prev) => updateSubagentStatus(prev, data));
+      setMessages((prev) => updateSubagentStatus(prev, data));
     };
 
     eventBus.on('user-message-sent', onUserMessageSent);
@@ -354,7 +354,7 @@ export function useMessages() {
       eventBus.off('subagent-dispatched', onSubagentDispatched);
       eventBus.off('subagent-completed', onSubagentCompleted);
     };
-  }, [eventBus, enqueue]);
+  }, [eventBus, setMessages]);
 
   return {messages};
 }


### PR DESCRIPTION
## Summary
- Introduces `useFrameBatchedState<T>` — a generic hook that coalesces state transforms within a single `requestAnimationFrame` window
- Replaces direct `setMessages` calls in `useMessages` with the new hook's `enqueue`, so all SSE events arriving within one frame are composed into a single state update
- During session replay, this prevents `useStreamingText` from seeing incremental content growth and triggering its character-by-character animation

## Test plan
- [x] 9 unit tests for `createFrameBatchScheduler` covering batching, composition order, cancel, re-enqueue, and empty flush
- [x] All 93 existing frontend tests pass
- [ ] Manual: navigate to `/chat/:sessionId` for a completed session — messages should appear instantly without streaming animation
- [x] Manual: send a new message in a live session — streaming animation should work as before

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)