### PR TITLE
feat: add system prompt guidance for todo tool usage

### DIFF
--- a/apps/backend/src/agent-core/agent/agent-catalog.ts
+++ b/apps/backend/src/agent-core/agent/agent-catalog.ts
@@ -57,11 +57,19 @@ export function buildAvailableTools(
 
 export function buildSystemPrompt(
   baseSystemPrompt: string,
+  toolRegistries: readonly ToolRegistry[],
   skillRegistries: readonly SkillRegistry[],
   workingDirectory: string,
   extraAllowedPaths: readonly AllowedPathEntry[],
 ): string {
   let prompt = baseSystemPrompt;
+
+  for (const registry of toolRegistries) {
+    const section = registry.getSystemPromptSection();
+    if (section) {
+      prompt += '\n\n' + section;
+    }
+  }
 
   const skills = buildAvailableSkills(skillRegistries);
   if (skills.size > 0) {

--- a/apps/backend/src/agent-core/agent/agent.ts
+++ b/apps/backend/src/agent-core/agent/agent.ts
@@ -325,6 +325,7 @@ export abstract class Agent {
     const toolDefs = [...availableTools.values()];
     const systemPrompt = buildSystemPrompt(
       this.baseSystemPrompt,
+      this.toolRegistries,
       this.skillRegistries,
       this.workingDirectory,
       this.extraAllowedPaths,

--- a/apps/backend/src/agent-core/tool/tool-registry.ts
+++ b/apps/backend/src/agent-core/tool/tool-registry.ts
@@ -62,4 +62,12 @@ export abstract class ToolRegistry {
   getAll(): ToolDefinition[] {
     return [...this.tools.values()];
   }
+
+  /**
+   * Returns an optional system prompt section for this registry's tools.
+   * Subclasses can override to contribute guidance to the agent's system prompt.
+   */
+  getSystemPromptSection(): string {
+    return '';
+  }
 }

--- a/apps/backend/src/agent/tools/todo/todo-append.ts
+++ b/apps/backend/src/agent/tools/todo/todo-append.ts
@@ -12,7 +12,8 @@ export const todoAppendTool: ToolDefinition<
   description:
     'Appends a new todo item to the end of the list with status pending. ' +
     'Use this to break down work into trackable steps ' +
-    'when handling a multi-step task.',
+    'when handling a multi-step task. ' +
+    'Do not create items for simple tasks that need no progress tracking.',
   parameters: todoAppendParametersSchema,
   suppressToolEvents: true,
   execute(args, context) {

--- a/apps/backend/src/agent/tools/todo/todo-tool-registry.ts
+++ b/apps/backend/src/agent/tools/todo/todo-tool-registry.ts
@@ -16,4 +16,23 @@ export class TodoToolRegistry extends ToolRegistry {
     instance.register(todoListTool);
     return instance;
   }
+
+  override getSystemPromptSection(): string {
+    return [
+      '## Task Tracking',
+      '',
+      'You have todo tools to track progress on multi-step work.',
+      '',
+      'When to use: The task involves multiple distinct steps that benefit from progress tracking.',
+      'When not to use: Simple tasks that can be completed in one or two straightforward steps.',
+      '',
+      'Workflow:',
+      `1. Break the task into steps with ${todoAppendTool.name}.`,
+      '2. Set an item to in_progress when you start working on it.',
+      '3. Set it to completed when done, then move to the next item.',
+      `4. Always call ${todoListTool.name} before using ${todoUpdateTool.name} or ${todoClearTool.name} — they require an up-to-date view and will fail otherwise.`,
+      '',
+      'Keep items actionable and update status as you work, not in bulk at the end.',
+    ].join('\n');
+  }
 }


### PR DESCRIPTION
## Summary

- Add `getSystemPromptSection()` hook to `ToolRegistry` base class, allowing registries to contribute workflow guidance to the agent's system prompt
- Override in `TodoToolRegistry` to provide task tracking instructions (when to use, usage flow, status lifecycle, staleness prevention)
- Wire `toolRegistries` into `buildSystemPrompt()` so sections are appended automatically
- Add negative guard to `todo_append` description ("Do not create items for simple tasks")

Closes #168

## Test plan

- [x] All 508 existing tests pass
- [x] Lint clean
- [x] Format check clean
- [ ] Manual: start a chat session and give the agent a multi-step task; verify it uses todo tools following the described workflow