### PR TITLE
fix: prevent AskUserCard crash during session transition

### DIFF
--- a/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/RenderItem/RenderItem.tsx
+++ b/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/RenderItem/RenderItem.tsx
@@ -43,8 +43,10 @@ export function RenderItem({item}: RenderItemProps) {
     case 'tool-execution': {
       if (item.toolName === TOOL_NAME.ASK_USER) {
         const sessionId = use(SessionIdContext);
+        // sessionId can be null during session transitions (old messages
+        // not yet cleared). Skip rendering; messages will be cleared next frame.
         if (sessionId === null) {
-          throw new Error('AskUserCard requires a sessionId');
+          return null;
         }
         if (item.status === 'running') {
           return (


### PR DESCRIPTION
## Summary
- AskUserCard throws when creating a new session while an ask card is displayed
- Root cause: `clearSessionId()` sets sessionId to null synchronously (via URL navigation), but messages are cleared asynchronously (via `useEffect` → `reset-session` event). During the transitional render frame, RenderItem tries to render AskUserCard with null sessionId and throws
- Fix: return `null` instead of throwing when sessionId is null, gracefully skipping the transitional frame

## Test plan
- [x] Open a session with an active AskUserCard (tool asking a question)
- [x] Click "New Session" — should no longer crash
- [x] Verify normal AskUserCard functionality still works in active sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)