### PR TITLE
docs: add when-to-use guidance to tool and parameter descriptions

### DIFF
--- a/apps/backend/src/agent/tools/CLAUDE.md
+++ b/apps/backend/src/agent/tools/CLAUDE.md
@@ -1,0 +1,12 @@
+## Tool Description Guidelines
+
+Every tool description and optional parameter description must include:
+
+1. **What it does** — the functionality.
+2. **When to use it** — the conditions under which this tool should be called or this parameter should be set.
+
+Descriptions must be **generic**:
+
+- Do not bind to specific types of work (e.g., programming, data analysis).
+- Do not reference other tools by name. Describe the boundary in generic terms (e.g., "rather than needing to discover information" instead of "use web_fetch instead of web_search").
+- Do not list overly specific examples. Prefer abstract guidance over enumerating concrete scenarios.

--- a/apps/backend/src/agent/tools/file/edit-file.ts
+++ b/apps/backend/src/agent/tools/file/edit-file.ts
@@ -41,7 +41,9 @@ export const editFileTool: ToolDefinition<typeof parameters, EditFileResult> = {
   name: TOOL_NAME.EDIT_FILE,
   displayName: 'Edit File',
   description:
-    'Replaces a specific string in a file. ' +
+    'Replaces a specific string in a file and returns a diff of the change. ' +
+    'Use this to make targeted modifications to an existing file ' +
+    'without rewriting the entire file. ' +
     'Requires the old string to uniquely match unless replaceAll is set.',
   parameters,
   suppressToolEvents: false,

--- a/apps/backend/src/agent/tools/file/read-file.ts
+++ b/apps/backend/src/agent/tools/file/read-file.ts
@@ -38,6 +38,8 @@ export const readFileTool: ToolDefinition<typeof parameters, ReadFileResult> = {
   description:
     'Reads a text file and returns its contents with line numbers. ' +
     'Supports partial reads via startLine and lineCount parameters. ' +
+    'Use this whenever you need to see the current content of a file ' +
+    'or review a specific section of it. ' +
     'Only text files within the working directory are allowed.',
   parameters,
   suppressToolEvents: false,

--- a/apps/backend/src/agent/tools/file/search-files.ts
+++ b/apps/backend/src/agent/tools/file/search-files.ts
@@ -86,7 +86,7 @@ export const searchFilesTool: ToolDefinition<
   displayName: 'Search Files',
   description:
     'Searches file contents for a regex pattern and returns matching lines with file paths and line numbers. ' +
-    'Use this to find where a function, variable, string, or pattern is used across the codebase.',
+    'Use this to find where a specific string or pattern appears across files.',
   parameters,
   suppressToolEvents: false,
   async execute(args: SearchFilesArgs, context: ToolExecutionContext) {

--- a/apps/backend/src/agent/tools/file/write-file.ts
+++ b/apps/backend/src/agent/tools/file/write-file.ts
@@ -32,7 +32,10 @@ export const writeFileTool: ToolDefinition<typeof parameters, WriteFileResult> =
     displayName: 'Write File',
     description:
       'Creates a new file or overwrites an existing file. ' +
-      'Prefer editing over overwriting when modifying existing files.',
+      'Use this to create files that do not exist yet, ' +
+      'or to completely replace the content of an existing file. ' +
+      'When only part of the content needs to change, ' +
+      'prefer a targeted replacement over a full overwrite.',
     parameters,
     suppressToolEvents: false,
     async execute(args: WriteFileArgs, context: ToolExecutionContext) {

--- a/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
+++ b/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
@@ -58,23 +58,33 @@ const parameters = z.object({
   task: z.string().min(1).describe('The task description for the subagent'),
   agentType: agentTypeSchema
     .optional()
-    .describe("Type of subagent to dispatch. Defaults to 'general'."),
+    .describe(
+      "Type of subagent to dispatch. Defaults to 'general'. " +
+        "Use 'coding' when the task is primarily about reading, modifying, " +
+        'or creating files.',
+    ),
   model: z
     .enum(['default', 'light'])
     .optional()
     .describe(
-      "Which model tier to use. 'default' uses the main model, 'light' uses the lightweight model. Defaults to 'default'.",
+      "Which model tier to use. 'default' uses the main model, 'light' uses the lightweight model. Defaults to 'default'. " +
+        "Use 'light' for simple, well-defined subtasks " +
+        'where speed matters more than reasoning depth.',
     ),
   workingDirectory: z
     .string()
     .optional()
     .describe(
-      "Working directory for the subagent. Must be within allowed paths. Defaults to the parent agent's working directory.",
+      "Working directory for the subagent. Must be within allowed paths. Defaults to the parent agent's working directory. " +
+        'Set this when the subtask operates in a different subdirectory or project root ' +
+        'than the current working directory.',
     ),
   thinkingLevel: thinkingLevelSchema
     .optional()
     .describe(
-      "Controls extended thinking for the subagent. Defaults to 'none'.",
+      "Controls extended thinking for the subagent ('none', 'low', 'medium', 'high'). Defaults to 'none'. " +
+        'Increase this for subtasks that require multi-step reasoning, complex analysis, ' +
+        'or planning before acting.',
     ),
 });
 

--- a/apps/backend/src/agent/tools/web/web-fetch.ts
+++ b/apps/backend/src/agent/tools/web/web-fetch.ts
@@ -92,7 +92,9 @@ export const webFetchTool: ToolDefinition<typeof parameters, WebFetchResult> = {
   description:
     'Fetches a URL and returns its content in a readable format. ' +
     'HTML pages are converted to Markdown with article extraction. ' +
-    'Other text content (JSON, plain text, XML) is returned as-is.',
+    'Other text content (JSON, plain text, XML) is returned as-is. ' +
+    'Use this when you already know the URL to retrieve, ' +
+    'rather than needing to discover information.',
   parameters,
   suppressToolEvents: false,
   async execute(args: WebFetchArgs, _context: ToolExecutionContext) {

--- a/packages/tool-schemas/src/parameter-schemas.ts
+++ b/packages/tool-schemas/src/parameter-schemas.ts
@@ -11,13 +11,21 @@ export const readFileParametersSchema = z.object({
     .int()
     .min(1)
     .optional()
-    .describe('Start line number (1-based), defaults to 1'),
+    .describe(
+      'Start line number (1-based), defaults to 1. ' +
+        'Use this to resume reading from a specific line after a previous partial read, ' +
+        'or to jump directly to a known region of interest.',
+    ),
   lineCount: z
     .number()
     .int()
     .min(1)
     .optional()
-    .describe('Number of lines to read, defaults to end of file'),
+    .describe(
+      'Number of lines to read from startLine, defaults to end of file. ' +
+        'Use this to read a specific portion of a large file ' +
+        'when you only need a particular section rather than the entire content.',
+    ),
 });
 
 // --- write_file ---
@@ -43,7 +51,9 @@ export const editFileParametersSchema = z.object({
     .boolean()
     .optional()
     .describe(
-      'Replace all occurrences. Defaults to false (requires unique match)',
+      'Replace all occurrences. Defaults to false (requires unique match). ' +
+        'Set to true when the same string appears multiple times in the file ' +
+        'and all occurrences should be replaced.',
     ),
 });
 
@@ -60,7 +70,9 @@ export const findFilesParametersSchema = z.object({
     .string()
     .optional()
     .describe(
-      'Search root directory (relative or absolute), defaults to working directory',
+      'Search root directory (relative or absolute), defaults to working directory. ' +
+        'Use this to narrow the search to a specific subdirectory ' +
+        'when you know which part of the project to look in.',
     ),
 });
 
@@ -77,13 +89,17 @@ export const searchFilesParametersSchema = z.object({
     .string()
     .optional()
     .describe(
-      'Search root directory (relative or absolute), defaults to working directory',
+      'Search root directory (relative or absolute), defaults to working directory. ' +
+        'Use this to limit the search scope to a specific subdirectory ' +
+        'for faster results or to avoid matches in irrelevant areas.',
     ),
   filePattern: z
     .string()
     .optional()
     .describe(
-      'Glob pattern to filter files, e.g. "**/*.ts", defaults to "**/*"',
+      'Glob pattern to filter which files are searched, e.g. "**/*.ts", defaults to "**/*". ' +
+        'Use this to restrict the search to specific file types ' +
+        'when you only care about matches in certain languages or file formats.',
     ),
 });
 
@@ -101,29 +117,46 @@ export const runCommandParametersSchema = z.object({
     .max(RUN_COMMAND_MAX_TIMEOUT_MS)
     .optional()
     .describe(
-      `Timeout in milliseconds (default: ${RUN_COMMAND_DEFAULT_TIMEOUT_MS}, max: ${RUN_COMMAND_MAX_TIMEOUT_MS})`,
+      `Timeout in milliseconds (default: ${RUN_COMMAND_DEFAULT_TIMEOUT_MS}, max: ${RUN_COMMAND_MAX_TIMEOUT_MS}). ` +
+        'Increase this for long-running commands ' +
+        'that are expected to exceed the default 2-minute limit.',
     ),
 });
 
 // --- web_search ---
 
 export const webSearchParametersSchema = z.object({
-  query: z.string().describe('Search keywords.'),
+  query: z
+    .string()
+    .describe(
+      'Search keywords or phrase describing the information to find on the web.',
+    ),
   maxResults: z
     .number()
     .int()
     .min(1)
     .max(20)
     .optional()
-    .describe('Number of results to return. Defaults to 5.'),
+    .describe(
+      'Number of results to return. Defaults to 5. ' +
+        'Increase this when you need a broader survey of sources ' +
+        'or when the first few results are unlikely to contain the answer.',
+    ),
   includeDomains: z
     .array(z.string())
     .optional()
-    .describe('Only search these domains.'),
+    .describe(
+      'Only search these domains. ' +
+        'Use this when you want results exclusively from specific sites.',
+    ),
   excludeDomains: z
     .array(z.string())
     .optional()
-    .describe('Exclude these domains from results.'),
+    .describe(
+      'Exclude these domains from results. ' +
+        'Use this to filter out known low-quality or irrelevant sites ' +
+        'that tend to dominate results for the query.',
+    ),
   timeRange: z
     .enum(['day', 'week', 'month', 'year'])
     .optional()
@@ -170,7 +203,9 @@ export const askUserParametersSchema = z.object({
         options: z
           .array(z.string())
           .describe(
-            'Predefined answer options. Empty array for free-text only.',
+            'Predefined answer options for the user to select from. ' +
+              'Provide options when there is a known set of valid choices to guide the user. ' +
+              'Use an empty array for open-ended questions that require free-text input.',
           ),
       }),
     )


### PR DESCRIPTION
## Summary

- Audited all 13 tool descriptions and their optional parameters for completeness
- Added "when to use" guidance to 4 tool-level descriptions (`read_file`, `write_file`, `edit_file`, `web_fetch`) that only described functionality
- Added "when to use" guidance to 15 optional parameter descriptions across `parameter-schemas.ts` and `dispatch-agent-tool.ts`
- Every tool description and optional parameter now consistently includes both **what it does** and **when to use it**

## Test plan

- [x] `bun run --filter '@omnicraft/backend' typecheck` passes
- [x] Lint and format checks pass via pre-commit hook
- [ ] Verify tool descriptions render correctly in LLM tool-calling context

🤖 Generated with [Claude Code](https://claude.com/claude-code)