### PR TITLE
refactor: internalize getConfig in MainAgent

### DIFF
--- a/apps/backend/src/agent/agents/main-agent/main-agent.ts
+++ b/apps/backend/src/agent/agents/main-agent/main-agent.ts
@@ -11,7 +11,6 @@ import {
 } from '@/agent/tools/index.js';
 import {Agent} from '@/agent-core/agent/index.js';
 import type {AgentSnapshot} from '@/agent-core/agent/types.js';
-import type {LlmConfig} from '@/agent-core/llm-api/index.js';
 import {settingsService} from '@/services/settings/index.js';
 
 /**
@@ -21,14 +20,17 @@ import {settingsService} from '@/services/settings/index.js';
  */
 export class MainAgent extends Agent {
   constructor(
-    getConfig: () => Promise<LlmConfig>,
     workingDirectory: string,
     extraAllowedPaths: readonly AllowedPathEntry[] = [],
     sessionsDir?: string,
     snapshot?: AgentSnapshot,
   ) {
     super(
-      getConfig,
+      async () => {
+        const settings = await settingsService.getAll();
+        const {apiFormat, apiKey, baseUrl, model} = settings.llm;
+        return {apiFormat, apiKey, baseUrl, model};
+      },
       {
         toolRegistries: [
           CoreToolRegistry.getInstance(),
@@ -57,15 +59,10 @@ export class MainAgent extends Agent {
     );
   }
 
-  static async restore(
-    getConfig: () => Promise<LlmConfig>,
-    sessionsDir: string,
-    id: string,
-  ): Promise<MainAgent> {
+  static async restore(sessionsDir: string, id: string): Promise<MainAgent> {
     const snapshot = await Agent.loadSnapshotFromDisk(sessionsDir, id);
     await Agent.reconcileEventsFile(sessionsDir, id, snapshot.sseEventCount);
     return new MainAgent(
-      getConfig,
       snapshot.options.workingDirectory,
       snapshot.options.extraAllowedPaths ?? [],
       sessionsDir,

--- a/apps/backend/src/models/agent-store/main-agent-store.ts
+++ b/apps/backend/src/models/agent-store/main-agent-store.ts
@@ -5,7 +5,6 @@ import path from 'node:path';
 import {MainAgent} from '@/agent/agents/index.js';
 import type {Agent} from '@/agent-core/agent/index.js';
 import {agentEventBus} from '@/agent-core/events/index.js';
-import {getLlmConfig} from '@/services/chat/helpers.js';
 
 const MAX_CACHED_AGENTS = 50;
 
@@ -113,7 +112,7 @@ export class MainAgentStore {
 
   private async loadFromDisk(id: string): Promise<Agent | undefined> {
     if (!(await this.existsOnDisk(id))) return undefined;
-    const agent = await MainAgent.restore(getLlmConfig, this._sessionsDir, id);
+    const agent = await MainAgent.restore(this._sessionsDir, id);
     const entry = this.cache.get(id);
     if (entry) entry.lastAccessedAt = Date.now();
     return agent;

--- a/apps/backend/src/services/chat/chat-service.ts
+++ b/apps/backend/src/services/chat/chat-service.ts
@@ -77,7 +77,6 @@ export const chatService = {
     }
 
     const agent = new MainAgent(
-      getLlmConfig,
       workingDirectory,
       resolvedExtraFilePathEntries,
       MainAgentStore.getInstance().sessionsDir,


### PR DESCRIPTION
## Summary
- Remove `getConfig` parameter from `MainAgent` constructor and `restore` method
- Resolve LLM config internally via `settingsService`, consistent with how `getLightConfig` and `getMaxToolRounds` are already resolved
- Update call sites in `chat-service.ts` and `main-agent-store.ts`

Closes #140

## Test plan
- [x] `bun run typecheck` passes
- [x] All 459 tests pass (`bun run test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)