### PR TITLE
perf: write metadata.json sidecar to avoid reading full snapshot in session listing

### DIFF
--- a/apps/backend/src/agent-core/agent/agent-persistence.test.ts
+++ b/apps/backend/src/agent-core/agent/agent-persistence.test.ts
@@ -48,6 +48,17 @@ describe('agentPersistence', () => {
       const loaded = await agentPersistence.loadSnapshot(tmpDir, agentId);
       expect(loaded).toEqual(snapshot);
     });
+
+    it('writes metadata.json alongside snapshot.json', async () => {
+      const snapshot = createTestSnapshot(agentId);
+      await agentPersistence.persistSnapshot(tmpDir, agentId, snapshot);
+
+      const metadataPath = agentPersistence.metadataPath(tmpDir, agentId);
+      const content = await readFile(metadataPath, 'utf-8');
+      const metadata: unknown = JSON.parse(content);
+
+      expect(metadata).toEqual({id: agentId, title: 'Test Session'});
+    });
   });
 
   describe('loadSnapshot', () => {

--- a/apps/backend/src/agent-core/agent/agent-persistence.ts
+++ b/apps/backend/src/agent-core/agent/agent-persistence.ts
@@ -31,15 +31,20 @@ export const agentPersistence = {
     const snapshotFile = agentPersistence.snapshotPath(sessionsDir, id);
     const snapshotTmp = `${snapshotFile}.${crypto.randomUUID()}.tmp`;
     const snapshotData = JSON.stringify(snapshot, null, 2) + '\n';
-    await writeFile(snapshotTmp, snapshotData);
-    await rename(snapshotTmp, snapshotFile);
 
     const metadataFile = agentPersistence.metadataPath(sessionsDir, id);
     const metadataTmp = `${metadataFile}.${crypto.randomUUID()}.tmp`;
     const metadataData =
       JSON.stringify({id: snapshot.id, title: snapshot.title}, null, 2) + '\n';
-    await writeFile(metadataTmp, metadataData);
-    await rename(metadataTmp, metadataFile);
+
+    await Promise.all([
+      writeFile(snapshotTmp, snapshotData).then(() =>
+        rename(snapshotTmp, snapshotFile),
+      ),
+      writeFile(metadataTmp, metadataData).then(() =>
+        rename(metadataTmp, metadataFile),
+      ),
+    ]);
   },
 
   async loadSnapshot(sessionsDir: string, id: string): Promise<AgentSnapshot> {

--- a/apps/backend/src/agent-core/agent/agent-persistence.ts
+++ b/apps/backend/src/agent-core/agent/agent-persistence.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 
 import {sseEventSchema} from '@omnicraft/sse-events';
 
+import {isFileNotFoundError} from '@/helpers/fs.js';
+
 import type {AgentSnapshot} from './types.js';
 import {agentSnapshotSchema} from './types.js';
 
@@ -64,11 +66,7 @@ export const agentPersistence = {
     try {
       content = await readFile(filePath, 'utf-8');
     } catch (error: unknown) {
-      if (
-        error instanceof Error &&
-        'code' in error &&
-        error.code === 'ENOENT'
-      ) {
+      if (isFileNotFoundError(error)) {
         return;
       }
       throw error;

--- a/apps/backend/src/agent-core/agent/agent-persistence.ts
+++ b/apps/backend/src/agent-core/agent/agent-persistence.ts
@@ -12,6 +12,10 @@ export const agentPersistence = {
     return path.join(sessionsDir, id, 'snapshot.json');
   },
 
+  metadataPath(sessionsDir: string, id: string): string {
+    return path.join(sessionsDir, id, 'metadata.json');
+  },
+
   eventsPath(sessionsDir: string, id: string): string {
     return path.join(sessionsDir, id, 'sse-events.jsonl');
   },
@@ -21,13 +25,21 @@ export const agentPersistence = {
     id: string,
     snapshot: AgentSnapshot,
   ): Promise<void> {
-    const filePath = agentPersistence.snapshotPath(sessionsDir, id);
-    const dir = path.dirname(filePath);
+    const dir = path.join(sessionsDir, id);
     await mkdir(dir, {recursive: true});
-    const tmpPath = `${filePath}.${crypto.randomUUID()}.tmp`;
-    const data = JSON.stringify(snapshot, null, 2) + '\n';
-    await writeFile(tmpPath, data);
-    await rename(tmpPath, filePath);
+
+    const snapshotFile = agentPersistence.snapshotPath(sessionsDir, id);
+    const snapshotTmp = `${snapshotFile}.${crypto.randomUUID()}.tmp`;
+    const snapshotData = JSON.stringify(snapshot, null, 2) + '\n';
+    await writeFile(snapshotTmp, snapshotData);
+    await rename(snapshotTmp, snapshotFile);
+
+    const metadataFile = agentPersistence.metadataPath(sessionsDir, id);
+    const metadataTmp = `${metadataFile}.${crypto.randomUUID()}.tmp`;
+    const metadataData =
+      JSON.stringify({id: snapshot.id, title: snapshot.title}, null, 2) + '\n';
+    await writeFile(metadataTmp, metadataData);
+    await rename(metadataTmp, metadataFile);
   },
 
   async loadSnapshot(sessionsDir: string, id: string): Promise<AgentSnapshot> {

--- a/apps/backend/src/agent-core/agent/agent-sse-log.ts
+++ b/apps/backend/src/agent-core/agent/agent-sse-log.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 
 import {type SseEvent, sseEventSchema} from '@omnicraft/sse-events';
 
+import {isFileNotFoundError} from '@/helpers/fs.js';
 import {Mutex} from '@/helpers/mutex.js';
 
 export interface AgentSseLogReaderOptions {
@@ -134,11 +135,7 @@ export class AgentSseLog {
       try {
         content = await readFile(this.filePath, 'utf-8');
       } catch (error) {
-        if (
-          error instanceof Error &&
-          'code' in error &&
-          error.code === 'ENOENT'
-        ) {
+        if (isFileNotFoundError(error)) {
           this.loaded = true;
           return;
         }

--- a/apps/backend/src/helpers/fs.ts
+++ b/apps/backend/src/helpers/fs.ts
@@ -6,6 +6,11 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+/** Checks whether an error is a file-not-found (ENOENT) error. */
+export function isFileNotFoundError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}
+
 /** Checks whether a file exists at the given path. */
 export async function fileExists(filePath: string): Promise<boolean> {
   try {

--- a/apps/backend/src/models/agent-store/main-agent-store.test.ts
+++ b/apps/backend/src/models/agent-store/main-agent-store.test.ts
@@ -37,6 +37,17 @@ async function writeSnapshot(
   await writeFile(path.join(dir, 'snapshot.json'), JSON.stringify(data));
 }
 
+/** Writes a metadata.json sidecar into a session directory. */
+async function writeMetadata(
+  sessionsDir: string,
+  id: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  const dir = path.join(sessionsDir, id);
+  await mkdir(dir, {recursive: true});
+  await writeFile(path.join(dir, 'metadata.json'), JSON.stringify(data));
+}
+
 describe('MainAgentStore', () => {
   let sessionsDir: string;
 
@@ -347,6 +358,40 @@ describe('MainAgentStore', () => {
       const page3 = await store.listSessionMetadata(4, 2);
       expect(page3.total).toBe(5);
       expect(page3.sessions).toEqual([{id: 's0', title: 'T0'}]);
+    });
+
+    it('reads from metadata.json when present', async () => {
+      const store = MainAgentStore.create(sessionsDir);
+      await writeSnapshot(sessionsDir, 'sess-1', {
+        id: 'sess-1',
+        title: 'Snapshot Title',
+        sseEventCount: 0,
+        llmSession: {id: 'llm-1', messages: [{large: 'data'}]},
+        options: {workingDirectory: '/tmp'},
+      });
+      await writeMetadata(sessionsDir, 'sess-1', {
+        id: 'sess-1',
+        title: 'Metadata Title',
+      });
+
+      const result = await store.listSessionMetadata(0, 100);
+      expect(result.sessions).toEqual([
+        {id: 'sess-1', title: 'Metadata Title'},
+      ]);
+    });
+
+    it('falls back to snapshot.json when metadata.json is missing', async () => {
+      const store = MainAgentStore.create(sessionsDir);
+      await writeSnapshot(sessionsDir, 'legacy', {
+        id: 'legacy',
+        title: 'Legacy Title',
+        sseEventCount: 0,
+        llmSession: {id: 'llm-1', messages: []},
+        options: {workingDirectory: '/tmp'},
+      });
+
+      const result = await store.listSessionMetadata(0, 100);
+      expect(result.sessions).toEqual([{id: 'legacy', title: 'Legacy Title'}]);
     });
   });
 

--- a/apps/backend/src/models/agent-store/main-agent-store.ts
+++ b/apps/backend/src/models/agent-store/main-agent-store.ts
@@ -156,15 +156,11 @@ export class MainAgentStore {
     const total = statResults.length;
     const page = statResults.slice(offset, offset + limit);
 
-    // Phase 2: read snapshot content only for the requested page.
+    // Phase 2: read metadata (or snapshot as fallback) for the requested page.
     const results = await Promise.all(
       page.map(async ({id}): Promise<SessionMetadata | null> => {
-        const snapshotPath = agentPersistence.snapshotPath(
-          this._sessionsDir,
-          id,
-        );
         try {
-          const content = await readFile(snapshotPath, 'utf-8');
+          const content = await this.readSessionMetadataFile(id);
           const json: unknown = JSON.parse(content);
           return sessionMetadataSchema.parse(json);
         } catch (e) {
@@ -177,6 +173,24 @@ export class MainAgentStore {
     const sessions = results.filter((r): r is SessionMetadata => r !== null);
 
     return {sessions, total};
+  }
+
+  /**
+   * Reads session metadata from metadata.json, falling back to snapshot.json
+   * for sessions created before the sidecar file was introduced.
+   */
+  private async readSessionMetadataFile(id: string): Promise<string> {
+    try {
+      return await readFile(
+        agentPersistence.metadataPath(this._sessionsDir, id),
+        'utf-8',
+      );
+    } catch {
+      return readFile(
+        agentPersistence.snapshotPath(this._sessionsDir, id),
+        'utf-8',
+      );
+    }
   }
 
   private async loadFromDisk(id: string): Promise<Agent | undefined> {

--- a/apps/backend/src/models/agent-store/main-agent-store.ts
+++ b/apps/backend/src/models/agent-store/main-agent-store.ts
@@ -11,6 +11,7 @@ import {MainAgent} from '@/agent/agents/index.js';
 import type {Agent} from '@/agent-core/agent/index.js';
 import {agentPersistence} from '@/agent-core/agent/index.js';
 import {agentEventBus} from '@/agent-core/events/index.js';
+import {isFileNotFoundError} from '@/helpers/fs.js';
 import {logger} from '@/logger.js';
 
 const MAX_CACHED_AGENTS = 50;
@@ -186,11 +187,7 @@ export class MainAgentStore {
         'utf-8',
       );
     } catch (error: unknown) {
-      if (
-        error instanceof Error &&
-        'code' in error &&
-        error.code === 'ENOENT'
-      ) {
+      if (isFileNotFoundError(error)) {
         return readFile(
           agentPersistence.snapshotPath(this._sessionsDir, id),
           'utf-8',

--- a/apps/backend/src/models/agent-store/main-agent-store.ts
+++ b/apps/backend/src/models/agent-store/main-agent-store.ts
@@ -185,11 +185,18 @@ export class MainAgentStore {
         agentPersistence.metadataPath(this._sessionsDir, id),
         'utf-8',
       );
-    } catch {
-      return readFile(
-        agentPersistence.snapshotPath(this._sessionsDir, id),
-        'utf-8',
-      );
+    } catch (error: unknown) {
+      if (
+        error instanceof Error &&
+        'code' in error &&
+        error.code === 'ENOENT'
+      ) {
+        return readFile(
+          agentPersistence.snapshotPath(this._sessionsDir, id),
+          'utf-8',
+        );
+      }
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary

- `persistSnapshot()` now also writes a lightweight `metadata.json` (`{id, title}`) alongside `snapshot.json` using the same atomic-rename pattern
- `listSessionMetadata()` reads `metadata.json` first, falling back to `snapshot.json` for legacy sessions without the sidecar
- Avoids reading the full snapshot (which contains the entire LLM conversation history) just to extract session metadata for listing

Closes #151

## Test plan

- [x] Existing tests pass (38/38 in changed files)
- [x] New test: `persistSnapshot` writes `metadata.json` with correct `{id, title}`
- [x] New test: `listSessionMetadata` reads from `metadata.json` when present
- [x] New test: `listSessionMetadata` falls back to `snapshot.json` when `metadata.json` is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)