### PR TITLE
fix: use stream.end() instead of stream.destroy() on SSE disconnect

### DIFF
--- a/apps/backend/src/dispatcher/chat/router.ts
+++ b/apps/backend/src/dispatcher/chat/router.ts
@@ -152,7 +152,7 @@ async function pumpSseEvents(
     req.off('close', onDisconnect);
     abortController.abort();
     if (!stream.destroyed) {
-      stream.destroy();
+      stream.end();
     }
   };
   req.on('close', onDisconnect);


### PR DESCRIPTION
## Summary

- Replace `stream.destroy()` with `stream.end()` in the SSE `onDisconnect` handler to gracefully close the stream when clients disconnect (e.g., session switch)
- Eliminates noisy `ERR_STREAM_PREMATURE_CLOSE` errors in backend logs caused by Koa's internal pipeline detecting a forcefully destroyed stream

## Test plan

- [x] Switch sessions in the frontend and verify no `Premature close` errors appear in backend logs
- [x] Verify SSE events still stream correctly during normal operation
- [x] Verify SSE connection cleans up properly when switching sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)