### PR TITLE
feat: switch Claude thinking to adaptive mode

### DIFF
--- a/apps/backend/src/agent-core/llm-api/claude/helpers.ts
+++ b/apps/backend/src/agent-core/llm-api/claude/helpers.ts
@@ -113,15 +113,20 @@ export function toClaudeTool(tool: ToolDefinition): Anthropic.Tool {
 /** Maps a ThinkingLevel to the Anthropic ThinkingConfigParam. */
 export function toThinkingConfig(
   level: ThinkingLevel,
-): Anthropic.ThinkingConfigParam | undefined {
-  switch (level) {
-    case 'none':
-      return undefined;
-    case 'low':
-      return {type: 'enabled', budget_tokens: 2048};
-    case 'medium':
-      return {type: 'enabled', budget_tokens: 8192};
-    case 'high':
-      return {type: 'enabled', budget_tokens: 32768};
+): Anthropic.ThinkingConfigParam {
+  if (level === 'none') {
+    return {type: 'disabled'};
   }
+  return {type: 'adaptive'};
+}
+
+/**
+ * Maps a ThinkingLevel to the Anthropic OutputConfig for adaptive effort.
+ * Returns `undefined` when thinking is disabled (no effort needed).
+ */
+export function toOutputConfig(
+  level: ThinkingLevel,
+): Anthropic.OutputConfig | undefined {
+  if (level === 'none') return undefined;
+  return {effort: level};
 }

--- a/apps/backend/src/agent-core/llm-api/claude/stream.ts
+++ b/apps/backend/src/agent-core/llm-api/claude/stream.ts
@@ -7,6 +7,7 @@ import type {LlmCompletionOptions, LlmEventStream, LlmUsage} from '../types.js';
 import {
   addCacheBreakpoint,
   toClaudeTool,
+  toOutputConfig,
   toSdkMessage,
   toThinkingConfig,
 } from './helpers.js';
@@ -43,13 +44,8 @@ export async function* streamClaude(
   }
 
   const thinking = toThinkingConfig(options.thinkingLevel);
+  const outputConfig = toOutputConfig(options.thinkingLevel);
   const maxTokens = await modelCapacity.getMaxOutputTokens(options.config);
-  if (thinking?.type === 'enabled') {
-    assert(
-      thinking.budget_tokens < maxTokens,
-      `Thinking budget (${thinking.budget_tokens.toString()}) must be less than max_tokens (${maxTokens.toString()})`,
-    );
-  }
 
   const stream = client.messages.stream(
     {
@@ -67,7 +63,8 @@ export async function* streamClaude(
         : undefined,
       messages: sdkMessages,
       tools: claudeTools,
-      ...(thinking ? {thinking} : {}),
+      thinking,
+      ...(outputConfig ? {output_config: outputConfig} : {}),
     },
     {signal: options.signal},
   );


### PR DESCRIPTION
## Summary

- Replace deprecated `thinking: {type: 'enabled', budget_tokens: N}` with `thinking: {type: 'adaptive'}` + `output_config: {effort: level}` for Claude API calls
- Explicitly pass `thinking: {type: 'disabled'}` when thinking level is `none`, preventing unintended thinking on models that default to adaptive (e.g. Mythos Preview)
- Remove `budget_tokens` assertion that is no longer needed

**Context:** Anthropic deprecated `budget_tokens` on Opus 4.6/Sonnet 4.6 and rejects it entirely on Opus 4.7. Adaptive thinking is now the recommended approach, with effort controlled via `output_config.effort`.

## Test plan

- [ ] Verify thinking is disabled when level is `none` (no thinking blocks in response)
- [ ] Verify `low`/`medium`/`high` levels produce thinking with appropriate depth
- [ ] Test with Claude Sonnet 4.6 model
- [ ] Typecheck passes (`bun run --filter='./apps/backend' typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)