### PR TITLE
feat: remove CodingSubAgent from dispatch and add todo tools to CodingAgent

### DIFF
--- a/apps/backend/src/agent/agents/coding-agent/coding-agent.ts
+++ b/apps/backend/src/agent/agents/coding-agent/coding-agent.ts
@@ -7,6 +7,7 @@ import {
   CoreToolRegistry,
   FileToolRegistry,
   SubAgentToolRegistry,
+  TodoToolRegistry,
   WebToolRegistry,
 } from '@/agent/tools/index.js';
 import {Agent, agentPersistence} from '@/agent-core/agent/index.js';
@@ -39,6 +40,7 @@ export class CodingAgent extends Agent {
           BashToolRegistry.getInstance(),
           SubAgentToolRegistry.getInstance(),
           ClientToolRegistry.getInstance(),
+          TodoToolRegistry.getInstance(),
         ],
         skillRegistries: [CoreSkillRegistry.getInstance()],
         baseSystemPrompt: 'You are a helpful assistant.',

--- a/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
+++ b/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
@@ -4,7 +4,7 @@ import {thinkingLevelSchema} from '@omnicraft/api-schema';
 import type {SseBaseEvent} from '@omnicraft/sse-events';
 import {z} from 'zod';
 
-import {CodingSubAgent, GeneralSubAgent} from '@/agent/agents/index.js';
+import {GeneralSubAgent} from '@/agent/agents/index.js';
 import type {Agent} from '@/agent-core/agent/index.js';
 import type {LlmConfig} from '@/agent-core/llm-api/index.js';
 import type {
@@ -26,12 +26,6 @@ const subAgentInfos = {
     description:
       'General-purpose agent for autonomous multi-step tasks. ' +
       'Use for any work that no other specialized subagent can handle.',
-  },
-  coding: {
-    name: 'Coding',
-    description:
-      'Coding agent powered by Claude Code for autonomous software engineering tasks. ' +
-      'Excels at code reading, writing, debugging, and refactoring.',
   },
 } as const satisfies Record<string, SubAgentInfo>;
 
@@ -58,11 +52,7 @@ const parameters = z.object({
   task: z.string().min(1).describe('The task description for the subagent'),
   agentType: agentTypeSchema
     .optional()
-    .describe(
-      "Type of subagent to dispatch. Defaults to 'general'. " +
-        "Use 'coding' when the task is primarily about reading, modifying, " +
-        'or creating files.',
-    ),
+    .describe("Type of subagent to dispatch. Defaults to 'general'."),
   model: z
     .enum(['default', 'light'])
     .optional()
@@ -158,22 +148,11 @@ export const dispatchAgentTool: ToolDefinition<
       });
 
     // Create subagent
-    let subagent: Agent;
-    switch (agentType) {
-      case 'general':
-        subagent = new GeneralSubAgent(
-          getConfig,
-          workingDirectory,
-          context.extraAllowedPaths,
-        );
-        break;
-      case 'coding':
-        subagent = new CodingSubAgent(
-          workingDirectory,
-          context.extraAllowedPaths,
-        );
-        break;
-    }
+    const subagent: Agent = new GeneralSubAgent(
+      getConfig,
+      workingDirectory,
+      context.extraAllowedPaths,
+    );
 
     // Link parent abort signal to subagent
     const onAbort = () => {


### PR DESCRIPTION
## Summary
- Temporarily remove `CodingSubAgent` from the dispatch tool's available agent types so it is not listed or selectable
- Add `TodoToolRegistry` to `CodingAgent` so it can use todo tools (append, update, clear, list) for work tracking

## Test plan
- [ ] Verify dispatch tool only lists `general` agent type
- [ ] Verify CodingAgent has access to todo tools
- [ ] Run type check (`tsc --noEmit`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)