### PR TITLE
feat: support batch append for todo tools

### DIFF
--- a/apps/backend/src/agent-core/agent/todo-store.test.ts
+++ b/apps/backend/src/agent-core/agent/todo-store.test.ts
@@ -4,9 +4,9 @@ import {TodoStore} from './todo-store.js';
 
 describe('TodoStore', () => {
   describe('append', () => {
-    it('appends an item with status pending', () => {
+    it('appends a single item with status pending', () => {
       const store = new TodoStore();
-      store.append('Task A', 'Do A');
+      store.append([{subject: 'Task A', description: 'Do A'}]);
       const items = store.list();
 
       expect(items).toHaveLength(1);
@@ -18,10 +18,12 @@ describe('TodoStore', () => {
       });
     });
 
-    it('appends multiple items with sequential indices', () => {
+    it('appends multiple items in one call with sequential indices', () => {
       const store = new TodoStore();
-      store.append('Task A', 'Do A');
-      store.append('Task B', 'Do B');
+      store.append([
+        {subject: 'Task A', description: 'Do A'},
+        {subject: 'Task B', description: 'Do B'},
+      ]);
       const items = store.list();
 
       expect(items).toHaveLength(2);
@@ -29,20 +31,36 @@ describe('TodoStore', () => {
       expect(items[1].index).toBe(1);
     });
 
-    it('increments version', () => {
+    it('appends to existing items with correct indices', () => {
+      const store = new TodoStore();
+      store.append([{subject: 'Task A', description: 'Do A'}]);
+      store.append([
+        {subject: 'Task B', description: 'Do B'},
+        {subject: 'Task C', description: 'Do C'},
+      ]);
+      const items = store.list();
+
+      expect(items).toHaveLength(3);
+      expect(items[0].index).toBe(0);
+      expect(items[1].index).toBe(1);
+      expect(items[2].index).toBe(2);
+    });
+
+    it('increments version once per call', () => {
       const store = new TodoStore();
       expect(store.version).toBe(0);
-      store.append('Task A', 'Do A');
+      store.append([
+        {subject: 'Task A', description: 'Do A'},
+        {subject: 'Task B', description: 'Do B'},
+      ]);
       expect(store.version).toBe(1);
-      store.append('Task B', 'Do B');
-      expect(store.version).toBe(2);
     });
   });
 
   describe('update', () => {
     it('updates status of an existing item', () => {
       const store = new TodoStore();
-      store.append('Task A', 'Do A');
+      store.append([{subject: 'Task A', description: 'Do A'}]);
       store.update(0, {status: 'in_progress'});
       const items = store.list();
 
@@ -51,7 +69,7 @@ describe('TodoStore', () => {
 
     it('updates subject and description', () => {
       const store = new TodoStore();
-      store.append('Old', 'Old desc');
+      store.append([{subject: 'Old', description: 'Old desc'}]);
       store.update(0, {subject: 'New', description: 'New desc'});
       const items = store.list();
 
@@ -61,7 +79,7 @@ describe('TodoStore', () => {
 
     it('throws on out-of-bounds index', () => {
       const store = new TodoStore();
-      store.append('Task A', 'Do A');
+      store.append([{subject: 'Task A', description: 'Do A'}]);
       expect(() => {
         store.update(5, {status: 'completed'});
       }).toThrow();
@@ -69,7 +87,7 @@ describe('TodoStore', () => {
 
     it('increments version', () => {
       const store = new TodoStore();
-      store.append('Task A', 'Do A');
+      store.append([{subject: 'Task A', description: 'Do A'}]);
       const before = store.version;
       store.update(0, {status: 'completed'});
       expect(store.version).toBe(before + 1);
@@ -79,8 +97,8 @@ describe('TodoStore', () => {
   describe('clear', () => {
     it('removes all items', () => {
       const store = new TodoStore();
-      store.append('Task A', 'Do A');
-      store.append('Task B', 'Do B');
+      store.append([{subject: 'Task A', description: 'Do A'}]);
+      store.append([{subject: 'Task B', description: 'Do B'}]);
       store.clear();
       const items = store.list();
 
@@ -89,9 +107,9 @@ describe('TodoStore', () => {
 
     it('resets indices so next append starts at 0', () => {
       const store = new TodoStore();
-      store.append('Task A', 'Do A');
+      store.append([{subject: 'Task A', description: 'Do A'}]);
       store.clear();
-      store.append('Task B', 'Do B');
+      store.append([{subject: 'Task B', description: 'Do B'}]);
       const items = store.list();
 
       expect(items).toHaveLength(1);
@@ -100,7 +118,7 @@ describe('TodoStore', () => {
 
     it('increments version', () => {
       const store = new TodoStore();
-      store.append('Task A', 'Do A');
+      store.append([{subject: 'Task A', description: 'Do A'}]);
       const before = store.version;
       store.clear();
       expect(store.version).toBe(before + 1);
@@ -115,8 +133,8 @@ describe('TodoStore', () => {
 
     it('returns all items', () => {
       const store = new TodoStore();
-      store.append('A', 'a');
-      store.append('B', 'b');
+      store.append([{subject: 'A', description: 'a'}]);
+      store.append([{subject: 'B', description: 'b'}]);
       const items = store.list();
 
       expect(items).toHaveLength(2);
@@ -124,7 +142,7 @@ describe('TodoStore', () => {
 
     it('returns a copy, not the internal array', () => {
       const store = new TodoStore();
-      store.append('A', 'a');
+      store.append([{subject: 'A', description: 'a'}]);
       const list1 = store.list();
       const list2 = store.list();
 
@@ -133,7 +151,7 @@ describe('TodoStore', () => {
 
     it('does not increment version', () => {
       const store = new TodoStore();
-      store.append('A', 'a');
+      store.append([{subject: 'A', description: 'a'}]);
       const before = store.version;
       store.list();
       expect(store.version).toBe(before);

--- a/apps/backend/src/agent-core/agent/todo-store.ts
+++ b/apps/backend/src/agent-core/agent/todo-store.ts
@@ -35,15 +35,16 @@ export class TodoStore {
     return this._version;
   }
 
-  /** Appends a new item with status `pending`. */
-  append(subject: string, description: string): void {
-    const item: TodoItem = {
-      index: this.items.length,
-      subject,
-      description,
-      status: 'pending',
-    };
-    this.items.push(item);
+  /** Appends one or more items, each with status `pending`. */
+  append(items: readonly Pick<TodoItem, 'subject' | 'description'>[]): void {
+    for (const {subject, description} of items) {
+      this.items.push({
+        index: this.items.length,
+        subject,
+        description,
+        status: 'pending',
+      });
+    }
     this._version++;
   }
 

--- a/apps/backend/src/agent/tools/todo/schemas.ts
+++ b/apps/backend/src/agent/tools/todo/schemas.ts
@@ -21,8 +21,15 @@ export type TodoResult = z.infer<typeof todoResultSchema>;
 // --- Parameter schemas ---
 
 export const todoAppendParametersSchema = z.object({
-  subject: z.string().min(1).describe('Brief title for the todo item'),
-  description: z.string().describe('What needs to be done'),
+  items: z
+    .array(
+      z.object({
+        subject: z.string().min(1).describe('Brief title for the todo item'),
+        description: z.string().describe('What needs to be done'),
+      }),
+    )
+    .min(1)
+    .describe('Items to append to the todo list'),
 });
 
 export const todoUpdateParametersSchema = z.object({

--- a/apps/backend/src/agent/tools/todo/todo-append.ts
+++ b/apps/backend/src/agent/tools/todo/todo-append.ts
@@ -10,7 +10,7 @@ export const todoAppendTool: ToolDefinition<
   name: 'todo_append',
   displayName: 'Todo Append',
   description:
-    'Appends a new todo item to the end of the list with status pending. ' +
+    'Appends one or more todo items to the end of the list with status pending. ' +
     'Use this to break down work into trackable steps ' +
     'when handling a multi-step task. ' +
     'Do not create items for simple tasks that need no progress tracking.',
@@ -18,7 +18,7 @@ export const todoAppendTool: ToolDefinition<
   suppressToolEvents: true,
   execute(args, context) {
     const {todoStore, todoState} = context;
-    todoStore.append(args.subject, args.description);
+    todoStore.append(args.items);
     const items = todoStore.list();
     markObserved(todoStore, todoState);
     return {

--- a/apps/backend/src/agent/tools/todo/todo-tools.test.ts
+++ b/apps/backend/src/agent/tools/todo/todo-tools.test.ts
@@ -18,7 +18,7 @@ describe('todo tools', () => {
     it('appends an item and returns full list', async () => {
       const ctx = createMockContext();
       const result = await todoAppendTool.execute(
-        {subject: 'Task A', description: 'Do A'},
+        {items: [{subject: 'Task A', description: 'Do A'}]},
         ctx,
       );
 
@@ -31,6 +31,25 @@ describe('todo tools', () => {
         description: 'Do A',
         status: 'pending',
       });
+    });
+
+    it('appends multiple items in one call', async () => {
+      const ctx = createMockContext();
+      const result = await todoAppendTool.execute(
+        {
+          items: [
+            {subject: 'Task A', description: 'Do A'},
+            {subject: 'Task B', description: 'Do B'},
+          ],
+        },
+        ctx,
+      );
+
+      expect(result.status).toBe('success');
+      assert(result.status === 'success');
+      expect(result.data.items).toHaveLength(2);
+      expect(result.data.items[0].index).toBe(0);
+      expect(result.data.items[1].index).toBe(1);
     });
 
     it('suppresses tool events', () => {
@@ -46,7 +65,7 @@ describe('todo tools', () => {
     it('updates item status', async () => {
       const ctx = createMockContext();
       await todoAppendTool.execute(
-        {subject: 'Task A', description: 'Do A'},
+        {items: [{subject: 'Task A', description: 'Do A'}]},
         ctx,
       );
       const result = await todoUpdateTool.execute(
@@ -62,7 +81,7 @@ describe('todo tools', () => {
     it('fails on out-of-bounds index', async () => {
       const ctx = createMockContext();
       await todoAppendTool.execute(
-        {subject: 'Task A', description: 'Do A'},
+        {items: [{subject: 'Task A', description: 'Do A'}]},
         ctx,
       );
       const result = await todoUpdateTool.execute(
@@ -85,7 +104,7 @@ describe('todo tools', () => {
     it('updates subject and description', async () => {
       const ctx = createMockContext();
       await todoAppendTool.execute(
-        {subject: 'Old', description: 'Old desc'},
+        {items: [{subject: 'Old', description: 'Old desc'}]},
         ctx,
       );
       const result = await todoUpdateTool.execute(
@@ -108,7 +127,7 @@ describe('todo tools', () => {
     it('clears all items', async () => {
       const ctx = createMockContext();
       await todoAppendTool.execute(
-        {subject: 'Task A', description: 'Do A'},
+        {items: [{subject: 'Task A', description: 'Do A'}]},
         ctx,
       );
       const result = await todoClearTool.execute({}, ctx);
@@ -141,8 +160,14 @@ describe('todo tools', () => {
 
     it('returns all items', async () => {
       const ctx = createMockContext();
-      await todoAppendTool.execute({subject: 'A', description: 'a'}, ctx);
-      await todoAppendTool.execute({subject: 'B', description: 'b'}, ctx);
+      await todoAppendTool.execute(
+        {items: [{subject: 'A', description: 'a'}]},
+        ctx,
+      );
+      await todoAppendTool.execute(
+        {items: [{subject: 'B', description: 'b'}]},
+        ctx,
+      );
       const result = await todoListTool.execute({}, ctx);
 
       assert(result.status === 'success');
@@ -154,11 +179,12 @@ describe('todo tools', () => {
     it('formats content string with status summary', async () => {
       const ctx = createMockContext();
       await todoAppendTool.execute(
-        {subject: 'Task A', description: 'Do A'},
-        ctx,
-      );
-      await todoAppendTool.execute(
-        {subject: 'Task B', description: 'Do B'},
+        {
+          items: [
+            {subject: 'Task A', description: 'Do A'},
+            {subject: 'Task B', description: 'Do B'},
+          ],
+        },
         ctx,
       );
       await todoUpdateTool.execute({index: 0, status: 'completed'}, ctx);


### PR DESCRIPTION
## Summary

- Change `todo_append` to accept an `items` array instead of single `subject`/`description` params
- Update `TodoStore.append()` to accept an array, incrementing version once per call (atomic batch)
- Reduces context bloat when creating multi-step plans (N items → 1 tool result instead of N)

Closes #171

## Test plan

- [x] All 510 existing tests pass
- [x] Lint passes
- [x] New test: batch append multiple items in one call (store level)
- [x] New test: batch append with correct sequential indices
- [x] New test: version increments once per batch call
- [x] New test: batch append via tool layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)