### PR TITLE
fix: reset usage data on session change

### DIFF
--- a/apps/frontend/src/pages/chat/components/UsageInfo/hooks/useUsage.ts
+++ b/apps/frontend/src/pages/chat/components/UsageInfo/hooks/useUsage.ts
@@ -11,9 +11,16 @@ export function useUsage(eventBus: ChatEventBus) {
     const handler = (data: {usage: SseUsage}) => {
       setUsage(data.usage);
     };
+
+    const onReset = () => {
+      setUsage(null);
+    };
+
     eventBus.on('done', handler);
+    eventBus.on('reset-session', onReset);
     return () => {
       eventBus.off('done', handler);
+      eventBus.off('reset-session', onReset);
     };
   }, [eventBus]);
 


### PR DESCRIPTION
## Summary
- `useUsage` did not subscribe to the `reset-session` event, causing stale token-usage data to persist when switching sessions.
- Added a `reset-session` listener that resets usage to `null`, consistent with `useSessionTitle` and other hooks.

## Test plan
- [ ] Open a session and send a message to populate usage info
- [ ] Switch to a different session — verify usage resets (no stale data shown)
- [ ] Send a message in the new session — verify fresh usage appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)