### PR TITLE
feat: improve web_search with timeRange and autoParameters

### DIFF
--- a/apps/backend/src/agent/tools/web/web-search.ts
+++ b/apps/backend/src/agent/tools/web/web-search.ts
@@ -67,6 +67,7 @@ export const webSearchTool: ToolDefinition<typeof parameters, WebSearchResult> =
           maxResults: args.maxResults ?? 5,
           includeDomains: args.includeDomains,
           excludeDomains: args.excludeDomains,
+          timeRange: args.timeRange,
         });
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);

--- a/apps/backend/src/agent/tools/web/web-search.ts
+++ b/apps/backend/src/agent/tools/web/web-search.ts
@@ -64,6 +64,8 @@ export const webSearchTool: ToolDefinition<typeof parameters, WebSearchResult> =
       try {
         const client = tavily({apiKey});
         response = await client.search(args.query, {
+          autoParameters: true,
+          searchDepth: 'basic',
           maxResults: args.maxResults ?? 5,
           includeDomains: args.includeDomains,
           excludeDomains: args.excludeDomains,

--- a/packages/tool-schemas/src/parameter-schemas.ts
+++ b/packages/tool-schemas/src/parameter-schemas.ts
@@ -124,6 +124,13 @@ export const webSearchParametersSchema = z.object({
     .array(z.string())
     .optional()
     .describe('Exclude these domains from results.'),
+  timeRange: z
+    .enum(['day', 'week', 'month', 'year'])
+    .optional()
+    .describe(
+      'Only return results published within this time range from now. ' +
+        'Use when searching for recent events, news, or time-sensitive information.',
+    ),
 });
 
 // --- web_fetch ---


### PR DESCRIPTION
## Summary
- Add `timeRange` parameter (`day`/`week`/`month`/`year`) to `web_search` tool for filtering results by recency
- Enable Tavily `autoParameters` to let it auto-optimize `topic`, `country`, etc. based on query intent
- Pin `searchDepth` to `basic` to prevent extra credit consumption from autoParameters

## Test plan
- [ ] Search with `timeRange: "week"` and verify results are recent
- [ ] Search without `timeRange` and verify it still works as before
- [ ] Verify autoParameters doesn't upgrade searchDepth (check credit usage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)