### PR TITLE
feat: session history sidebar with CollapsibleSidebar component

### DIFF
--- a/apps/frontend/src/api/chat/chat.ts
+++ b/apps/frontend/src/api/chat/chat.ts
@@ -1,5 +1,7 @@
 import {
   createSessionResponseSchema,
+  type ListSessionsResponse,
+  listSessionsResponseSchema,
   type ThinkingLevel,
 } from '@omnicraft/api-schema';
 import type {SseEvent} from '@omnicraft/sse-events';
@@ -119,6 +121,40 @@ export async function submitToolResponse(
     const body = await res.text();
     throw new Error(
       `Failed to submit tool response (${res.status.toString()}): ${body}`,
+    );
+  }
+}
+
+/** Fetches the list of past sessions. */
+export async function listSessions(
+  offset: number,
+  limit: number,
+): Promise<ListSessionsResponse> {
+  const res = await fetch(
+    `${BASE}/sessions?offset=${offset.toString()}&limit=${limit.toString()}`,
+  );
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `Failed to list sessions (${res.status.toString()}): ${body}`,
+    );
+  }
+
+  const json: unknown = await res.json();
+  return listSessionsResponseSchema.parse(json);
+}
+
+/** Deletes a session by ID. */
+export async function deleteSession(id: string): Promise<void> {
+  const res = await fetch(`${BASE}/session/${id}`, {
+    method: 'DELETE',
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `Failed to delete session (${res.status.toString()}): ${body}`,
     );
   }
 }

--- a/apps/frontend/src/api/chat/chat.ts
+++ b/apps/frontend/src/api/chat/chat.ts
@@ -130,9 +130,11 @@ export async function listSessions(
   offset: number,
   limit: number,
 ): Promise<ListSessionsResponse> {
-  const res = await fetch(
-    `${BASE}/sessions?offset=${offset.toString()}&limit=${limit.toString()}`,
-  );
+  const params = new URLSearchParams({
+    offset: offset.toString(),
+    limit: limit.toString(),
+  });
+  const res = await fetch(`${BASE}/sessions?${params.toString()}`);
 
   if (!res.ok) {
     const body = await res.text();

--- a/apps/frontend/src/api/chat/index.ts
+++ b/apps/frontend/src/api/chat/index.ts
@@ -1,6 +1,7 @@
 export {
   abortCompletion,
   createSession,
+  listSessions,
   sendMessage,
   submitToolResponse,
   subscribeEvents,

--- a/apps/frontend/src/api/chat/index.ts
+++ b/apps/frontend/src/api/chat/index.ts
@@ -1,6 +1,7 @@
 export {
   abortCompletion,
   createSession,
+  deleteSession,
   listSessions,
   sendMessage,
   submitToolResponse,

--- a/apps/frontend/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
+++ b/apps/frontend/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
@@ -1,4 +1,4 @@
-import {Button, Tooltip} from '@heroui/react';
+import {Button, ScrollShadow, Tooltip} from '@heroui/react';
 import {SidebarClose, SidebarOpen} from 'lucide-react';
 import type {ReactNode} from 'react';
 
@@ -46,7 +46,7 @@ export function CollapsibleSidebar({
             </Tooltip.Content>
           </Tooltip>
         </div>
-        <div className={styles.content}>{children}</div>
+        <ScrollShadow className={styles.content}>{children}</ScrollShadow>
       </div>
       <div className={styles.collapsed}>
         <Tooltip delay={0}>

--- a/apps/frontend/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
+++ b/apps/frontend/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
@@ -1,0 +1,76 @@
+import {Button, Tooltip} from '@heroui/react';
+import {PanelLeftClose, PanelLeftOpen} from 'lucide-react';
+import type {ReactNode} from 'react';
+
+import styles from './styles.module.css';
+
+interface CollapsibleSidebarProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  headerExtra?: ReactNode;
+  children: ReactNode;
+}
+
+export function CollapsibleSidebar({
+  isOpen,
+  onOpenChange,
+  title,
+  headerExtra,
+  children,
+}: CollapsibleSidebarProps) {
+  if (!isOpen) {
+    return (
+      <aside className={styles.sidebar} data-open='false'>
+        <div className={styles.collapsed}>
+          <Tooltip delay={0}>
+            <Tooltip.Trigger>
+              <Button
+                isIconOnly
+                size='sm'
+                variant='ghost'
+                aria-label='Expand sidebar'
+                onPress={() => {
+                  onOpenChange(true);
+                }}
+              >
+                <PanelLeftOpen size={16} />
+              </Button>
+            </Tooltip.Trigger>
+            <Tooltip.Content>
+              <p>Expand sidebar</p>
+            </Tooltip.Content>
+          </Tooltip>
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className={styles.sidebar} data-open='true'>
+      <div className={styles.header}>
+        <span className={styles.title}>{title}</span>
+        {headerExtra && <div className={styles.headerExtra}>{headerExtra}</div>}
+        <Tooltip delay={0}>
+          <Tooltip.Trigger>
+            <Button
+              isIconOnly
+              size='sm'
+              variant='ghost'
+              aria-label='Collapse sidebar'
+              onPress={() => {
+                onOpenChange(false);
+              }}
+            >
+              <PanelLeftClose size={16} />
+            </Button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>
+            <p>Collapse sidebar</p>
+          </Tooltip.Content>
+        </Tooltip>
+      </div>
+      <div className={styles.content}>{children}</div>
+    </aside>
+  );
+}

--- a/apps/frontend/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
+++ b/apps/frontend/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
@@ -19,58 +19,55 @@ export function CollapsibleSidebar({
   headerExtra,
   children,
 }: CollapsibleSidebarProps) {
-  if (!isOpen) {
-    return (
-      <aside className={styles.sidebar} data-open='false'>
-        <div className={styles.collapsed}>
+  return (
+    <aside className={styles.sidebar} data-open={isOpen}>
+      <div className={styles.expanded}>
+        <div className={styles.header}>
+          <span className={styles.title}>{title}</span>
+          {headerExtra && (
+            <div className={styles.headerExtra}>{headerExtra}</div>
+          )}
           <Tooltip delay={0}>
             <Tooltip.Trigger>
               <Button
                 isIconOnly
                 size='sm'
                 variant='ghost'
-                aria-label='Expand sidebar'
+                aria-label='Collapse sidebar'
                 onPress={() => {
-                  onOpenChange(true);
+                  onOpenChange(false);
                 }}
               >
-                <PanelLeftOpen size={16} />
+                <PanelLeftClose size={16} />
               </Button>
             </Tooltip.Trigger>
             <Tooltip.Content>
-              <p>Expand sidebar</p>
+              <p>Collapse sidebar</p>
             </Tooltip.Content>
           </Tooltip>
         </div>
-      </aside>
-    );
-  }
-
-  return (
-    <aside className={styles.sidebar} data-open='true'>
-      <div className={styles.header}>
-        <span className={styles.title}>{title}</span>
-        {headerExtra && <div className={styles.headerExtra}>{headerExtra}</div>}
+        <div className={styles.content}>{children}</div>
+      </div>
+      <div className={styles.collapsed}>
         <Tooltip delay={0}>
           <Tooltip.Trigger>
             <Button
               isIconOnly
               size='sm'
               variant='ghost'
-              aria-label='Collapse sidebar'
+              aria-label='Expand sidebar'
               onPress={() => {
-                onOpenChange(false);
+                onOpenChange(true);
               }}
             >
-              <PanelLeftClose size={16} />
+              <PanelLeftOpen size={16} />
             </Button>
           </Tooltip.Trigger>
           <Tooltip.Content>
-            <p>Collapse sidebar</p>
+            <p>Expand sidebar</p>
           </Tooltip.Content>
         </Tooltip>
       </div>
-      <div className={styles.content}>{children}</div>
     </aside>
   );
 }

--- a/apps/frontend/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
+++ b/apps/frontend/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx
@@ -1,5 +1,5 @@
 import {Button, Tooltip} from '@heroui/react';
-import {PanelLeftClose, PanelLeftOpen} from 'lucide-react';
+import {SidebarClose, SidebarOpen} from 'lucide-react';
 import type {ReactNode} from 'react';
 
 import styles from './styles.module.css';
@@ -38,7 +38,7 @@ export function CollapsibleSidebar({
                   onOpenChange(false);
                 }}
               >
-                <PanelLeftClose size={16} />
+                <SidebarClose size={16} />
               </Button>
             </Tooltip.Trigger>
             <Tooltip.Content>
@@ -60,7 +60,7 @@ export function CollapsibleSidebar({
                 onOpenChange(true);
               }}
             >
-              <PanelLeftOpen size={16} />
+              <SidebarOpen size={16} />
             </Button>
           </Tooltip.Trigger>
           <Tooltip.Content>

--- a/apps/frontend/src/components/CollapsibleSidebar/index.ts
+++ b/apps/frontend/src/components/CollapsibleSidebar/index.ts
@@ -1,0 +1,1 @@
+export {CollapsibleSidebar} from './CollapsibleSidebar.js';

--- a/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
+++ b/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
@@ -5,17 +5,20 @@
   flex-shrink: 0;
   height: 100%;
   background-color: var(--color-background);
-  border-right: 1px solid var(--color-border);
   overflow: hidden;
-  transition: width 200ms ease;
+  transition:
+    width 200ms ease,
+    border-color 200ms ease;
 }
 
 .sidebar[data-open='true'] {
   width: 260px;
+  border-right: 1px solid var(--color-border);
 }
 
 .sidebar[data-open='false'] {
   width: 40px;
+  border-right: 1px solid transparent;
 }
 
 .expanded {

--- a/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
+++ b/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
@@ -12,13 +12,18 @@
 }
 
 .sidebar[data-open='true'] {
+  position: relative;
   width: 260px;
   border-right: 1px solid var(--color-border);
 }
 
 .sidebar[data-open='false'] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
   width: 40px;
-  border-right: 1px solid transparent;
+  z-index: 10;
 }
 
 .expanded {

--- a/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
+++ b/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
@@ -1,6 +1,7 @@
 .sidebar {
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
   height: 100%;
   border-right: 1px solid var(--color-border);
   overflow: hidden;

--- a/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
+++ b/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
@@ -5,7 +5,6 @@
   flex-shrink: 0;
   height: 100%;
   background-color: var(--color-background);
-  overflow: hidden;
   transition:
     width 200ms ease,
     border-color 200ms ease;
@@ -13,12 +12,14 @@
 
 .sidebar[data-open='true'] {
   width: 260px;
+  overflow: hidden;
   border-right: 1px solid var(--color-border);
 }
 
 .sidebar[data-open='false'] {
-  width: 40px;
-  border-right: 1px solid transparent;
+  width: 0;
+  overflow: visible;
+  border-right: none;
 }
 
 .expanded {
@@ -40,13 +41,10 @@
 }
 
 .collapsed {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   position: absolute;
-  inset: 0;
-  padding-top: 10px;
-  background-color: var(--color-background);
+  top: 8px;
+  left: 4px;
+  z-index: 10;
   transition: opacity 200ms ease;
 }
 

--- a/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
+++ b/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
@@ -1,4 +1,5 @@
 .sidebar {
+  position: relative;
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
@@ -14,6 +15,44 @@
 
 .sidebar[data-open='false'] {
   width: 40px;
+}
+
+.expanded {
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  inset: 0;
+  transition: opacity 200ms ease;
+}
+
+.sidebar[data-open='true'] .expanded {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.sidebar[data-open='false'] .expanded {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.collapsed {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: absolute;
+  inset: 0;
+  padding-top: 8px;
+  transition: opacity 200ms ease;
+}
+
+.sidebar[data-open='true'] .collapsed {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.sidebar[data-open='false'] .collapsed {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .header {
@@ -42,12 +81,4 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-}
-
-.collapsed {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding-top: 8px;
-  height: 100%;
 }

--- a/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
+++ b/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
@@ -1,0 +1,52 @@
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border-right: 1px solid var(--color-border);
+  overflow: hidden;
+  transition: width 200ms ease;
+}
+
+.sidebar[data-open='true'] {
+  width: 240px;
+}
+
+.sidebar[data-open='false'] {
+  width: 40px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px;
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.title {
+  flex: 1;
+  font-weight: 600;
+  font-size: 0.875rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.headerExtra {
+  flex-shrink: 0;
+}
+
+.content {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.collapsed {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 8px;
+  height: 100%;
+}

--- a/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
+++ b/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
@@ -4,7 +4,7 @@
   flex-direction: column;
   flex-shrink: 0;
   height: 100%;
-  background-color: var(--color-surface);
+  background-color: var(--color-background);
   border-right: 1px solid var(--color-border);
   overflow: hidden;
   transition: width 200ms ease;
@@ -43,7 +43,7 @@
   position: absolute;
   inset: 0;
   padding-top: 10px;
-  background-color: var(--color-surface);
+  background-color: var(--color-background);
   transition: opacity 200ms ease;
 }
 

--- a/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
+++ b/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
@@ -4,13 +4,14 @@
   flex-direction: column;
   flex-shrink: 0;
   height: 100%;
+  background-color: var(--color-surface);
   border-right: 1px solid var(--color-border);
   overflow: hidden;
   transition: width 200ms ease;
 }
 
 .sidebar[data-open='true'] {
-  width: 240px;
+  width: 260px;
 }
 
 .sidebar[data-open='false'] {
@@ -41,7 +42,8 @@
   align-items: center;
   position: absolute;
   inset: 0;
-  padding-top: 8px;
+  padding-top: 10px;
+  background-color: var(--color-surface);
   transition: opacity 200ms ease;
 }
 
@@ -59,15 +61,17 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 8px;
-  border-bottom: 1px solid var(--color-border);
+  padding: 12px 12px 12px 16px;
   flex-shrink: 0;
 }
 
 .title {
   flex: 1;
   font-weight: 600;
-  font-size: 0.875rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+  color: var(--color-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -81,4 +85,5 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  padding: 0 8px;
 }

--- a/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
+++ b/apps/frontend/src/components/CollapsibleSidebar/styles.module.css
@@ -12,18 +12,13 @@
 }
 
 .sidebar[data-open='true'] {
-  position: relative;
   width: 260px;
   border-right: 1px solid var(--color-border);
 }
 
 .sidebar[data-open='false'] {
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
   width: 40px;
-  z-index: 10;
+  border-right: 1px solid transparent;
 }
 
 .expanded {

--- a/apps/frontend/src/hooks/useInfiniteList.ts
+++ b/apps/frontend/src/hooks/useInfiniteList.ts
@@ -87,7 +87,7 @@ export function useInfiniteList<T>({
 
     setIsLoadingMore(true);
 
-    void (async () => {
+    async function fetchNextPage() {
       try {
         const page = await fetcher(nextLoadStartOffset.current, pageSize);
         setItems((prev) => [...prev, ...page.items]);
@@ -98,7 +98,9 @@ export function useInfiniteList<T>({
       } finally {
         setIsLoadingMore(false);
       }
-    })();
+    }
+
+    void fetchNextPage();
   }, [fetcher, pageSize, isLoadingMore, hasMore]);
 
   return {

--- a/apps/frontend/src/hooks/useInfiniteList.ts
+++ b/apps/frontend/src/hooks/useInfiniteList.ts
@@ -83,7 +83,7 @@ export function useInfiniteList<T>({
   const hasMore = items.length < total;
 
   const loadMore = useCallback(() => {
-    if (isLoadingMore || items.length >= total) {
+    if (isLoadingMore || !hasMore) {
       return;
     }
 
@@ -112,7 +112,7 @@ export function useInfiniteList<T>({
     }
 
     void fetchNextPage();
-  }, [fetcher, pageSize, isLoadingMore, items.length, total]);
+  }, [fetcher, pageSize, isLoadingMore, hasMore, items.length]);
 
   return {
     items,

--- a/apps/frontend/src/hooks/useInfiniteList.ts
+++ b/apps/frontend/src/hooks/useInfiniteList.ts
@@ -40,9 +40,14 @@ export function useInfiniteList<T>({
   const [refreshKey, setRefreshKey] = useState(0);
 
   const nextLoadStartOffset = useRef(0);
+  // Incremented on each refresh. loadMore captures this value before fetching
+  // and discards results if it has changed, preventing stale pages from being
+  // appended after a refresh has already replaced the list.
+  const refreshGenerationId = useRef(0);
 
   const refresh = useCallback(() => {
     nextLoadStartOffset.current = 0;
+    refreshGenerationId.current += 1;
     setRefreshKey((prev) => prev + 1);
   }, []);
 
@@ -86,17 +91,26 @@ export function useInfiniteList<T>({
     }
 
     setIsLoadingMore(true);
+    const currentRefreshGenerationId = refreshGenerationId.current;
 
     async function fetchNextPage() {
       try {
         const page = await fetcher(nextLoadStartOffset.current, pageSize);
+        if (currentRefreshGenerationId !== refreshGenerationId.current) {
+          return;
+        }
         setItems((prev) => [...prev, ...page.items]);
         setTotal(page.total);
         nextLoadStartOffset.current += page.items.length;
       } catch (e: unknown) {
+        if (currentRefreshGenerationId !== refreshGenerationId.current) {
+          return;
+        }
         setError(e instanceof Error ? e.message : 'Failed to load more');
       } finally {
-        setIsLoadingMore(false);
+        if (currentRefreshGenerationId === refreshGenerationId.current) {
+          setIsLoadingMore(false);
+        }
       }
     }
 

--- a/apps/frontend/src/hooks/useInfiniteList.ts
+++ b/apps/frontend/src/hooks/useInfiniteList.ts
@@ -1,7 +1,5 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 
-const PAGE_SIZE = 20;
-
 interface Page<T> {
   items: readonly T[];
   total: number;
@@ -9,9 +7,14 @@ interface Page<T> {
 
 type Fetcher<T> = (offset: number, limit: number) => Promise<Page<T>>;
 
+interface UseInfiniteListOptions<T> {
+  fetcher: Fetcher<T>;
+  pageSize: number;
+}
+
 interface UseInfiniteListReturn<T> {
   items: readonly T[];
-  isLoading: boolean;
+  isLoadingInitial: boolean;
   isLoadingMore: boolean;
   error: string | null;
   hasMore: boolean;
@@ -25,12 +28,13 @@ interface UseInfiniteListReturn<T> {
  * Manages initial load, load-more, and full refresh. The caller provides
  * a fetcher that returns a page of items plus the total count.
  */
-export function useInfiniteList<T>(
-  fetcher: Fetcher<T>,
-): UseInfiniteListReturn<T> {
+export function useInfiniteList<T>({
+  fetcher,
+  pageSize,
+}: UseInfiniteListOptions<T>): UseInfiniteListReturn<T> {
   const [items, setItems] = useState<readonly T[]>([]);
   const [total, setTotal] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingInitial, setIsLoadingInitial] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -47,10 +51,10 @@ export function useInfiniteList<T>(
     let cancelled = false;
 
     async function fetchFirstPage() {
-      setIsLoading(true);
+      setIsLoadingInitial(true);
       setError(null);
       try {
-        const page = await fetcher(0, PAGE_SIZE);
+        const page = await fetcher(0, pageSize);
         if (!cancelled) {
           setItems(page.items);
           setTotal(page.total);
@@ -62,7 +66,7 @@ export function useInfiniteList<T>(
         }
       } finally {
         if (!cancelled) {
-          setIsLoading(false);
+          setIsLoadingInitial(false);
         }
       }
     }
@@ -72,7 +76,7 @@ export function useInfiniteList<T>(
     return () => {
       cancelled = true;
     };
-  }, [fetcher, refreshKey]);
+  }, [fetcher, pageSize, refreshKey]);
 
   const hasMore = offsetRef.current < total;
 
@@ -85,7 +89,7 @@ export function useInfiniteList<T>(
 
     void (async () => {
       try {
-        const page = await fetcher(offsetRef.current, PAGE_SIZE);
+        const page = await fetcher(offsetRef.current, pageSize);
         setItems((prev) => [...prev, ...page.items]);
         setTotal(page.total);
         offsetRef.current += page.items.length;
@@ -95,7 +99,15 @@ export function useInfiniteList<T>(
         setIsLoadingMore(false);
       }
     })();
-  }, [fetcher, isLoadingMore, hasMore]);
+  }, [fetcher, pageSize, isLoadingMore, hasMore]);
 
-  return {items, isLoading, isLoadingMore, error, hasMore, loadMore, refresh};
+  return {
+    items,
+    isLoadingInitial,
+    isLoadingMore,
+    error,
+    hasMore,
+    loadMore,
+    refresh,
+  };
 }

--- a/apps/frontend/src/hooks/useInfiniteList.ts
+++ b/apps/frontend/src/hooks/useInfiniteList.ts
@@ -5,7 +5,7 @@ interface Page<T> {
   total: number;
 }
 
-type Fetcher<T> = (offset: number, limit: number) => Promise<Page<T>>;
+export type Fetcher<T> = (offset: number, limit: number) => Promise<Page<T>>;
 
 interface UseInfiniteListOptions<T> {
   fetcher: Fetcher<T>;

--- a/apps/frontend/src/hooks/useInfiniteList.ts
+++ b/apps/frontend/src/hooks/useInfiniteList.ts
@@ -39,10 +39,10 @@ export function useInfiniteList<T>({
   const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
 
-  const offsetRef = useRef(0);
+  const nextLoadStartOffset = useRef(0);
 
   const refresh = useCallback(() => {
-    offsetRef.current = 0;
+    nextLoadStartOffset.current = 0;
     setRefreshKey((prev) => prev + 1);
   }, []);
 
@@ -58,7 +58,7 @@ export function useInfiniteList<T>({
         if (!cancelled) {
           setItems(page.items);
           setTotal(page.total);
-          offsetRef.current = page.items.length;
+          nextLoadStartOffset.current = page.items.length;
         }
       } catch (e: unknown) {
         if (!cancelled) {
@@ -78,7 +78,7 @@ export function useInfiniteList<T>({
     };
   }, [fetcher, pageSize, refreshKey]);
 
-  const hasMore = offsetRef.current < total;
+  const hasMore = nextLoadStartOffset.current < total;
 
   const loadMore = useCallback(() => {
     if (isLoadingMore || !hasMore) {
@@ -89,10 +89,10 @@ export function useInfiniteList<T>({
 
     void (async () => {
       try {
-        const page = await fetcher(offsetRef.current, pageSize);
+        const page = await fetcher(nextLoadStartOffset.current, pageSize);
         setItems((prev) => [...prev, ...page.items]);
         setTotal(page.total);
-        offsetRef.current += page.items.length;
+        nextLoadStartOffset.current += page.items.length;
       } catch (e: unknown) {
         setError(e instanceof Error ? e.message : 'Failed to load more');
       } finally {

--- a/apps/frontend/src/hooks/useInfiniteList.ts
+++ b/apps/frontend/src/hooks/useInfiniteList.ts
@@ -1,0 +1,101 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+const PAGE_SIZE = 20;
+
+interface Page<T> {
+  items: readonly T[];
+  total: number;
+}
+
+type Fetcher<T> = (offset: number, limit: number) => Promise<Page<T>>;
+
+interface UseInfiniteListReturn<T> {
+  items: readonly T[];
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  error: string | null;
+  hasMore: boolean;
+  loadMore: () => void;
+  refresh: () => void;
+}
+
+/**
+ * Generic infinite-list hook with offset/limit pagination.
+ *
+ * Manages initial load, load-more, and full refresh. The caller provides
+ * a fetcher that returns a page of items plus the total count.
+ */
+export function useInfiniteList<T>(
+  fetcher: Fetcher<T>,
+): UseInfiniteListReturn<T> {
+  const [items, setItems] = useState<readonly T[]>([]);
+  const [total, setTotal] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const offsetRef = useRef(0);
+
+  const refresh = useCallback(() => {
+    offsetRef.current = 0;
+    setRefreshKey((prev) => prev + 1);
+  }, []);
+
+  // Initial load / refresh
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchFirstPage() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const page = await fetcher(0, PAGE_SIZE);
+        if (!cancelled) {
+          setItems(page.items);
+          setTotal(page.total);
+          offsetRef.current = page.items.length;
+        }
+      } catch (e: unknown) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Failed to load');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void fetchFirstPage();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fetcher, refreshKey]);
+
+  const hasMore = offsetRef.current < total;
+
+  const loadMore = useCallback(() => {
+    if (isLoadingMore || !hasMore) {
+      return;
+    }
+
+    setIsLoadingMore(true);
+
+    void (async () => {
+      try {
+        const page = await fetcher(offsetRef.current, PAGE_SIZE);
+        setItems((prev) => [...prev, ...page.items]);
+        setTotal(page.total);
+        offsetRef.current += page.items.length;
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : 'Failed to load more');
+      } finally {
+        setIsLoadingMore(false);
+      }
+    })();
+  }, [fetcher, isLoadingMore, hasMore]);
+
+  return {items, isLoading, isLoadingMore, error, hasMore, loadMore, refresh};
+}

--- a/apps/frontend/src/hooks/useInfiniteList.ts
+++ b/apps/frontend/src/hooks/useInfiniteList.ts
@@ -39,14 +39,12 @@ export function useInfiniteList<T>({
   const [error, setError] = useState<string | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
 
-  const nextLoadStartOffset = useRef(0);
   // Incremented on each refresh. loadMore captures this value before fetching
   // and discards results if it has changed, preventing stale pages from being
   // appended after a refresh has already replaced the list.
   const refreshGenerationId = useRef(0);
 
   const refresh = useCallback(() => {
-    nextLoadStartOffset.current = 0;
     refreshGenerationId.current += 1;
     setRefreshKey((prev) => prev + 1);
   }, []);
@@ -63,7 +61,6 @@ export function useInfiniteList<T>({
         if (!cancelled) {
           setItems(page.items);
           setTotal(page.total);
-          nextLoadStartOffset.current = page.items.length;
         }
       } catch (e: unknown) {
         if (!cancelled) {
@@ -83,25 +80,25 @@ export function useInfiniteList<T>({
     };
   }, [fetcher, pageSize, refreshKey]);
 
-  const hasMore = nextLoadStartOffset.current < total;
+  const hasMore = items.length < total;
 
   const loadMore = useCallback(() => {
-    if (isLoadingMore || !hasMore) {
+    if (isLoadingMore || items.length >= total) {
       return;
     }
 
     setIsLoadingMore(true);
     const currentRefreshGenerationId = refreshGenerationId.current;
+    const offset = items.length;
 
     async function fetchNextPage() {
       try {
-        const page = await fetcher(nextLoadStartOffset.current, pageSize);
+        const page = await fetcher(offset, pageSize);
         if (currentRefreshGenerationId !== refreshGenerationId.current) {
           return;
         }
         setItems((prev) => [...prev, ...page.items]);
         setTotal(page.total);
-        nextLoadStartOffset.current += page.items.length;
       } catch (e: unknown) {
         if (currentRefreshGenerationId !== refreshGenerationId.current) {
           return;
@@ -115,7 +112,7 @@ export function useInfiniteList<T>({
     }
 
     void fetchNextPage();
-  }, [fetcher, pageSize, isLoadingMore, hasMore]);
+  }, [fetcher, pageSize, isLoadingMore, items.length, total]);
 
   return {
     items,

--- a/apps/frontend/src/hooks/useInfiniteScroll.ts
+++ b/apps/frontend/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,88 @@
+import type {RefObject} from 'react';
+import {useEffect, useRef} from 'react';
+
+import type {Fetcher} from './useInfiniteList.js';
+import {useInfiniteList} from './useInfiniteList.js';
+
+interface UseInfiniteScrollOptions<T> {
+  fetcher: Fetcher<T>;
+  pageSize: number;
+}
+
+interface UseInfiniteScrollReturn<T> {
+  items: readonly T[];
+  isLoadingInitial: boolean;
+  isLoadingMore: boolean;
+  error: string | null;
+  hasMore: boolean;
+  sentinelRef: RefObject<HTMLDivElement | null>;
+  refresh: () => void;
+}
+
+/**
+ * Combines {@link useInfiniteList} with an IntersectionObserver sentinel
+ * for automatic infinite scrolling.
+ *
+ * @example
+ * ```tsx
+ * const {items, isLoadingMore, hasMore, sentinelRef} = useInfiniteScroll({
+ *   fetcher: (offset, limit) => fetchItems(offset, limit),
+ *   pageSize: 20,
+ * });
+ *
+ * return (
+ *   <ul>
+ *     {items.map((item) => <li key={item.id}>{item.name}</li>)}
+ *     {hasMore && <div ref={sentinelRef}>{isLoadingMore && <Spinner />}</div>}
+ *   </ul>
+ * );
+ * ```
+ */
+export function useInfiniteScroll<T>({
+  fetcher,
+  pageSize,
+}: UseInfiniteScrollOptions<T>): UseInfiniteScrollReturn<T> {
+  const {
+    items,
+    isLoadingInitial,
+    isLoadingMore,
+    error,
+    hasMore,
+    loadMore,
+    refresh,
+  } = useInfiniteList<T>({fetcher, pageSize});
+
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel || !hasMore) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          loadMore();
+        }
+      },
+      {threshold: 0},
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasMore, loadMore]);
+
+  return {
+    items,
+    isLoadingInitial,
+    isLoadingMore,
+    error,
+    hasMore,
+    sentinelRef,
+    refresh,
+  };
+}

--- a/apps/frontend/src/pages/chat/ChatPageView.tsx
+++ b/apps/frontend/src/pages/chat/ChatPageView.tsx
@@ -6,6 +6,7 @@ import {ChatAlert} from './components/ChatAlert/index.js';
 import {ChatInput} from './components/ChatInput/index.js';
 import {InfoBar} from './components/InfoBar/index.js';
 import {SessionSetup} from './components/SessionSetup/index.js';
+import {SessionSidebar} from './components/SessionSidebar/index.js';
 import {
   type ChatEventBus,
   type ChatMessage,
@@ -54,50 +55,59 @@ export function ChatPageView({
   onDismissMaxRoundsReached,
 }: ChatPageViewProps) {
   return (
-    <div className={styles.page}>
-      {isReconnecting && (
-        <ChatAlert
-          status='warning'
-          title='Reconnecting'
-          message='Connection lost. Attempting to reconnect...'
-        />
-      )}
-      {error && (
-        <ChatAlert
-          status='danger'
-          title='Error'
-          message={error}
-          onDismiss={onDismissError}
-        />
-      )}
-      {maxRoundsReached && (
-        <ChatAlert
-          status='warning'
-          title='Tool limit reached'
-          message='The assistant reached the maximum number of tool execution rounds. You can increase this limit in Settings > Agent.'
-          onDismiss={onDismissMaxRoundsReached}
-        />
-      )}
-      <TitleBarView
-        title={title}
-        onNewSession={onNewSession}
-        newSessionDisabled={newSessionDisabled}
-        vscodeUrl={vscodeUrl}
-      />
-      <ScrollShadow className={styles.messageListWrapper} ref={scrollRef}>
-        {isEmpty && !sessionId && (
-          <div className={styles.emptyState}>
-            <SessionSetup />
-          </div>
-        )}
-        <StreamingMessageDisplay
-          eventBus={eventBus}
-          sessionId={sessionId}
-          onMessagesChange={onMessagesChange}
-        />
-      </ScrollShadow>
-      {sessionId && <InfoBar />}
-      <ChatInput isStreaming={isStreaming} onSend={onSend} onStop={onStop} />
+    <div className={styles.wrapper}>
+      <SessionSidebar />
+      <div className={styles.main}>
+        <div className={styles.page}>
+          {isReconnecting && (
+            <ChatAlert
+              status='warning'
+              title='Reconnecting'
+              message='Connection lost. Attempting to reconnect...'
+            />
+          )}
+          {error && (
+            <ChatAlert
+              status='danger'
+              title='Error'
+              message={error}
+              onDismiss={onDismissError}
+            />
+          )}
+          {maxRoundsReached && (
+            <ChatAlert
+              status='warning'
+              title='Tool limit reached'
+              message='The assistant reached the maximum number of tool execution rounds. You can increase this limit in Settings > Agent.'
+              onDismiss={onDismissMaxRoundsReached}
+            />
+          )}
+          <TitleBarView
+            title={title}
+            onNewSession={onNewSession}
+            newSessionDisabled={newSessionDisabled}
+            vscodeUrl={vscodeUrl}
+          />
+          <ScrollShadow className={styles.messageListWrapper} ref={scrollRef}>
+            {isEmpty && !sessionId && (
+              <div className={styles.emptyState}>
+                <SessionSetup />
+              </div>
+            )}
+            <StreamingMessageDisplay
+              eventBus={eventBus}
+              sessionId={sessionId}
+              onMessagesChange={onMessagesChange}
+            />
+          </ScrollShadow>
+          {sessionId && <InfoBar />}
+          <ChatInput
+            isStreaming={isStreaming}
+            onSend={onSend}
+            onStop={onStop}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
@@ -23,7 +23,6 @@ export function SessionSidebar() {
     refresh,
   } = useSessionList({
     eventBus,
-    sessionId,
   });
   const navigate = useNavigate();
 

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
@@ -15,7 +15,7 @@ export function SessionSidebar() {
   const {sessionId} = useSessionId();
   const {
     sessions,
-    isLoading,
+    isLoadingInitial,
     isLoadingMore,
     error,
     hasMore,
@@ -60,7 +60,7 @@ export function SessionSidebar() {
       isOpen={isOpen}
       onOpenChange={setIsOpen}
       sessions={sessions}
-      isLoading={isLoading}
+      isLoadingInitial={isLoadingInitial}
       isLoadingMore={isLoadingMore}
       error={error}
       hasMore={hasMore}

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
@@ -30,10 +30,11 @@ export function SessionSidebar() {
   const handleSelectSession = useCallback(
     (id: string) => {
       if (id !== sessionId) {
+        eventBus.emit('reset');
         void navigate(`/chat/${id}`);
       }
     },
-    [navigate, sessionId],
+    [navigate, sessionId, eventBus],
   );
 
   const handleDeleteSession = useCallback(

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
@@ -19,7 +19,7 @@ export function SessionSidebar() {
     isLoadingMore,
     error,
     hasMore,
-    loadMore,
+    sentinelRef,
     refresh,
   } = useSessionList({
     eventBus,
@@ -64,7 +64,7 @@ export function SessionSidebar() {
       isLoadingMore={isLoadingMore}
       error={error}
       hasMore={hasMore}
-      onLoadMore={loadMore}
+      sentinelRef={sentinelRef}
       currentSessionId={sessionId}
       onSelectSession={handleSelectSession}
       onDeleteSession={handleDeleteSession}

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
@@ -13,7 +13,15 @@ export function SessionSidebar() {
   const [isOpen, setIsOpen] = useState(true);
   const eventBus = useChatEventBus();
   const {sessionId} = useSessionId();
-  const {sessions, isLoading, error, refresh} = useSessionList({
+  const {
+    sessions,
+    isLoading,
+    isLoadingMore,
+    error,
+    hasMore,
+    loadMore,
+    refresh,
+  } = useSessionList({
     eventBus,
     sessionId,
   });
@@ -52,7 +60,10 @@ export function SessionSidebar() {
       onOpenChange={setIsOpen}
       sessions={sessions}
       isLoading={isLoading}
+      isLoadingMore={isLoadingMore}
       error={error}
+      hasMore={hasMore}
+      onLoadMore={loadMore}
       currentSessionId={sessionId}
       onSelectSession={handleSelectSession}
       onDeleteSession={handleDeleteSession}

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
@@ -3,13 +3,15 @@ import {useNavigate} from 'react-router';
 
 import {deleteSession} from '@/api/chat/index.js';
 
+import {useChatEventBus} from '../../hooks/useChatEventBus.js';
 import {useSessionId} from '../../hooks/useSessionId.js';
 import {useSessionList} from './hooks/useSessionList.js';
 import {SessionSidebarView} from './SessionSidebarView.js';
 
 export function SessionSidebar() {
   const [isOpen, setIsOpen] = useState(true);
-  const {sessions, refresh} = useSessionList();
+  const eventBus = useChatEventBus();
+  const {sessions, refresh} = useSessionList({eventBus});
   const {sessionId} = useSessionId();
   const navigate = useNavigate();
 

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
@@ -12,7 +12,10 @@ import {SessionSidebarView} from './SessionSidebarView.js';
 export function SessionSidebar() {
   const [isOpen, setIsOpen] = useState(true);
   const eventBus = useChatEventBus();
-  const {sessions, isLoading, error, refresh} = useSessionList({eventBus});
+  const {sessions, isLoading, error, refresh} = useSessionList({
+    eventBus,
+    sessionId,
+  });
   const {sessionId} = useSessionId();
   const navigate = useNavigate();
 

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
@@ -29,7 +29,8 @@ export function SessionSidebar() {
     async (id: string) => {
       try {
         await deleteSession(id);
-      } catch {
+      } catch (e: unknown) {
+        console.error('Failed to delete session:', e);
         toast.danger('Failed to delete session');
         return;
       }

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
@@ -11,7 +11,7 @@ import {SessionSidebarView} from './SessionSidebarView.js';
 export function SessionSidebar() {
   const [isOpen, setIsOpen] = useState(true);
   const eventBus = useChatEventBus();
-  const {sessions, refresh} = useSessionList({eventBus});
+  const {sessions, isLoading, error, refresh} = useSessionList({eventBus});
   const {sessionId} = useSessionId();
   const navigate = useNavigate();
 
@@ -26,7 +26,11 @@ export function SessionSidebar() {
 
   const handleDeleteSession = useCallback(
     async (id: string) => {
-      await deleteSession(id);
+      try {
+        await deleteSession(id);
+      } catch {
+        return;
+      }
       refresh();
       if (id === sessionId) {
         void navigate('/chat', {replace: true});
@@ -40,6 +44,8 @@ export function SessionSidebar() {
       isOpen={isOpen}
       onOpenChange={setIsOpen}
       sessions={sessions}
+      isLoading={isLoading}
+      error={error}
       currentSessionId={sessionId}
       onSelectSession={handleSelectSession}
       onDeleteSession={handleDeleteSession}

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
@@ -23,6 +23,7 @@ export function SessionSidebar() {
     refresh,
   } = useSessionList({
     eventBus,
+    sessionId,
   });
   const navigate = useNavigate();
 

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
@@ -1,3 +1,4 @@
+import {toast} from '@heroui/react';
 import {useCallback, useState} from 'react';
 import {useNavigate} from 'react-router';
 
@@ -29,8 +30,10 @@ export function SessionSidebar() {
       try {
         await deleteSession(id);
       } catch {
+        toast.danger('Failed to delete session');
         return;
       }
+      toast.success('Session deleted');
       refresh();
       if (id === sessionId) {
         void navigate('/chat', {replace: true});

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
@@ -1,0 +1,46 @@
+import {useCallback, useState} from 'react';
+import {useNavigate} from 'react-router';
+
+import {deleteSession} from '@/api/chat/index.js';
+
+import {useSessionId} from '../../hooks/useSessionId.js';
+import {useSessionList} from './hooks/useSessionList.js';
+import {SessionSidebarView} from './SessionSidebarView.js';
+
+export function SessionSidebar() {
+  const [isOpen, setIsOpen] = useState(true);
+  const {sessions, refresh} = useSessionList();
+  const {sessionId} = useSessionId();
+  const navigate = useNavigate();
+
+  const handleSelectSession = useCallback(
+    (id: string) => {
+      if (id !== sessionId) {
+        void navigate(`/chat/${id}`);
+      }
+    },
+    [navigate, sessionId],
+  );
+
+  const handleDeleteSession = useCallback(
+    async (id: string) => {
+      await deleteSession(id);
+      refresh();
+      if (id === sessionId) {
+        void navigate('/chat', {replace: true});
+      }
+    },
+    [refresh, sessionId, navigate],
+  );
+
+  return (
+    <SessionSidebarView
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+      sessions={sessions}
+      currentSessionId={sessionId}
+      onSelectSession={handleSelectSession}
+      onDeleteSession={handleDeleteSession}
+    />
+  );
+}

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
@@ -12,11 +12,11 @@ import {SessionSidebarView} from './SessionSidebarView.js';
 export function SessionSidebar() {
   const [isOpen, setIsOpen] = useState(true);
   const eventBus = useChatEventBus();
+  const {sessionId} = useSessionId();
   const {sessions, isLoading, error, refresh} = useSessionList({
     eventBus,
     sessionId,
   });
-  const {sessionId} = useSessionId();
   const navigate = useNavigate();
 
   const handleSelectSession = useCallback(

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx
@@ -3,6 +3,7 @@ import {useCallback, useState} from 'react';
 import {useNavigate} from 'react-router';
 
 import {deleteSession} from '@/api/chat/index.js';
+import {ROUTES} from '@/routes.js';
 
 import {useChatEventBus} from '../../hooks/useChatEventBus.js';
 import {useSessionId} from '../../hooks/useSessionId.js';
@@ -31,7 +32,7 @@ export function SessionSidebar() {
     (id: string) => {
       if (id !== sessionId) {
         eventBus.emit('reset');
-        void navigate(`/chat/${id}`);
+        void navigate(`${ROUTES.chat()}/${id}`);
       }
     },
     [navigate, sessionId, eventBus],
@@ -49,7 +50,7 @@ export function SessionSidebar() {
       toast.success('Session deleted');
       refresh();
       if (id === sessionId) {
-        void navigate('/chat', {replace: true});
+        void navigate(ROUTES.chat(), {replace: true});
       }
     },
     [refresh, sessionId, navigate],

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
@@ -12,7 +12,7 @@ interface SessionSidebarViewProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   sessions: readonly SessionMetadata[];
-  isLoading: boolean;
+  isLoadingInitial: boolean;
   isLoadingMore: boolean;
   error: string | null;
   hasMore: boolean;
@@ -26,7 +26,7 @@ export function SessionSidebarView({
   isOpen,
   onOpenChange,
   sessions,
-  isLoading,
+  isLoadingInitial,
   isLoadingMore,
   error,
   hasMore,
@@ -68,7 +68,7 @@ export function SessionSidebarView({
       onOpenChange={onOpenChange}
       title='Sessions'
     >
-      {isLoading ? (
+      {isLoadingInitial ? (
         <div className={styles.centered}>
           <Spinner size='sm' />
         </div>

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
@@ -1,7 +1,7 @@
 import type {Selection} from '@heroui/react';
 import {ListBox, Spinner} from '@heroui/react';
 import type {SessionMetadata} from '@omnicraft/api-schema';
-import {useEffect, useRef} from 'react';
+import type {RefObject} from 'react';
 
 import {CollapsibleSidebar} from '@/components/CollapsibleSidebar/index.js';
 
@@ -16,7 +16,7 @@ interface SessionSidebarViewProps {
   isLoadingMore: boolean;
   error: string | null;
   hasMore: boolean;
-  onLoadMore: () => void;
+  sentinelRef: RefObject<HTMLDivElement | null>;
   currentSessionId: string | null;
   onSelectSession: (id: string) => void;
   onDeleteSession: (id: string) => Promise<void>;
@@ -30,37 +30,13 @@ export function SessionSidebarView({
   isLoadingMore,
   error,
   hasMore,
-  onLoadMore,
+  sentinelRef,
   currentSessionId,
   onSelectSession,
   onDeleteSession,
 }: SessionSidebarViewProps) {
   const selectedKeys =
     currentSessionId !== null ? new Set([currentSessionId]) : new Set<string>();
-
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel || !hasMore) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting) {
-          onLoadMore();
-        }
-      },
-      {threshold: 0},
-    );
-
-    observer.observe(sentinel);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [hasMore, onLoadMore]);
 
   return (
     <CollapsibleSidebar

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
@@ -1,6 +1,7 @@
+import type {Selection} from '@heroui/react';
 import {ListBox, Spinner} from '@heroui/react';
 import type {SessionMetadata} from '@omnicraft/api-schema';
-import {type Key, useEffect, useRef} from 'react';
+import {useEffect, useRef} from 'react';
 
 import {CollapsibleSidebar} from '@/components/CollapsibleSidebar/index.js';
 
@@ -87,8 +88,14 @@ export function SessionSidebarView({
             items={sessions}
             selectedKeys={selectedKeys}
             selectionMode='single'
-            onAction={(key: Key) => {
-              onSelectSession(String(key));
+            onSelectionChange={(keys: Selection) => {
+              if (keys === 'all') {
+                return;
+              }
+              const selected = [...keys][0];
+              if (typeof selected === 'string') {
+                onSelectSession(selected);
+              }
             }}
           >
             {(session) => (

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
@@ -35,65 +35,113 @@ export function SessionSidebarView({
   onSelectSession,
   onDeleteSession,
 }: SessionSidebarViewProps) {
-  const selectedKeys =
-    currentSessionId !== null ? new Set([currentSessionId]) : new Set<string>();
-
   return (
     <CollapsibleSidebar
       isOpen={isOpen}
       onOpenChange={onOpenChange}
       title='Sessions'
     >
-      {isLoadingInitial ? (
-        <div className={styles.centered}>
-          <Spinner size='sm' />
-        </div>
-      ) : error !== null ? (
-        <div className={styles.centered}>
-          <p className={styles.errorText}>Failed to load sessions</p>
-        </div>
-      ) : sessions.length === 0 ? (
-        <div className={styles.centered}>
-          <p className={styles.emptyText}>No sessions yet</p>
-        </div>
-      ) : (
-        <>
-          <ListBox
-            aria-label='Session list'
-            className={styles.listBox}
-            items={sessions}
-            selectedKeys={selectedKeys}
-            selectionMode='single'
-            onSelectionChange={(keys: Selection) => {
-              if (keys === 'all') {
-                return;
-              }
-              const selected = [...keys][0];
-              if (typeof selected === 'string') {
-                onSelectSession(selected);
-              }
-            }}
-          >
-            {(session) => (
-              <ListBox.Item
-                key={session.id}
-                id={session.id}
-                textValue={session.title}
-              >
-                <SessionItem
-                  title={session.title}
-                  onDelete={async () => onDeleteSession(session.id)}
-                />
-              </ListBox.Item>
-            )}
-          </ListBox>
-          {hasMore && (
-            <div ref={sentinelRef} className={styles.centered}>
-              {isLoadingMore && <Spinner size='sm' />}
-            </div>
-          )}
-        </>
-      )}
+      <SessionSidebarContent
+        sessions={sessions}
+        isLoadingInitial={isLoadingInitial}
+        isLoadingMore={isLoadingMore}
+        error={error}
+        hasMore={hasMore}
+        sentinelRef={sentinelRef}
+        currentSessionId={currentSessionId}
+        onSelectSession={onSelectSession}
+        onDeleteSession={onDeleteSession}
+      />
     </CollapsibleSidebar>
+  );
+}
+
+interface SessionSidebarContentProps {
+  sessions: readonly SessionMetadata[];
+  isLoadingInitial: boolean;
+  isLoadingMore: boolean;
+  error: string | null;
+  hasMore: boolean;
+  sentinelRef: RefObject<HTMLDivElement | null>;
+  currentSessionId: string | null;
+  onSelectSession: (id: string) => void;
+  onDeleteSession: (id: string) => Promise<void>;
+}
+
+function SessionSidebarContent({
+  sessions,
+  isLoadingInitial,
+  isLoadingMore,
+  error,
+  hasMore,
+  sentinelRef,
+  currentSessionId,
+  onSelectSession,
+  onDeleteSession,
+}: SessionSidebarContentProps) {
+  if (isLoadingInitial) {
+    return (
+      <div className={styles.centered}>
+        <Spinner size='sm' />
+      </div>
+    );
+  }
+
+  if (error !== null) {
+    return (
+      <div className={styles.centered}>
+        <p className={styles.errorText}>Failed to load sessions</p>
+      </div>
+    );
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <div className={styles.centered}>
+        <p className={styles.emptyText}>No sessions yet</p>
+      </div>
+    );
+  }
+
+  const selectedKeys =
+    currentSessionId !== null ? new Set([currentSessionId]) : new Set<string>();
+
+  return (
+    <>
+      <ListBox
+        aria-label='Session list'
+        className={styles.listBox}
+        items={sessions}
+        selectedKeys={selectedKeys}
+        selectionMode='single'
+        onSelectionChange={(keys: Selection) => {
+          if (keys === 'all') {
+            return;
+          }
+          const selected = [...keys][0];
+          if (typeof selected === 'string') {
+            onSelectSession(selected);
+          }
+        }}
+      >
+        {(session) => (
+          <ListBox.Item
+            key={session.id}
+            id={session.id}
+            textValue={session.title}
+          >
+            <SessionItem
+              title={session.title}
+              onDelete={async () => onDeleteSession(session.id)}
+            />
+          </ListBox.Item>
+        )}
+      </ListBox>
+      {hasMore && (
+        <div ref={sentinelRef} className={styles.centered}>
+          {isLoadingMore && <Spinner size='sm' />}
+        </div>
+      )}
+    </>
   );
 }

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
@@ -1,6 +1,6 @@
 import {ListBox, Spinner} from '@heroui/react';
 import type {SessionMetadata} from '@omnicraft/api-schema';
-import type {Key} from 'react';
+import {type Key, useEffect, useRef} from 'react';
 
 import {CollapsibleSidebar} from '@/components/CollapsibleSidebar/index.js';
 
@@ -12,7 +12,10 @@ interface SessionSidebarViewProps {
   onOpenChange: (open: boolean) => void;
   sessions: readonly SessionMetadata[];
   isLoading: boolean;
+  isLoadingMore: boolean;
   error: string | null;
+  hasMore: boolean;
+  onLoadMore: () => void;
   currentSessionId: string | null;
   onSelectSession: (id: string) => void;
   onDeleteSession: (id: string) => Promise<void>;
@@ -23,13 +26,40 @@ export function SessionSidebarView({
   onOpenChange,
   sessions,
   isLoading,
+  isLoadingMore,
   error,
+  hasMore,
+  onLoadMore,
   currentSessionId,
   onSelectSession,
   onDeleteSession,
 }: SessionSidebarViewProps) {
   const selectedKeys =
     currentSessionId !== null ? new Set([currentSessionId]) : new Set<string>();
+
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel || !hasMore) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          onLoadMore();
+        }
+      },
+      {threshold: 0},
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasMore, onLoadMore]);
 
   return (
     <CollapsibleSidebar
@@ -50,29 +80,36 @@ export function SessionSidebarView({
           <p className={styles.emptyText}>No sessions yet</p>
         </div>
       ) : (
-        <ListBox
-          aria-label='Session list'
-          className={styles.listBox}
-          items={sessions}
-          selectedKeys={selectedKeys}
-          selectionMode='single'
-          onAction={(key: Key) => {
-            onSelectSession(String(key));
-          }}
-        >
-          {(session) => (
-            <ListBox.Item
-              key={session.id}
-              id={session.id}
-              textValue={session.title}
-            >
-              <SessionItem
-                title={session.title}
-                onDelete={async () => onDeleteSession(session.id)}
-              />
-            </ListBox.Item>
+        <>
+          <ListBox
+            aria-label='Session list'
+            className={styles.listBox}
+            items={sessions}
+            selectedKeys={selectedKeys}
+            selectionMode='single'
+            onAction={(key: Key) => {
+              onSelectSession(String(key));
+            }}
+          >
+            {(session) => (
+              <ListBox.Item
+                key={session.id}
+                id={session.id}
+                textValue={session.title}
+              >
+                <SessionItem
+                  title={session.title}
+                  onDelete={async () => onDeleteSession(session.id)}
+                />
+              </ListBox.Item>
+            )}
+          </ListBox>
+          {hasMore && (
+            <div ref={sentinelRef} className={styles.centered}>
+              {isLoadingMore && <Spinner size='sm' />}
+            </div>
           )}
-        </ListBox>
+        </>
       )}
     </CollapsibleSidebar>
   );

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
@@ -1,4 +1,4 @@
-import {ListBox} from '@heroui/react';
+import {ListBox, Spinner} from '@heroui/react';
 import type {SessionMetadata} from '@omnicraft/api-schema';
 import type {Key} from 'react';
 
@@ -11,6 +11,8 @@ interface SessionSidebarViewProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   sessions: readonly SessionMetadata[];
+  isLoading: boolean;
+  error: string | null;
   currentSessionId: string | null;
   onSelectSession: (id: string) => void;
   onDeleteSession: (id: string) => Promise<void>;
@@ -20,6 +22,8 @@ export function SessionSidebarView({
   isOpen,
   onOpenChange,
   sessions,
+  isLoading,
+  error,
   currentSessionId,
   onSelectSession,
   onDeleteSession,
@@ -33,29 +37,43 @@ export function SessionSidebarView({
       onOpenChange={onOpenChange}
       title='Sessions'
     >
-      <ListBox
-        aria-label='Session list'
-        className={styles.listBox}
-        items={sessions}
-        selectedKeys={selectedKeys}
-        selectionMode='single'
-        onAction={(key: Key) => {
-          onSelectSession(String(key));
-        }}
-      >
-        {(session) => (
-          <ListBox.Item
-            key={session.id}
-            id={session.id}
-            textValue={session.title}
-          >
-            <SessionItem
-              title={session.title}
-              onDelete={async () => onDeleteSession(session.id)}
-            />
-          </ListBox.Item>
-        )}
-      </ListBox>
+      {isLoading ? (
+        <div className={styles.centered}>
+          <Spinner size='sm' />
+        </div>
+      ) : error !== null ? (
+        <div className={styles.centered}>
+          <p className={styles.errorText}>Failed to load sessions</p>
+        </div>
+      ) : sessions.length === 0 ? (
+        <div className={styles.centered}>
+          <p className={styles.emptyText}>No sessions yet</p>
+        </div>
+      ) : (
+        <ListBox
+          aria-label='Session list'
+          className={styles.listBox}
+          items={sessions}
+          selectedKeys={selectedKeys}
+          selectionMode='single'
+          onAction={(key: Key) => {
+            onSelectSession(String(key));
+          }}
+        >
+          {(session) => (
+            <ListBox.Item
+              key={session.id}
+              id={session.id}
+              textValue={session.title}
+            >
+              <SessionItem
+                title={session.title}
+                onDelete={async () => onDeleteSession(session.id)}
+              />
+            </ListBox.Item>
+          )}
+        </ListBox>
+      )}
     </CollapsibleSidebar>
   );
 }

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
@@ -1,0 +1,61 @@
+import {ListBox} from '@heroui/react';
+import type {SessionMetadata} from '@omnicraft/api-schema';
+import type {Key} from 'react';
+
+import {CollapsibleSidebar} from '@/components/CollapsibleSidebar/index.js';
+
+import {SessionItem} from './components/SessionItem/index.js';
+import styles from './styles.module.css';
+
+interface SessionSidebarViewProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  sessions: readonly SessionMetadata[];
+  currentSessionId: string | null;
+  onSelectSession: (id: string) => void;
+  onDeleteSession: (id: string) => Promise<void>;
+}
+
+export function SessionSidebarView({
+  isOpen,
+  onOpenChange,
+  sessions,
+  currentSessionId,
+  onSelectSession,
+  onDeleteSession,
+}: SessionSidebarViewProps) {
+  const selectedKeys =
+    currentSessionId !== null ? new Set([currentSessionId]) : new Set<string>();
+
+  return (
+    <CollapsibleSidebar
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      title='Sessions'
+    >
+      <ListBox
+        aria-label='Session list'
+        className={styles.listBox}
+        items={sessions}
+        selectedKeys={selectedKeys}
+        selectionMode='single'
+        onAction={(key: Key) => {
+          onSelectSession(String(key));
+        }}
+      >
+        {(session) => (
+          <ListBox.Item
+            key={session.id}
+            id={session.id}
+            textValue={session.title}
+          >
+            <SessionItem
+              title={session.title}
+              onDelete={async () => onDeleteSession(session.id)}
+            />
+          </ListBox.Item>
+        )}
+      </ListBox>
+    </CollapsibleSidebar>
+  );
+}

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx
@@ -1,7 +1,8 @@
 import type {Selection} from '@heroui/react';
 import {ListBox, Spinner} from '@heroui/react';
 import type {SessionMetadata} from '@omnicraft/api-schema';
-import type {RefObject} from 'react';
+import type {ReactNode, RefObject} from 'react';
+import {useMemo} from 'react';
 
 import {CollapsibleSidebar} from '@/components/CollapsibleSidebar/index.js';
 
@@ -35,113 +36,93 @@ export function SessionSidebarView({
   onSelectSession,
   onDeleteSession,
 }: SessionSidebarViewProps) {
+  const content = useMemo((): ReactNode => {
+    if (isLoadingInitial) {
+      return (
+        <div className={styles.centered}>
+          <Spinner size='sm' />
+        </div>
+      );
+    }
+
+    if (error !== null) {
+      return (
+        <div className={styles.centered}>
+          <p className={styles.errorText}>Failed to load sessions</p>
+        </div>
+      );
+    }
+
+    if (sessions.length === 0) {
+      return (
+        <div className={styles.centered}>
+          <p className={styles.emptyText}>No sessions yet</p>
+        </div>
+      );
+    }
+
+    const selectedKeys =
+      currentSessionId !== null
+        ? new Set([currentSessionId])
+        : new Set<string>();
+
+    return (
+      <>
+        <ListBox
+          aria-label='Session list'
+          className={styles.listBox}
+          items={sessions}
+          selectedKeys={selectedKeys}
+          selectionMode='single'
+          onSelectionChange={(keys: Selection) => {
+            if (keys === 'all') {
+              return;
+            }
+            const selected = [...keys][0];
+            if (typeof selected === 'string') {
+              onSelectSession(selected);
+            }
+          }}
+        >
+          {(session) => (
+            <ListBox.Item
+              key={session.id}
+              id={session.id}
+              textValue={session.title}
+            >
+              <SessionItem
+                title={session.title}
+                onDelete={async () => onDeleteSession(session.id)}
+              />
+            </ListBox.Item>
+          )}
+        </ListBox>
+        {hasMore && (
+          <div ref={sentinelRef} className={styles.centered}>
+            {isLoadingMore && <Spinner size='sm' />}
+          </div>
+        )}
+      </>
+    );
+  }, [
+    isLoadingInitial,
+    isLoadingMore,
+    error,
+    sessions,
+    hasMore,
+    sentinelRef,
+    currentSessionId,
+    onSelectSession,
+    onDeleteSession,
+  ]);
+
   return (
     <CollapsibleSidebar
       isOpen={isOpen}
       onOpenChange={onOpenChange}
       title='Sessions'
     >
-      <SessionSidebarContent
-        sessions={sessions}
-        isLoadingInitial={isLoadingInitial}
-        isLoadingMore={isLoadingMore}
-        error={error}
-        hasMore={hasMore}
-        sentinelRef={sentinelRef}
-        currentSessionId={currentSessionId}
-        onSelectSession={onSelectSession}
-        onDeleteSession={onDeleteSession}
-      />
+      {content}
     </CollapsibleSidebar>
-  );
-}
-
-interface SessionSidebarContentProps {
-  sessions: readonly SessionMetadata[];
-  isLoadingInitial: boolean;
-  isLoadingMore: boolean;
-  error: string | null;
-  hasMore: boolean;
-  sentinelRef: RefObject<HTMLDivElement | null>;
-  currentSessionId: string | null;
-  onSelectSession: (id: string) => void;
-  onDeleteSession: (id: string) => Promise<void>;
-}
-
-function SessionSidebarContent({
-  sessions,
-  isLoadingInitial,
-  isLoadingMore,
-  error,
-  hasMore,
-  sentinelRef,
-  currentSessionId,
-  onSelectSession,
-  onDeleteSession,
-}: SessionSidebarContentProps) {
-  if (isLoadingInitial) {
-    return (
-      <div className={styles.centered}>
-        <Spinner size='sm' />
-      </div>
-    );
-  }
-
-  if (error !== null) {
-    return (
-      <div className={styles.centered}>
-        <p className={styles.errorText}>Failed to load sessions</p>
-      </div>
-    );
-  }
-
-  if (sessions.length === 0) {
-    return (
-      <div className={styles.centered}>
-        <p className={styles.emptyText}>No sessions yet</p>
-      </div>
-    );
-  }
-
-  const selectedKeys =
-    currentSessionId !== null ? new Set([currentSessionId]) : new Set<string>();
-
-  return (
-    <>
-      <ListBox
-        aria-label='Session list'
-        className={styles.listBox}
-        items={sessions}
-        selectedKeys={selectedKeys}
-        selectionMode='single'
-        onSelectionChange={(keys: Selection) => {
-          if (keys === 'all') {
-            return;
-          }
-          const selected = [...keys][0];
-          if (typeof selected === 'string') {
-            onSelectSession(selected);
-          }
-        }}
-      >
-        {(session) => (
-          <ListBox.Item
-            key={session.id}
-            id={session.id}
-            textValue={session.title}
-          >
-            <SessionItem
-              title={session.title}
-              onDelete={async () => onDeleteSession(session.id)}
-            />
-          </ListBox.Item>
-        )}
-      </ListBox>
-      {hasMore && (
-        <div ref={sentinelRef} className={styles.centered}>
-          {isLoadingMore && <Spinner size='sm' />}
-        </div>
-      )}
-    </>
   );
 }

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/SessionItem.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/SessionItem.tsx
@@ -1,0 +1,35 @@
+import {useCallback, useState} from 'react';
+
+import {SessionItemView} from './SessionItemView.js';
+
+interface SessionItemProps {
+  title: string;
+  onDelete: () => Promise<void>;
+}
+
+export function SessionItem({title, onDelete}: SessionItemProps) {
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleConfirmDelete = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      await onDelete();
+    } finally {
+      setIsDeleting(false);
+      setIsDeleteOpen(false);
+    }
+  }, [onDelete]);
+
+  return (
+    <SessionItemView
+      title={title}
+      isDeleteOpen={isDeleteOpen}
+      onDeleteOpenChange={setIsDeleteOpen}
+      onConfirmDelete={() => {
+        void handleConfirmDelete();
+      }}
+      isDeleting={isDeleting}
+    />
+  );
+}

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/SessionItemView.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/SessionItemView.tsx
@@ -1,0 +1,65 @@
+import {Button, Popover} from '@heroui/react';
+import {Trash2} from 'lucide-react';
+
+import styles from './styles.module.css';
+
+interface SessionItemViewProps {
+  title: string;
+  isDeleteOpen: boolean;
+  onDeleteOpenChange: (open: boolean) => void;
+  onConfirmDelete: () => void;
+  isDeleting: boolean;
+}
+
+export function SessionItemView({
+  title,
+  isDeleteOpen,
+  onDeleteOpenChange,
+  onConfirmDelete,
+  isDeleting,
+}: SessionItemViewProps) {
+  return (
+    <div className={styles.item}>
+      <span className={styles.title}>{title}</span>
+      <div className={styles.deleteButton}>
+        <Popover isOpen={isDeleteOpen} onOpenChange={onDeleteOpenChange}>
+          <Popover.Trigger>
+            <Button
+              isIconOnly
+              size='sm'
+              variant='ghost'
+              aria-label='Delete session'
+            >
+              <Trash2 size={14} />
+            </Button>
+          </Popover.Trigger>
+          <Popover.Content placement='right'>
+            <Popover.Dialog>
+              <Popover.Heading>Delete session?</Popover.Heading>
+              <p className={styles.popoverBody}>This cannot be undone.</p>
+              <div className={styles.popoverActions}>
+                <Button
+                  size='sm'
+                  variant='ghost'
+                  onPress={() => {
+                    onDeleteOpenChange(false);
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size='sm'
+                  variant='danger'
+                  isDisabled={isDeleting}
+                  onPress={onConfirmDelete}
+                >
+                  Delete
+                </Button>
+              </div>
+            </Popover.Dialog>
+          </Popover.Content>
+        </Popover>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/SessionItemView.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/SessionItemView.tsx
@@ -27,7 +27,7 @@ export function SessionItemView({
             <Button
               isIconOnly
               size='sm'
-              variant='danger-soft'
+              variant='ghost'
               aria-label='Delete session'
             >
               <Trash2 size={14} />

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/SessionItemView.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/SessionItemView.tsx
@@ -1,5 +1,5 @@
 import {Button, Popover} from '@heroui/react';
-import {Trash2} from 'lucide-react';
+import {MessageSquare, Trash2} from 'lucide-react';
 
 import styles from './styles.module.css';
 
@@ -20,6 +20,9 @@ export function SessionItemView({
 }: SessionItemViewProps) {
   return (
     <div className={styles.item}>
+      <div className={styles.icon}>
+        <MessageSquare size={14} fill='currentColor' strokeWidth={1.5} />
+      </div>
       <span className={styles.title}>{title}</span>
       <div className={styles.actions}>
         <Popover isOpen={isDeleteOpen} onOpenChange={onDeleteOpenChange}>

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/SessionItemView.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/SessionItemView.tsx
@@ -27,7 +27,7 @@ export function SessionItemView({
             <Button
               isIconOnly
               size='sm'
-              variant='ghost'
+              variant='danger-soft'
               aria-label='Delete session'
             >
               <Trash2 size={14} />

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/SessionItemView.tsx
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/SessionItemView.tsx
@@ -21,7 +21,7 @@ export function SessionItemView({
   return (
     <div className={styles.item}>
       <span className={styles.title}>{title}</span>
-      <div className={styles.deleteButton}>
+      <div className={styles.actions}>
         <Popover isOpen={isDeleteOpen} onOpenChange={onDeleteOpenChange}>
           <Popover.Trigger>
             <Button

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/index.ts
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/index.ts
@@ -1,0 +1,1 @@
+export {SessionItem} from './SessionItem.js';

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/styles.module.css
@@ -29,8 +29,8 @@
 
 .popoverBody {
   margin-top: 8px;
-  font-size: 0.875rem;
-  color: var(--color-foreground-400);
+  font-size: 0.85rem;
+  color: var(--color-muted);
 }
 
 .popoverActions {

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/styles.module.css
@@ -22,8 +22,8 @@
   transition: opacity 150ms ease;
 }
 
-.item:hover .actions,
-.item:focus-within .actions {
+:global(.list-box-item):hover .actions,
+:global(.list-box-item):focus-within .actions {
   opacity: 1;
 }
 

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/styles.module.css
@@ -1,7 +1,7 @@
 .item {
   display: flex;
   align-items: center;
-  gap: 4px;
+  width: 100%;
 }
 
 .title {
@@ -12,14 +12,18 @@
   white-space: nowrap;
 }
 
-.deleteButton {
+.actions {
   flex-shrink: 0;
+  width: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   opacity: 0;
   transition: opacity 150ms ease;
 }
 
-.item:hover .deleteButton,
-.item:focus-within .deleteButton {
+.item:hover .actions,
+.item:focus-within .actions {
   opacity: 1;
 }
 

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/styles.module.css
@@ -18,7 +18,8 @@
   transition: opacity 150ms ease;
 }
 
-.item:hover .deleteButton {
+.item:hover .deleteButton,
+.item:focus-within .deleteButton {
   opacity: 1;
 }
 

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/styles.module.css
@@ -1,0 +1,36 @@
+.item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.deleteButton {
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+
+.item:hover .deleteButton {
+  opacity: 1;
+}
+
+.popoverBody {
+  margin-top: 8px;
+  font-size: 0.875rem;
+  color: var(--color-foreground-400);
+}
+
+.popoverActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/styles.module.css
@@ -1,7 +1,19 @@
 .item {
   display: flex;
   align-items: center;
+  gap: 8px;
   width: 100%;
+}
+
+.icon {
+  flex-shrink: 0;
+  color: var(--color-muted);
+  display: flex;
+  align-items: center;
+}
+
+:global(.list-box-item[data-selected='true']) .icon {
+  color: var(--color-accent);
 }
 
 .title {

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
@@ -1,7 +1,8 @@
 import type {SessionMetadata} from '@omnicraft/api-schema';
-import {useCallback, useEffect, useState} from 'react';
+import {useEffect} from 'react';
 
 import {listSessions} from '@/api/chat/index.js';
+import {useInfiniteList} from '@/hooks/useInfiniteList.js';
 
 import type {ChatEventBus} from '../../StreamingMessageDisplay/index.js';
 
@@ -13,52 +14,31 @@ interface UseSessionListOptions {
 interface UseSessionListReturn {
   sessions: readonly SessionMetadata[];
   isLoading: boolean;
+  isLoadingMore: boolean;
   error: string | null;
+  hasMore: boolean;
+  loadMore: () => void;
   refresh: () => void;
 }
+
+const fetchSessions = async (offset: number, limit: number) => {
+  const result = await listSessions(offset, limit);
+  return {items: result.sessions, total: result.total};
+};
 
 export function useSessionList({
   eventBus,
   sessionId,
 }: UseSessionListOptions): UseSessionListReturn {
-  const [sessions, setSessions] = useState<readonly SessionMetadata[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [refreshKey, setRefreshKey] = useState(0);
+  const {items, isLoading, isLoadingMore, error, hasMore, loadMore, refresh} =
+    useInfiniteList<SessionMetadata>(fetchSessions);
 
-  const refresh = useCallback(() => {
-    setRefreshKey((prev) => prev + 1);
-  }, []);
-
+  // Refresh when sessionId changes (new session created)
   useEffect(() => {
-    let cancelled = false;
+    refresh();
+  }, [sessionId, refresh]);
 
-    async function fetchSessions() {
-      setIsLoading(true);
-      setError(null);
-      try {
-        const result = await listSessions(0, 50);
-        if (!cancelled) {
-          setSessions(result.sessions);
-        }
-      } catch (e: unknown) {
-        if (!cancelled) {
-          setError(e instanceof Error ? e.message : 'Failed to load sessions');
-        }
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
-      }
-    }
-
-    void fetchSessions();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [refreshKey, sessionId]);
-
+  // Refresh when a session receives its title
   useEffect(() => {
     const handler = () => {
       refresh();
@@ -69,5 +49,13 @@ export function useSessionList({
     };
   }, [eventBus, refresh]);
 
-  return {sessions, isLoading, error, refresh};
+  return {
+    sessions: items,
+    isLoading,
+    isLoadingMore,
+    error,
+    hasMore,
+    loadMore,
+    refresh,
+  };
 }

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
@@ -31,15 +31,13 @@ export function useSessionList({
   const {items, isLoading, isLoadingMore, error, hasMore, loadMore, refresh} =
     useInfiniteList<SessionMetadata>(fetchSessions);
 
-  // Refresh when a completion finishes (new session persisted) or title updates
+  // Refresh when a session receives its title (first completion persists the session)
   useEffect(() => {
     const handler = () => {
       refresh();
     };
-    eventBus.on('done', handler);
     eventBus.on('session-title', handler);
     return () => {
-      eventBus.off('done', handler);
       eventBus.off('session-title', handler);
     };
   }, [eventBus, refresh]);

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
@@ -3,6 +3,12 @@ import {useCallback, useEffect, useState} from 'react';
 
 import {listSessions} from '@/api/chat/index.js';
 
+import type {ChatEventBus} from '../../StreamingMessageDisplay/index.js';
+
+interface UseSessionListOptions {
+  eventBus: ChatEventBus;
+}
+
 interface UseSessionListReturn {
   sessions: readonly SessionMetadata[];
   isLoading: boolean;
@@ -10,11 +16,9 @@ interface UseSessionListReturn {
   refresh: () => void;
 }
 
-/**
- * Fetches the session list from the API and provides a manual refresh.
- * Re-fetches automatically on mount.
- */
-export function useSessionList(): UseSessionListReturn {
+export function useSessionList({
+  eventBus,
+}: UseSessionListOptions): UseSessionListReturn {
   const [sessions, setSessions] = useState<readonly SessionMetadata[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -52,6 +56,16 @@ export function useSessionList(): UseSessionListReturn {
       cancelled = true;
     };
   }, [refreshKey]);
+
+  useEffect(() => {
+    const handler = () => {
+      refresh();
+    };
+    eventBus.on('session-title', handler);
+    return () => {
+      eventBus.off('session-title', handler);
+    };
+  }, [eventBus, refresh]);
 
   return {sessions, isLoading, error, refresh};
 }

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
@@ -33,10 +33,12 @@ export function useSessionList({
   const {items, isLoading, isLoadingMore, error, hasMore, loadMore, refresh} =
     useInfiniteList<SessionMetadata>(fetchSessions);
 
-  // Refresh when sessionId changes (new session created)
+  // Refresh only when a new session is created (sessionId not in current list)
   useEffect(() => {
-    refresh();
-  }, [sessionId, refresh]);
+    if (sessionId !== null && !items.some((s) => s.id === sessionId)) {
+      refresh();
+    }
+  }, [sessionId, items, refresh]);
 
   // Refresh when a session receives its title
   useEffect(() => {

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
@@ -1,8 +1,9 @@
 import type {SessionMetadata} from '@omnicraft/api-schema';
+import type {RefObject} from 'react';
 import {useCallback, useEffect, useRef} from 'react';
 
 import {listSessions} from '@/api/chat/index.js';
-import {useInfiniteList} from '@/hooks/useInfiniteList.js';
+import {useInfiniteScroll} from '@/hooks/useInfiniteScroll.js';
 
 import type {ChatEventBus} from '../../StreamingMessageDisplay/index.js';
 
@@ -17,7 +18,7 @@ interface UseSessionListReturn {
   isLoadingMore: boolean;
   error: string | null;
   hasMore: boolean;
-  loadMore: () => void;
+  sentinelRef: RefObject<HTMLDivElement | null>;
   refresh: () => void;
 }
 
@@ -36,9 +37,12 @@ export function useSessionList({
     isLoadingMore,
     error,
     hasMore,
-    loadMore,
+    sentinelRef,
     refresh,
-  } = useInfiniteList<SessionMetadata>({fetcher: fetchSessions, pageSize: 20});
+  } = useInfiniteScroll<SessionMetadata>({
+    fetcher: fetchSessions,
+    pageSize: 20,
+  });
 
   // Use a ref so the event handler always sees the latest items without
   // re-subscribing on every items change.
@@ -71,7 +75,7 @@ export function useSessionList({
     isLoadingMore,
     error,
     hasMore,
-    loadMore,
+    sentinelRef,
     refresh,
   };
 }

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
@@ -1,0 +1,57 @@
+import type {SessionMetadata} from '@omnicraft/api-schema';
+import {useCallback, useEffect, useState} from 'react';
+
+import {listSessions} from '@/api/chat/index.js';
+
+interface UseSessionListReturn {
+  sessions: readonly SessionMetadata[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+/**
+ * Fetches the session list from the API and provides a manual refresh.
+ * Re-fetches automatically on mount.
+ */
+export function useSessionList(): UseSessionListReturn {
+  const [sessions, setSessions] = useState<readonly SessionMetadata[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const refresh = useCallback(() => {
+    setRefreshKey((prev) => prev + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchSessions() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await listSessions(0, 50);
+        if (!cancelled) {
+          setSessions(result.sessions);
+        }
+      } catch (e: unknown) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Failed to load sessions');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void fetchSessions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
+
+  return {sessions, isLoading, error, refresh};
+}

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
@@ -7,6 +7,7 @@ import type {ChatEventBus} from '../../StreamingMessageDisplay/index.js';
 
 interface UseSessionListOptions {
   eventBus: ChatEventBus;
+  sessionId: string | null;
 }
 
 interface UseSessionListReturn {
@@ -18,6 +19,7 @@ interface UseSessionListReturn {
 
 export function useSessionList({
   eventBus,
+  sessionId,
 }: UseSessionListOptions): UseSessionListReturn {
   const [sessions, setSessions] = useState<readonly SessionMetadata[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -55,7 +57,7 @@ export function useSessionList({
     return () => {
       cancelled = true;
     };
-  }, [refreshKey]);
+  }, [refreshKey, sessionId]);
 
   useEffect(() => {
     const handler = () => {

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
@@ -1,5 +1,5 @@
 import type {SessionMetadata} from '@omnicraft/api-schema';
-import {useEffect, useRef} from 'react';
+import {useEffect} from 'react';
 
 import {listSessions} from '@/api/chat/index.js';
 import {useInfiniteList} from '@/hooks/useInfiniteList.js';
@@ -8,7 +8,6 @@ import type {ChatEventBus} from '../../StreamingMessageDisplay/index.js';
 
 interface UseSessionListOptions {
   eventBus: ChatEventBus;
-  sessionId: string | null;
 }
 
 interface UseSessionListReturn {
@@ -28,28 +27,19 @@ const fetchSessions = async (offset: number, limit: number) => {
 
 export function useSessionList({
   eventBus,
-  sessionId,
 }: UseSessionListOptions): UseSessionListReturn {
   const {items, isLoading, isLoadingMore, error, hasMore, loadMore, refresh} =
     useInfiniteList<SessionMetadata>(fetchSessions);
 
-  // Refresh when a new session is created (sessionId transitions from null to a value)
-  const prevSessionIdRef = useRef(sessionId);
-  useEffect(() => {
-    const prev = prevSessionIdRef.current;
-    prevSessionIdRef.current = sessionId;
-    if (prev === null && sessionId !== null) {
-      refresh();
-    }
-  }, [sessionId, refresh]);
-
-  // Refresh when a session receives its title
+  // Refresh when a completion finishes (new session persisted) or title updates
   useEffect(() => {
     const handler = () => {
       refresh();
     };
+    eventBus.on('done', handler);
     eventBus.on('session-title', handler);
     return () => {
+      eventBus.off('done', handler);
       eventBus.off('session-title', handler);
     };
   }, [eventBus, refresh]);

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
@@ -13,7 +13,7 @@ interface UseSessionListOptions {
 
 interface UseSessionListReturn {
   sessions: readonly SessionMetadata[];
-  isLoading: boolean;
+  isLoadingInitial: boolean;
   isLoadingMore: boolean;
   error: string | null;
   hasMore: boolean;
@@ -30,8 +30,15 @@ export function useSessionList({
   eventBus,
   sessionId,
 }: UseSessionListOptions): UseSessionListReturn {
-  const {items, isLoading, isLoadingMore, error, hasMore, loadMore, refresh} =
-    useInfiniteList<SessionMetadata>(fetchSessions);
+  const {
+    items,
+    isLoadingInitial,
+    isLoadingMore,
+    error,
+    hasMore,
+    loadMore,
+    refresh,
+  } = useInfiniteList<SessionMetadata>({fetcher: fetchSessions, pageSize: 20});
 
   // Use a ref so the event handler always sees the latest items without
   // re-subscribing on every items change.
@@ -60,7 +67,7 @@ export function useSessionList({
 
   return {
     sessions: items,
-    isLoading,
+    isLoadingInitial,
     isLoadingMore,
     error,
     hasMore,

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
@@ -1,5 +1,5 @@
 import type {SessionMetadata} from '@omnicraft/api-schema';
-import {useEffect} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 
 import {listSessions} from '@/api/chat/index.js';
 import {useInfiniteList} from '@/hooks/useInfiniteList.js';
@@ -8,6 +8,7 @@ import type {ChatEventBus} from '../../StreamingMessageDisplay/index.js';
 
 interface UseSessionListOptions {
   eventBus: ChatEventBus;
+  sessionId: string | null;
 }
 
 interface UseSessionListReturn {
@@ -27,20 +28,35 @@ const fetchSessions = async (offset: number, limit: number) => {
 
 export function useSessionList({
   eventBus,
+  sessionId,
 }: UseSessionListOptions): UseSessionListReturn {
   const {items, isLoading, isLoadingMore, error, hasMore, loadMore, refresh} =
     useInfiniteList<SessionMetadata>(fetchSessions);
 
-  // Refresh when a session receives its title (first completion persists the session)
+  // Use a ref so the event handler always sees the latest items without
+  // re-subscribing on every items change.
+  const itemsRef = useRef(items);
   useEffect(() => {
-    const handler = () => {
+    itemsRef.current = items;
+  }, [items]);
+
+  const refreshIfNewSession = useCallback(() => {
+    if (
+      sessionId !== null &&
+      !itemsRef.current.some((s) => s.id === sessionId)
+    ) {
       refresh();
-    };
-    eventBus.on('session-title', handler);
+    }
+  }, [sessionId, refresh]);
+
+  // Refresh only when a genuinely new session receives its title.
+  // Replayed session-title events for existing sessions are ignored.
+  useEffect(() => {
+    eventBus.on('session-title', refreshIfNewSession);
     return () => {
-      eventBus.off('session-title', handler);
+      eventBus.off('session-title', refreshIfNewSession);
     };
-  }, [eventBus, refresh]);
+  }, [eventBus, refreshIfNewSession]);
 
   return {
     sessions: items,

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
@@ -1,5 +1,5 @@
 import type {SessionMetadata} from '@omnicraft/api-schema';
-import {useEffect} from 'react';
+import {useEffect, useRef} from 'react';
 
 import {listSessions} from '@/api/chat/index.js';
 import {useInfiniteList} from '@/hooks/useInfiniteList.js';
@@ -33,12 +33,15 @@ export function useSessionList({
   const {items, isLoading, isLoadingMore, error, hasMore, loadMore, refresh} =
     useInfiniteList<SessionMetadata>(fetchSessions);
 
-  // Refresh only when a new session is created (sessionId not in current list)
+  // Refresh when a new session is created (sessionId transitions from null to a value)
+  const prevSessionIdRef = useRef(sessionId);
   useEffect(() => {
-    if (sessionId !== null && !items.some((s) => s.id === sessionId)) {
+    const prev = prevSessionIdRef.current;
+    prevSessionIdRef.current = sessionId;
+    if (prev === null && sessionId !== null) {
       refresh();
     }
-  }, [sessionId, items, refresh]);
+  }, [sessionId, refresh]);
 
   // Refresh when a session receives its title
   useEffect(() => {

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/index.ts
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/index.ts
@@ -1,0 +1,1 @@
+export {SessionSidebar} from './SessionSidebar.js';

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
@@ -3,10 +3,12 @@
 }
 
 .listBox :global(.list-box-item) {
+  position: relative;
   border-radius: 10px;
   padding: 8px 10px;
   font-size: 0.85rem;
   color: var(--color-foreground);
+  gap: 0;
   transition:
     background-color 150ms ease,
     box-shadow 150ms ease;
@@ -16,6 +18,17 @@
   background-color: var(--color-segment);
   box-shadow: var(--shadow-surface);
   font-weight: 500;
+}
+
+.listBox :global(.list-box-item[data-selected='true'])::before {
+  content: '';
+  position: absolute;
+  left: 4px;
+  top: 25%;
+  height: 50%;
+  width: 3px;
+  border-radius: 2px;
+  background-color: var(--color-accent);
 }
 
 .centered {

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
@@ -2,10 +2,16 @@
   padding: 0;
 }
 
+.listBox :global(.list-box) {
+  gap: 2px;
+  padding: 2px;
+}
+
 .listBox :global(.list-box-item) {
   position: relative;
   border-radius: 10px;
-  padding: 8px 10px;
+  padding: 6px 10px;
+  min-height: unset;
   font-size: 0.85rem;
   color: var(--color-foreground);
   gap: 0;

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
@@ -1,16 +1,27 @@
 .listBox {
-  padding: 4px;
+  padding: 0;
+}
+
+.listBox :global(.list-box-item) {
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: 0.85rem;
+  color: var(--color-foreground);
+  transition:
+    background-color 150ms ease,
+    color 150ms ease;
 }
 
 .listBox :global(.list-box-item[data-selected='true']) {
   background-color: var(--color-default);
+  font-weight: 500;
 }
 
 .centered {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 24px 8px;
+  padding: 32px 8px;
 }
 
 .errorText {
@@ -20,5 +31,5 @@
 
 .emptyText {
   font-size: 0.8rem;
-  color: var(--color-foreground-400);
+  color: var(--color-muted);
 }

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
@@ -1,3 +1,20 @@
 .listBox {
   padding: 4px;
 }
+
+.centered {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 8px;
+}
+
+.errorText {
+  font-size: 0.8rem;
+  color: var(--color-danger);
+}
+
+.emptyText {
+  font-size: 0.8rem;
+  color: var(--color-foreground-400);
+}

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
@@ -2,6 +2,10 @@
   padding: 4px;
 }
 
+.listBox :global(.list-box-item[data-selected='true']) {
+  background-color: var(--color-default);
+}
+
 .centered {
   display: flex;
   align-items: center;

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
@@ -13,7 +13,11 @@
 }
 
 .listBox :global(.list-box-item[data-selected='true']) {
-  background-color: var(--color-default);
+  background-color: color-mix(
+    in oklch,
+    var(--color-accent) 12%,
+    var(--color-surface)
+  );
   font-weight: 500;
 }
 

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
@@ -1,0 +1,3 @@
+.listBox {
+  padding: 4px;
+}

--- a/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
+++ b/apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css
@@ -9,15 +9,12 @@
   color: var(--color-foreground);
   transition:
     background-color 150ms ease,
-    color 150ms ease;
+    box-shadow 150ms ease;
 }
 
 .listBox :global(.list-box-item[data-selected='true']) {
-  background-color: color-mix(
-    in oklch,
-    var(--color-accent) 12%,
-    var(--color-surface)
-  );
+  background-color: var(--color-segment);
+  box-shadow: var(--shadow-surface);
   font-weight: 500;
 }
 

--- a/apps/frontend/src/pages/chat/styles.module.css
+++ b/apps/frontend/src/pages/chat/styles.module.css
@@ -1,3 +1,13 @@
+.wrapper {
+  display: flex;
+  height: 100%;
+}
+
+.main {
+  flex: 1;
+  min-width: 0;
+}
+
 .page {
   display: flex;
   flex-direction: column;

--- a/docs/superpowers/plans/2026-04-16-session-history-sidebar.md
+++ b/docs/superpowers/plans/2026-04-16-session-history-sidebar.md
@@ -1,0 +1,1027 @@
+# Session History Sidebar — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a collapsible sidebar to the Chat page that lists historical
+sessions, lets users switch between them, and delete them.
+
+**Architecture:** A reusable `CollapsibleSidebar` shared component provides the
+expand/collapse shell. A chat-page-specific `SessionSidebar` fills it with a
+HeroUI `ListBox` of sessions fetched from `GET /api/chat/sessions`. Clicking a
+session navigates to `/chat/:sessionId`; deleting uses a `Popover` confirmation
+then calls `DELETE /api/chat/session/:id`.
+
+**Tech Stack:** React 19, HeroUI v3 (ListBox, Popover, Button), CSS Modules,
+lucide-react icons, Zod schema validation
+
+---
+
+## File Map
+
+### New files
+
+| File                                                                              | Purpose                                    |
+| --------------------------------------------------------------------------------- | ------------------------------------------ |
+| `components/CollapsibleSidebar/index.ts`                                          | Barrel export                              |
+| `components/CollapsibleSidebar/CollapsibleSidebar.tsx`                            | Stateless sidebar with expand/collapse     |
+| `components/CollapsibleSidebar/styles.module.css`                                 | Sidebar layout and transition styles       |
+| `pages/chat/components/SessionSidebar/index.ts`                                   | Barrel export                              |
+| `pages/chat/components/SessionSidebar/SessionSidebar.tsx`                         | Container: state, API calls, navigation    |
+| `pages/chat/components/SessionSidebar/SessionSidebarView.tsx`                     | View: renders CollapsibleSidebar + ListBox |
+| `pages/chat/components/SessionSidebar/styles.module.css`                          | ListBox styling                            |
+| `pages/chat/components/SessionSidebar/hooks/useSessionList.ts`                    | Fetches session list from API              |
+| `pages/chat/components/SessionSidebar/components/SessionItem/index.ts`            | Barrel export                              |
+| `pages/chat/components/SessionSidebar/components/SessionItem/SessionItem.tsx`     | Container: delete popover state            |
+| `pages/chat/components/SessionSidebar/components/SessionItem/SessionItemView.tsx` | View: title + delete button                |
+| `pages/chat/components/SessionSidebar/components/SessionItem/styles.module.css`   | Hover-reveal delete button styles          |
+
+### Modified files
+
+| File                           | Change                                  |
+| ------------------------------ | --------------------------------------- |
+| `api/chat/chat.ts`             | Add `listSessions()`, `deleteSession()` |
+| `pages/chat/ChatPage.tsx`      | Add sidebar state, pass props           |
+| `pages/chat/ChatPageView.tsx`  | Wrap in horizontal flex, add sidebar    |
+| `pages/chat/styles.module.css` | Add horizontal wrapper class            |
+
+> All paths relative to `apps/frontend/src/`.
+
+---
+
+### Task 1: API Functions
+
+**Files:**
+
+- Modify: `apps/frontend/src/api/chat/chat.ts`
+
+- [ ] **Step 1: Add `listSessions` function**
+
+Append to `apps/frontend/src/api/chat/chat.ts`:
+
+```ts
+import {
+  createSessionResponseSchema,
+  listSessionsResponseSchema,
+  type ListSessionsResponse,
+  type ThinkingLevel,
+} from '@omnicraft/api-schema';
+```
+
+(Update the existing import to add `listSessionsResponseSchema` and
+`ListSessionsResponse`.)
+
+```ts
+/** Fetches the list of past sessions. */
+export async function listSessions(
+  offset: number,
+  limit: number,
+): Promise<ListSessionsResponse> {
+  const res = await fetch(
+    `${BASE}/sessions?offset=${offset.toString()}&limit=${limit.toString()}`,
+  );
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `Failed to list sessions (${res.status.toString()}): ${body}`,
+    );
+  }
+
+  const json: unknown = await res.json();
+  return listSessionsResponseSchema.parse(json);
+}
+```
+
+- [ ] **Step 2: Add `deleteSession` function**
+
+Append to the same file:
+
+```ts
+/** Deletes a session by ID. */
+export async function deleteSession(id: string): Promise<void> {
+  const res = await fetch(`${BASE}/session/${id}`, {
+    method: 'DELETE',
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `Failed to delete session (${res.status.toString()}): ${body}`,
+    );
+  }
+}
+```
+
+- [ ] **Step 3: Verify the build**
+
+Run: `cd apps/frontend && npx tsc --noEmit`
+
+Expected: No type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/frontend/src/api/chat/chat.ts
+git commit -m "feat(frontend): add listSessions and deleteSession API functions"
+```
+
+---
+
+### Task 2: CollapsibleSidebar Shared Component
+
+**Files:**
+
+- Create: `apps/frontend/src/components/CollapsibleSidebar/index.ts`
+- Create: `apps/frontend/src/components/CollapsibleSidebar/CollapsibleSidebar.tsx`
+- Create: `apps/frontend/src/components/CollapsibleSidebar/styles.module.css`
+
+- [ ] **Step 1: Create `styles.module.css`**
+
+```css
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border-right: 1px solid var(--color-border);
+  overflow: hidden;
+  transition: width 200ms ease;
+}
+
+.sidebar[data-open='true'] {
+  width: 240px;
+}
+
+.sidebar[data-open='false'] {
+  width: 40px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px;
+  border-bottom: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.title {
+  flex: 1;
+  font-weight: 600;
+  font-size: 0.875rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.headerExtra {
+  flex-shrink: 0;
+}
+
+.content {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.collapsed {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 8px;
+  height: 100%;
+}
+```
+
+- [ ] **Step 2: Create `CollapsibleSidebar.tsx`**
+
+```tsx
+import {Button, Tooltip} from '@heroui/react';
+import {PanelLeftClose, PanelLeftOpen} from 'lucide-react';
+import type {ReactNode} from 'react';
+
+import styles from './styles.module.css';
+
+interface CollapsibleSidebarProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  headerExtra?: ReactNode;
+  children: ReactNode;
+}
+
+export function CollapsibleSidebar({
+  isOpen,
+  onOpenChange,
+  title,
+  headerExtra,
+  children,
+}: CollapsibleSidebarProps) {
+  if (!isOpen) {
+    return (
+      <aside className={styles.sidebar} data-open='false'>
+        <div className={styles.collapsed}>
+          <Tooltip delay={0}>
+            <Tooltip.Trigger>
+              <Button
+                isIconOnly
+                size='sm'
+                variant='ghost'
+                aria-label='Expand sidebar'
+                onPress={() => {
+                  onOpenChange(true);
+                }}
+              >
+                <PanelLeftOpen size={16} />
+              </Button>
+            </Tooltip.Trigger>
+            <Tooltip.Content>
+              <p>Expand sidebar</p>
+            </Tooltip.Content>
+          </Tooltip>
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className={styles.sidebar} data-open='true'>
+      <div className={styles.header}>
+        <span className={styles.title}>{title}</span>
+        {headerExtra && <div className={styles.headerExtra}>{headerExtra}</div>}
+        <Tooltip delay={0}>
+          <Tooltip.Trigger>
+            <Button
+              isIconOnly
+              size='sm'
+              variant='ghost'
+              aria-label='Collapse sidebar'
+              onPress={() => {
+                onOpenChange(false);
+              }}
+            >
+              <PanelLeftClose size={16} />
+            </Button>
+          </Tooltip.Trigger>
+          <Tooltip.Content>
+            <p>Collapse sidebar</p>
+          </Tooltip.Content>
+        </Tooltip>
+      </div>
+      <div className={styles.content}>{children}</div>
+    </aside>
+  );
+}
+```
+
+- [ ] **Step 3: Create `index.ts`**
+
+```ts
+export {CollapsibleSidebar} from './CollapsibleSidebar.js';
+```
+
+- [ ] **Step 4: Verify the build**
+
+Run: `cd apps/frontend && npx tsc --noEmit`
+
+Expected: No type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/frontend/src/components/CollapsibleSidebar/
+git commit -m "feat(frontend): add CollapsibleSidebar shared component"
+```
+
+---
+
+### Task 3: useSessionList Hook
+
+**Files:**
+
+- Create:
+  `apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts`
+
+- [ ] **Step 1: Create the hook**
+
+```ts
+import type {SessionMetadata} from '@omnicraft/api-schema';
+import {useCallback, useEffect, useState} from 'react';
+
+import {listSessions} from '@/api/chat/index.js';
+
+interface UseSessionListReturn {
+  sessions: readonly SessionMetadata[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+/**
+ * Fetches the session list from the API and provides a manual refresh.
+ * Re-fetches automatically on mount.
+ */
+export function useSessionList(): UseSessionListReturn {
+  const [sessions, setSessions] = useState<readonly SessionMetadata[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const refresh = useCallback(() => {
+    setRefreshKey((prev) => prev + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchSessions() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await listSessions(0, 50);
+        if (!cancelled) {
+          setSessions(result.sessions);
+        }
+      } catch (e: unknown) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Failed to load sessions');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void fetchSessions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
+
+  return {sessions, isLoading, error, refresh};
+}
+```
+
+- [ ] **Step 2: Verify the build**
+
+Run: `cd apps/frontend && npx tsc --noEmit`
+
+Expected: No type errors. (The `listSessions` import requires Task 1 to be
+done.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts
+git commit -m "feat(frontend): add useSessionList hook"
+```
+
+---
+
+### Task 4: SessionItem Component
+
+**Files:**
+
+- Create:
+  `apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/index.ts`
+- Create:
+  `apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/SessionItemView.tsx`
+- Create:
+  `apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/SessionItem.tsx`
+- Create:
+  `apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/styles.module.css`
+
+- [ ] **Step 1: Create `styles.module.css`**
+
+```css
+.item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.deleteButton {
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+
+.item:hover .deleteButton {
+  opacity: 1;
+}
+
+.popoverBody {
+  margin-top: 8px;
+  font-size: 0.875rem;
+  color: var(--color-foreground-400);
+}
+
+.popoverActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}
+```
+
+- [ ] **Step 2: Create `SessionItemView.tsx`**
+
+```tsx
+import {Button, Popover} from '@heroui/react';
+import {Trash2} from 'lucide-react';
+
+import styles from './styles.module.css';
+
+interface SessionItemViewProps {
+  title: string;
+  isDeleteOpen: boolean;
+  onDeleteOpenChange: (open: boolean) => void;
+  onConfirmDelete: () => void;
+  isDeleting: boolean;
+}
+
+export function SessionItemView({
+  title,
+  isDeleteOpen,
+  onDeleteOpenChange,
+  onConfirmDelete,
+  isDeleting,
+}: SessionItemViewProps) {
+  return (
+    <div className={styles.item}>
+      <span className={styles.title}>{title}</span>
+      <div className={styles.deleteButton}>
+        <Popover isOpen={isDeleteOpen} onOpenChange={onDeleteOpenChange}>
+          <Popover.Trigger>
+            <Button
+              isIconOnly
+              size='sm'
+              variant='ghost'
+              aria-label='Delete session'
+            >
+              <Trash2 size={14} />
+            </Button>
+          </Popover.Trigger>
+          <Popover.Content placement='right'>
+            <Popover.Dialog>
+              <Popover.Heading>Delete session?</Popover.Heading>
+              <p className={styles.popoverBody}>This cannot be undone.</p>
+              <div className={styles.popoverActions}>
+                <Button
+                  size='sm'
+                  variant='ghost'
+                  onPress={() => {
+                    onDeleteOpenChange(false);
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size='sm'
+                  variant='danger'
+                  isDisabled={isDeleting}
+                  onPress={onConfirmDelete}
+                >
+                  Delete
+                </Button>
+              </div>
+            </Popover.Dialog>
+          </Popover.Content>
+        </Popover>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create `SessionItem.tsx`**
+
+```tsx
+import {useCallback, useState} from 'react';
+
+import {SessionItemView} from './SessionItemView.js';
+
+interface SessionItemProps {
+  title: string;
+  onDelete: () => Promise<void>;
+}
+
+export function SessionItem({title, onDelete}: SessionItemProps) {
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleConfirmDelete = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      await onDelete();
+    } finally {
+      setIsDeleting(false);
+      setIsDeleteOpen(false);
+    }
+  }, [onDelete]);
+
+  return (
+    <SessionItemView
+      title={title}
+      isDeleteOpen={isDeleteOpen}
+      onDeleteOpenChange={setIsDeleteOpen}
+      onConfirmDelete={() => {
+        void handleConfirmDelete();
+      }}
+      isDeleting={isDeleting}
+    />
+  );
+}
+```
+
+- [ ] **Step 4: Create `index.ts`**
+
+```ts
+export {SessionItem} from './SessionItem.js';
+```
+
+- [ ] **Step 5: Verify the build**
+
+Run: `cd apps/frontend && npx tsc --noEmit`
+
+Expected: No type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/frontend/src/pages/chat/components/SessionSidebar/components/SessionItem/
+git commit -m "feat(frontend): add SessionItem component with delete popover"
+```
+
+---
+
+### Task 5: SessionSidebar Component
+
+**Files:**
+
+- Create:
+  `apps/frontend/src/pages/chat/components/SessionSidebar/index.ts`
+- Create:
+  `apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebarView.tsx`
+- Create:
+  `apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx`
+- Create:
+  `apps/frontend/src/pages/chat/components/SessionSidebar/styles.module.css`
+
+- [ ] **Step 1: Create `styles.module.css`**
+
+```css
+.listBox {
+  padding: 4px;
+}
+```
+
+- [ ] **Step 2: Create `SessionSidebarView.tsx`**
+
+```tsx
+import {ListBox} from '@heroui/react';
+import type {SessionMetadata} from '@omnicraft/api-schema';
+import type {Key} from 'react';
+
+import {CollapsibleSidebar} from '@/components/CollapsibleSidebar/index.js';
+
+import {SessionItem} from './components/SessionItem/index.js';
+import styles from './styles.module.css';
+
+interface SessionSidebarViewProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  sessions: readonly SessionMetadata[];
+  currentSessionId: string | null;
+  onSelectSession: (id: string) => void;
+  onDeleteSession: (id: string) => Promise<void>;
+}
+
+export function SessionSidebarView({
+  isOpen,
+  onOpenChange,
+  sessions,
+  currentSessionId,
+  onSelectSession,
+  onDeleteSession,
+}: SessionSidebarViewProps) {
+  const selectedKeys =
+    currentSessionId !== null ? new Set([currentSessionId]) : new Set<string>();
+
+  return (
+    <CollapsibleSidebar
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      title='Sessions'
+    >
+      <ListBox
+        aria-label='Session list'
+        className={styles.listBox}
+        items={sessions}
+        selectedKeys={selectedKeys}
+        selectionMode='single'
+        onAction={(key: Key) => {
+          onSelectSession(String(key));
+        }}
+      >
+        {(session) => (
+          <ListBox.Item
+            key={session.id}
+            id={session.id}
+            textValue={session.title}
+          >
+            <SessionItem
+              title={session.title}
+              onDelete={async () => onDeleteSession(session.id)}
+            />
+          </ListBox.Item>
+        )}
+      </ListBox>
+    </CollapsibleSidebar>
+  );
+}
+```
+
+- [ ] **Step 3: Create `SessionSidebar.tsx`**
+
+```tsx
+import {useCallback, useState} from 'react';
+import {useNavigate} from 'react-router';
+
+import {deleteSession} from '@/api/chat/index.js';
+
+import {useSessionId} from '../../hooks/useSessionId.js';
+import {useSessionList} from './hooks/useSessionList.js';
+import {SessionSidebarView} from './SessionSidebarView.js';
+
+export function SessionSidebar() {
+  const [isOpen, setIsOpen] = useState(true);
+  const {sessions, refresh} = useSessionList();
+  const {sessionId} = useSessionId();
+  const navigate = useNavigate();
+
+  const handleSelectSession = useCallback(
+    (id: string) => {
+      if (id !== sessionId) {
+        void navigate(`/chat/${id}`);
+      }
+    },
+    [navigate, sessionId],
+  );
+
+  const handleDeleteSession = useCallback(
+    async (id: string) => {
+      await deleteSession(id);
+      refresh();
+      if (id === sessionId) {
+        void navigate('/chat', {replace: true});
+      }
+    },
+    [refresh, sessionId, navigate],
+  );
+
+  return (
+    <SessionSidebarView
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+      sessions={sessions}
+      currentSessionId={sessionId}
+      onSelectSession={handleSelectSession}
+      onDeleteSession={handleDeleteSession}
+    />
+  );
+}
+```
+
+- [ ] **Step 4: Create `index.ts`**
+
+```ts
+export {SessionSidebar} from './SessionSidebar.js';
+```
+
+- [ ] **Step 5: Verify the build**
+
+Run: `cd apps/frontend && npx tsc --noEmit`
+
+Expected: No type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/frontend/src/pages/chat/components/SessionSidebar/
+git commit -m "feat(frontend): add SessionSidebar component"
+```
+
+---
+
+### Task 6: Integrate Sidebar into Chat Page
+
+**Files:**
+
+- Modify: `apps/frontend/src/pages/chat/ChatPageView.tsx`
+- Modify: `apps/frontend/src/pages/chat/styles.module.css`
+- Modify: `apps/frontend/src/pages/chat/ChatPage.tsx`
+
+- [ ] **Step 1: Add wrapper class to `styles.module.css`**
+
+Add to `apps/frontend/src/pages/chat/styles.module.css`:
+
+```css
+.wrapper {
+  display: flex;
+  height: 100%;
+}
+
+.main {
+  flex: 1;
+  min-width: 0;
+}
+```
+
+- [ ] **Step 2: Update `ChatPageView.tsx`**
+
+Add the sidebar to the layout. The `SessionSidebar` is a container component
+(has its own state and hooks), so it goes directly in the view without being
+threaded through props.
+
+Update the import section — add `SessionSidebar`:
+
+```tsx
+import {SessionSidebar} from './components/SessionSidebar/index.js';
+```
+
+Wrap the return JSX: replace the existing `<div className={styles.page}>` with
+the new wrapper structure:
+
+```tsx
+return (
+  <div className={styles.wrapper}>
+    <SessionSidebar />
+    <div className={styles.main}>
+      <div className={styles.page}>
+        {/* ... all existing content unchanged ... */}
+      </div>
+    </div>
+  </div>
+);
+```
+
+The full updated return:
+
+```tsx
+return (
+  <div className={styles.wrapper}>
+    <SessionSidebar />
+    <div className={styles.main}>
+      <div className={styles.page}>
+        {isReconnecting && (
+          <ChatAlert
+            status='warning'
+            title='Reconnecting'
+            message='Connection lost. Attempting to reconnect...'
+          />
+        )}
+        {error && (
+          <ChatAlert
+            status='danger'
+            title='Error'
+            message={error}
+            onDismiss={onDismissError}
+          />
+        )}
+        {maxRoundsReached && (
+          <ChatAlert
+            status='warning'
+            title='Tool limit reached'
+            message='The assistant reached the maximum number of tool execution rounds. You can increase this limit in Settings > Agent.'
+            onDismiss={onDismissMaxRoundsReached}
+          />
+        )}
+        <TitleBarView
+          title={title}
+          onNewSession={onNewSession}
+          newSessionDisabled={newSessionDisabled}
+          vscodeUrl={vscodeUrl}
+        />
+        <ScrollShadow className={styles.messageListWrapper} ref={scrollRef}>
+          {isEmpty && !sessionId && (
+            <div className={styles.emptyState}>
+              <SessionSetup />
+            </div>
+          )}
+          <StreamingMessageDisplay
+            eventBus={eventBus}
+            sessionId={sessionId}
+            onMessagesChange={onMessagesChange}
+          />
+        </ScrollShadow>
+        {sessionId && <InfoBar />}
+        <ChatInput isStreaming={isStreaming} onSend={onSend} onStop={onStop} />
+      </div>
+    </div>
+  </div>
+);
+```
+
+- [ ] **Step 3: Verify the build**
+
+Run: `cd apps/frontend && npx tsc --noEmit`
+
+Expected: No type errors.
+
+- [ ] **Step 4: Manual smoke test**
+
+Run: `cd apps/frontend && bun run dev`
+
+Verify:
+
+1. Chat page shows sidebar on the left, expanded by default.
+2. Collapse button hides sidebar to narrow strip; expand button restores it.
+3. Session list loads and shows past sessions.
+4. Clicking a session navigates to `/chat/:sessionId` and loads history.
+5. Hover shows delete icon; clicking it shows Popover confirmation.
+6. Confirming delete removes the session and refreshes the list.
+7. New session button in TitleBar still works.
+8. Sidebar and chat area resize correctly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/frontend/src/pages/chat/ChatPageView.tsx \
+       apps/frontend/src/pages/chat/styles.module.css
+git commit -m "feat(frontend): integrate session sidebar into chat page"
+```
+
+---
+
+### Task 7: Refresh sidebar on new session title
+
+**Files:**
+
+- Modify:
+  `apps/frontend/src/pages/chat/components/SessionSidebar/SessionSidebar.tsx`
+- Modify:
+  `apps/frontend/src/pages/chat/components/SessionSidebar/hooks/useSessionList.ts`
+
+When a new session receives its title via the `session-title` SSE event, the
+sidebar should refresh to show the updated entry. The `ChatEventBus` already
+emits a `session-title` event.
+
+- [ ] **Step 1: Subscribe to `session-title` in `useSessionList`**
+
+Update `useSessionList.ts` to accept an optional `ChatEventBus` and refresh when
+a `session-title` event fires:
+
+```ts
+import type {SessionMetadata} from '@omnicraft/api-schema';
+import {useCallback, useEffect, useState} from 'react';
+
+import {listSessions} from '@/api/chat/index.js';
+
+import type {ChatEventBus} from '../../StreamingMessageDisplay/index.js';
+
+interface UseSessionListOptions {
+  eventBus: ChatEventBus;
+}
+
+interface UseSessionListReturn {
+  sessions: readonly SessionMetadata[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+export function useSessionList({
+  eventBus,
+}: UseSessionListOptions): UseSessionListReturn {
+  const [sessions, setSessions] = useState<readonly SessionMetadata[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const refresh = useCallback(() => {
+    setRefreshKey((prev) => prev + 1);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchSessions() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await listSessions(0, 50);
+        if (!cancelled) {
+          setSessions(result.sessions);
+        }
+      } catch (e: unknown) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Failed to load sessions');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    void fetchSessions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
+
+  useEffect(() => {
+    const handler = () => {
+      refresh();
+    };
+    eventBus.on('session-title', handler);
+    return () => {
+      eventBus.off('session-title', handler);
+    };
+  }, [eventBus, refresh]);
+
+  return {sessions, isLoading, error, refresh};
+}
+```
+
+- [ ] **Step 2: Pass `eventBus` in `SessionSidebar.tsx`**
+
+Update `SessionSidebar.tsx`:
+
+```tsx
+import {useCallback, useState} from 'react';
+import {useNavigate} from 'react-router';
+
+import {deleteSession} from '@/api/chat/index.js';
+
+import {useChatEventBus} from '../../hooks/useChatEventBus.js';
+import {useSessionId} from '../../hooks/useSessionId.js';
+import {useSessionList} from './hooks/useSessionList.js';
+import {SessionSidebarView} from './SessionSidebarView.js';
+
+export function SessionSidebar() {
+  const [isOpen, setIsOpen] = useState(true);
+  const eventBus = useChatEventBus();
+  const {sessions, refresh} = useSessionList({eventBus});
+  const {sessionId} = useSessionId();
+  const navigate = useNavigate();
+
+  const handleSelectSession = useCallback(
+    (id: string) => {
+      if (id !== sessionId) {
+        void navigate(`/chat/${id}`);
+      }
+    },
+    [navigate, sessionId],
+  );
+
+  const handleDeleteSession = useCallback(
+    async (id: string) => {
+      await deleteSession(id);
+      refresh();
+      if (id === sessionId) {
+        void navigate('/chat', {replace: true});
+      }
+    },
+    [refresh, sessionId, navigate],
+  );
+
+  return (
+    <SessionSidebarView
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+      sessions={sessions}
+      currentSessionId={sessionId}
+      onSelectSession={handleSelectSession}
+      onDeleteSession={handleDeleteSession}
+    />
+  );
+}
+```
+
+- [ ] **Step 3: Verify the build**
+
+Run: `cd apps/frontend && npx tsc --noEmit`
+
+Expected: No type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/frontend/src/pages/chat/components/SessionSidebar/
+git commit -m "feat(frontend): refresh sidebar on session title update"
+```

--- a/docs/superpowers/specs/2026-04-16-session-history-sidebar-design.md
+++ b/docs/superpowers/specs/2026-04-16-session-history-sidebar-design.md
@@ -1,0 +1,229 @@
+# Session History Sidebar
+
+## Goal
+
+Add a collapsible sidebar to the Chat page showing historical sessions. Users
+can see, resume, and delete past sessions. Relates to
+[issue #143](https://github.com/Soulike/OmniCraft/issues/143).
+
+## Design Decisions
+
+- **Sidebar component**: A reusable `CollapsibleSidebar` controlled component in
+  `components/`. Default expanded, collapsible to a narrow strip with an expand
+  button.
+- **Session list**: HeroUI `ListBox` with `selectionMode="single"`. Chosen over
+  `Tabs` because sessions are dynamic data with per-item actions (delete), not
+  fixed navigation sections.
+- **Delete confirmation**: HeroUI `Popover` with confirm/cancel buttons.
+  Lightweight, doesn't block the view.
+- **Icons**: `lucide-react` — consistent with existing usage (e.g.,
+  `MessageSquarePlus`, `Code` in TitleBar).
+- **No new Context**: Session list state lives inside the sidebar component via
+  `useState` + `useEffect`. No global context needed.
+- **New session button**: Stays in TitleBar, not moved. Sidebar is purely for
+  browsing and switching between historical sessions.
+
+## Components
+
+### 1. CollapsibleSidebar (new shared component)
+
+**Location**: `components/CollapsibleSidebar/`
+
+```
+CollapsibleSidebar/
+  index.ts
+  CollapsibleSidebar.tsx
+  styles.module.css
+```
+
+**Props**:
+
+```ts
+interface CollapsibleSidebarProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  headerExtra?: ReactNode;
+  children: ReactNode;
+}
+```
+
+**Behavior**:
+
+- **Expanded** (`isOpen=true`): Renders header bar (title + headerExtra +
+  collapse button) and children content area. Fixed width via CSS.
+- **Collapsed** (`isOpen=false`): Renders a narrow strip with only an expand
+  button.
+- **Icons**: `PanelLeftClose` (collapse), `PanelLeftOpen` (expand) from
+  `lucide-react`.
+- Layout uses CSS Modules. No margin/padding on the outer element — parent
+  controls placement.
+
+### 2. SessionSidebar (new chat-page component)
+
+**Location**: `pages/chat/components/SessionSidebar/`
+
+```
+SessionSidebar/
+  index.ts
+  SessionSidebar.tsx          # Container: fetches data, manages state
+  SessionSidebarView.tsx      # View: renders CollapsibleSidebar + ListBox
+  components/
+    SessionItem/
+      index.ts
+      SessionItem.tsx         # Container: manages delete popover state
+      SessionItemView.tsx     # View: renders item content + delete button
+      styles.module.css
+  hooks/
+    useSessionList.ts         # Fetches & caches session list from API
+  styles.module.css
+```
+
+**SessionSidebar.tsx** (container):
+
+- Manages `isOpen` state for the sidebar (default: `true`).
+- Uses `useSessionList()` hook to fetch sessions.
+- Gets `sessionId` from `useSessionId()` context to highlight current session.
+- Passes `onSelectSession` that calls `navigate(ROUTES.chat(sessionId))`.
+
+**SessionSidebarView.tsx** (view):
+
+```ts
+interface SessionSidebarViewProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  sessions: SessionMetadata[];
+  currentSessionId: string | null;
+  onSelectSession: (id: string) => void;
+  onDeleteSession: (id: string) => Promise<void>;
+}
+```
+
+- Wraps content in `<CollapsibleSidebar>`.
+- Renders `<ListBox>` with `selectionMode="single"`,
+  `selectedKeys={currentSessionId}`, `onAction={onSelectSession}`.
+- Each item renders `<SessionItem>`.
+
+**SessionItem**:
+
+- Shows session title (truncated with ellipsis).
+- Delete button (`Trash2` icon from lucide-react) visible on hover via CSS.
+- Click on delete opens a `<Popover>` with "Delete session?" heading, message,
+  Cancel and Delete buttons.
+- Delete button calls `DELETE /api/chat/session/:id`, then refreshes the list.
+- If deleting the current session, navigates to `/chat`.
+
+### 3. useSessionList hook
+
+**Location**: `pages/chat/components/SessionSidebar/hooks/useSessionList.ts`
+
+```ts
+interface UseSessionListReturn {
+  sessions: SessionMetadata[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+```
+
+- Calls `listSessions()` on mount and exposes a `refresh()` for manual reload.
+- Called again when sidebar becomes visible or after delete.
+
+## API Layer
+
+**Location**: `api/chat/chat.ts` — add two functions:
+
+```ts
+/** Fetches the list of past sessions. */
+async function listSessions(
+  offset: number,
+  limit: number,
+): Promise<ListSessionsResponse>;
+
+/** Deletes a session by ID. */
+async function deleteSession(id: string): Promise<void>;
+```
+
+- `listSessions`: `GET /api/chat/sessions?offset=0&limit=50`, validates response
+  with `listSessionsResponseSchema`.
+- `deleteSession`: `DELETE /api/chat/session/${id}`, expects 204 No Content.
+
+## Layout Changes
+
+### ChatPageView
+
+Current layout (vertical flex):
+
+```
+┌──────────────────────────────┐
+│ TitleBar                     │
+│ ScrollShadow (messages)      │
+│ InfoBar                      │
+│ ChatInput                    │
+└──────────────────────────────┘
+```
+
+New layout (horizontal flex wrapping existing content):
+
+```
+┌────────────┬─────────────────┐
+│            │ TitleBar        │
+│  Session   │ ScrollShadow   │
+│  Sidebar   │ InfoBar        │
+│            │ ChatInput      │
+└────────────┴─────────────────┘
+```
+
+- `ChatPageView` gets a new outer `div` with `display: flex`.
+- `SessionSidebar` is the left child.
+- Existing page content (alerts, title bar, messages, input) is the right child
+  with `flex: 1`.
+
+### TitleBar Changes
+
+- No changes. New session button and VSCode button stay as-is.
+
+## Route Changes
+
+The route `/chat/:sessionId?` already supports both `/chat` and
+`/chat/:sessionId`. No router changes needed. When a user clicks a session in
+the sidebar, navigate to `/chat/:sessionId`. The existing `useStreamChat` hook
+replays history via `GET /events?from=0`.
+
+## Data Flow
+
+1. User opens `/chat` → sidebar loads session list via `listSessions()`.
+2. User clicks a session → navigate to `/chat/:sessionId` → `SessionIdContext`
+   picks up new `sessionId` from URL params → `useStreamChat` subscribes to
+   events from index 0 → messages replay.
+3. User clicks delete → Popover confirms → `deleteSession(id)` →
+   `useSessionList.refresh()` → if deleted session was current, navigate to
+   `/chat`.
+4. User clicks new session button in TitleBar → same flow as before
+   (`startNewSession` from `useSessionLifecycle`).
+5. When a new session gets a title (via `session-title` SSE event), the sidebar
+   list should refresh to show the updated title.
+
+## File Summary
+
+New files:
+
+- `components/CollapsibleSidebar/index.ts`
+- `components/CollapsibleSidebar/CollapsibleSidebarView.tsx`
+- `components/CollapsibleSidebar/styles.module.css`
+- `pages/chat/components/SessionSidebar/index.ts`
+- `pages/chat/components/SessionSidebar/SessionSidebar.tsx`
+- `pages/chat/components/SessionSidebar/SessionSidebarView.tsx`
+- `pages/chat/components/SessionSidebar/styles.module.css`
+- `pages/chat/components/SessionSidebar/components/SessionItem/index.ts`
+- `pages/chat/components/SessionSidebar/components/SessionItem/SessionItem.tsx`
+- `pages/chat/components/SessionSidebar/components/SessionItem/SessionItemView.tsx`
+- `pages/chat/components/SessionSidebar/components/SessionItem/styles.module.css`
+- `pages/chat/components/SessionSidebar/hooks/useSessionList.ts`
+
+Modified files:
+
+- `api/chat/chat.ts` — add `listSessions()`, `deleteSession()`
+- `pages/chat/ChatPage.tsx` — pass sidebar-related props
+- `pages/chat/ChatPageView.tsx` — add sidebar to layout
+- `pages/chat/styles.module.css` — horizontal flex wrapper


### PR DESCRIPTION
## Summary

- Add a reusable `CollapsibleSidebar` shared component (default expanded, collapsible to narrow strip)
- Add `SessionSidebar` to the Chat page left side, listing historical sessions via `GET /api/chat/sessions`
- Click a session to navigate and replay history; delete with Popover confirmation via `DELETE /api/chat/session/:id`
- Sidebar auto-refreshes when a new session receives its title

Closes #143

## Test plan

- [x] Chat page shows sidebar on the left, expanded by default
- [x] Collapse button hides sidebar to narrow strip; expand button restores it
- [x] Session list loads and shows past sessions
- [x] Clicking a session navigates to `/chat/:sessionId` and replays history
- [x] Hover shows delete icon; clicking it shows Popover confirmation
- [x] Confirming delete removes the session and refreshes the list
- [x] Deleting the current session navigates back to `/chat`
- [x] New session button in TitleBar still works
- [x] Sidebar refreshes when a new session gets its title

🤖 Generated with [Claude Code](https://claude.com/claude-code)