### PR TITLE
refactor: differentiate session creation between Chat and Coding agents

### DIFF
--- a/apps/backend/src/dispatcher/agent-session/router.ts
+++ b/apps/backend/src/dispatcher/agent-session/router.ts
@@ -3,8 +3,9 @@ import {PassThrough} from 'node:stream';
 
 import Router from '@koa/router';
 import {
+  AgentType,
   chatCompletionsRequestSchema,
-  createSessionRequestSchema,
+  createCodingSessionRequestSchema,
   listSessionsQuerySchema,
   submitToolResponseRequestSchema,
   type ThinkingLevel,
@@ -70,12 +71,17 @@ router.post(SESSION, async (ctx) => {
 
   let options = {};
   try {
-    const body = createSessionRequestSchema.parse(ctx.request.body);
-    if (body) {
-      options = {
-        workspace: body.workspace,
-        extraAllowedPaths: body.extraAllowedPaths,
-      };
+    switch (agentType) {
+      case AgentType.CHAT:
+        break;
+      case AgentType.CODING: {
+        const body = createCodingSessionRequestSchema.parse(ctx.request.body);
+        options = {
+          workspace: body.workspace,
+          extraAllowedPaths: body.extraAllowedPaths,
+        };
+        break;
+      }
     }
   } catch (e) {
     if (e instanceof ZodError) {

--- a/apps/frontend/src/api/chat/chat.ts
+++ b/apps/frontend/src/api/chat/chat.ts
@@ -5,14 +5,11 @@ import {
 } from '@omnicraft/api-schema';
 import type {SseEvent} from '@omnicraft/sse-events';
 
-import type {CreateSessionOptions} from '../agent-session/index.js';
 import * as agentSessionApi from '../agent-session/index.js';
 
 /** Creates a new chat session. Returns the session ID. */
-export async function createSession(
-  options: CreateSessionOptions = {},
-): Promise<string> {
-  return agentSessionApi.createSession(AgentType.CHAT, options);
+export async function createSession(): Promise<string> {
+  return agentSessionApi.createSession(AgentType.CHAT);
 }
 
 export async function sendMessage(

--- a/apps/frontend/src/pages/coding/CodingPage.tsx
+++ b/apps/frontend/src/pages/coding/CodingPage.tsx
@@ -74,7 +74,7 @@ function CodingPageContent() {
 
   const createNewSessionIdWithConfig = useCallback(async () => {
     if (selectedWorkspace === undefined) {
-      return null;
+      throw new Error('Please select a workspace before starting a session.');
     }
     return createNewSessionId({
       workspace: selectedWorkspace,

--- a/apps/frontend/src/pages/coding/CodingPage.tsx
+++ b/apps/frontend/src/pages/coding/CodingPage.tsx
@@ -72,17 +72,18 @@ function CodingPageContent() {
     return getVscodeUrl(vscodePort, vscodeToken, selectedWorkspace);
   }, [sessionId, vscodeAvailable, vscodePort, vscodeToken, selectedWorkspace]);
 
-  const createNewSessionIdWithConfig = useCallback(
-    async () =>
-      createNewSessionId({
-        workspace: selectedWorkspace,
-        extraAllowedPaths:
-          selectedExtraAllowedPaths.length > 0
-            ? selectedExtraAllowedPaths
-            : undefined,
-      }),
-    [createNewSessionId, selectedWorkspace, selectedExtraAllowedPaths],
-  );
+  const createNewSessionIdWithConfig = useCallback(async () => {
+    if (selectedWorkspace === undefined) {
+      return null;
+    }
+    return createNewSessionId({
+      workspace: selectedWorkspace,
+      extraAllowedPaths:
+        selectedExtraAllowedPaths.length > 0
+          ? selectedExtraAllowedPaths
+          : undefined,
+    });
+  }, [createNewSessionId, selectedWorkspace, selectedExtraAllowedPaths]);
 
   const {
     isStreaming,

--- a/docs/superpowers/specs/2026-04-21-agent-specific-session-creation-design.md
+++ b/docs/superpowers/specs/2026-04-21-agent-specific-session-creation-design.md
@@ -1,0 +1,126 @@
+# Agent-Specific Session Creation
+
+## Problem
+
+All agent types (Chat, Coding) share a single `createSessionRequestSchema` where
+`workspace` and `extraAllowedPaths` are optional. This is incorrect:
+
+- **Chat Agent** does not need `workspace` or `extraAllowedPaths` at all.
+- **Coding Agent** requires `workspace` to function properly, but the schema
+  and frontend don't enforce this.
+
+## Design
+
+Differentiate session creation per agent type across 4 layers: api-schema,
+backend router, frontend API, and frontend context/page.
+
+### 1. api-schema (`packages/api-schema`)
+
+**Remove** the shared `createSessionRequestSchema`.
+
+**Add** `createCodingSessionRequestSchema`:
+
+```typescript
+export const createCodingSessionRequestSchema = z.object({
+  workspace: z.string(),
+  extraAllowedPaths: z.array(z.string()).optional(),
+});
+```
+
+Chat has no request schema — the router ignores whatever body is sent.
+
+### 2. Backend Router (`apps/backend/src/dispatcher/agent-session/router.ts`)
+
+In the `POST /:agentType/session` handler, switch on `agentType`:
+
+- **Chat**: Skip body parsing entirely. Pass empty options to the service.
+- **Coding**: Parse body with `createCodingSessionRequestSchema`. Pass
+  `workspace` and `extraAllowedPaths` to the service.
+
+```typescript
+let options: CreateSessionOptions = {};
+switch (agentType) {
+  case AgentType.CHAT:
+    break;
+  case AgentType.CODING: {
+    const body = createCodingSessionRequestSchema.parse(ctx.request.body);
+    options = {
+      workspace: body.workspace,
+      extraAllowedPaths: body.extraAllowedPaths,
+    };
+    break;
+  }
+}
+```
+
+### 3. Backend Service (`apps/backend/src/services/agent-session/agent-session-service.ts`)
+
+`CreateSessionOptions` interface keeps all fields optional — the router is the
+validation boundary. No changes needed.
+
+### 4. Frontend API (`apps/frontend/src/api/`)
+
+**`agent-session.ts`**: Keep the generic `createSession(agentType, options?)`
+function as-is. It's the low-level transport. `CreateSessionOptions` stays
+as-is (all optional). No longer needs to be exported since per-agent wrappers
+now define their own signatures.
+
+**`chat.ts`**: `createSession()` takes no parameters.
+
+```typescript
+export async function createSession(): Promise<string> {
+  return agentSessionApi.createSession(AgentType.CHAT);
+}
+```
+
+**`coding.ts`**: `createSession()` keeps optional params to stay compatible
+with the shared `ChatSessionApi` context interface (property-style function
+types are contravariant under `strictFunctionTypes`, so a required-param
+signature would not be assignable to the optional-param context type).
+
+```typescript
+export async function createSession(
+  options: CreateSessionOptions = {},
+): Promise<string> {
+  return agentSessionApi.createSession(AgentType.CODING, options);
+}
+```
+
+### 5. Frontend Context/Page Layer
+
+**`ChatSessionApi` interface**: No changes needed. Keep
+`createSession(options?)` with optional params. Both `chat.createSession()`
+(0 params) and `coding.createSession(opts?)` are assignable.
+
+**`SessionConfigProvider`**: Stays in `ChatPage` for future extensibility.
+
+**`CodingPage`**: Add a guard in `createNewSessionIdWithConfig` — if
+`selectedWorkspace` is `undefined`, show an error instead of creating a
+session. This is the frontend enforcement that workspace is required for
+Coding.
+
+**`ChatPage`**: Already calls `createNewSessionId()` without config — no change
+needed.
+
+### Enforcement Summary
+
+| Layer             | Chat            | Coding                                                      |
+| ----------------- | --------------- | ----------------------------------------------------------- |
+| Backend schema    | No body parsing | `workspace` required via `createCodingSessionRequestSchema` |
+| Frontend API type | No params       | Optional params (for context compatibility)                 |
+| Frontend page     | No constraint   | Guard: `selectedWorkspace` must be defined                  |
+
+## Files to Modify
+
+| File                                                  | Change                                                                      |
+| ----------------------------------------------------- | --------------------------------------------------------------------------- |
+| `packages/api-schema/src/chat/schema.ts`              | Remove `createSessionRequestSchema`, add `createCodingSessionRequestSchema` |
+| `packages/api-schema/src/chat/index.ts`               | Update exports                                                              |
+| `apps/backend/src/dispatcher/agent-session/router.ts` | Switch on agentType for schema selection                                    |
+| `apps/frontend/src/api/chat/chat.ts`                  | Remove options parameter from `createSession`                               |
+| `apps/frontend/src/api/coding/coding.ts`              | No signature change (stays compatible with context)                         |
+| `apps/frontend/src/pages/coding/CodingPage.tsx`       | Guard `selectedWorkspace` in `createNewSessionIdWithConfig`                 |
+
+## Out of Scope
+
+- Renaming `ChatSessionApi` to a more generic name — orthogonal concern.

--- a/packages/api-schema/src/chat/schema.ts
+++ b/packages/api-schema/src/chat/schema.ts
@@ -5,15 +5,15 @@ export const thinkingLevelSchema = z.enum(['none', 'low', 'medium', 'high']);
 
 export type ThinkingLevel = z.infer<typeof thinkingLevelSchema>;
 
-/** Schema for the POST /chat/session request body. */
-export const createSessionRequestSchema = z
-  .object({
-    workspace: z.string().optional(),
-    extraAllowedPaths: z.array(z.string()).optional(),
-  })
-  .optional();
+/** Schema for the POST /coding/session request body. */
+export const createCodingSessionRequestSchema = z.object({
+  workspace: z.string(),
+  extraAllowedPaths: z.array(z.string()).optional(),
+});
 
-export type CreateSessionRequest = z.infer<typeof createSessionRequestSchema>;
+export type CreateCodingSessionRequest = z.infer<
+  typeof createCodingSessionRequestSchema
+>;
 
 /** Schema for the POST /chat/session response body. */
 export const createSessionResponseSchema = z.object({

--- a/packages/api-schema/src/index.ts
+++ b/packages/api-schema/src/index.ts
@@ -2,8 +2,8 @@ export {AgentType, agentTypeSchema} from './agent-type/schema.js';
 export {
   type ChatCompletionsRequest,
   chatCompletionsRequestSchema,
-  type CreateSessionRequest,
-  createSessionRequestSchema,
+  type CreateCodingSessionRequest,
+  createCodingSessionRequestSchema,
   type CreateSessionResponse,
   createSessionResponseSchema,
   type ListSessionsQuery,


### PR DESCRIPTION
## Summary

- Replace shared `createSessionRequestSchema` with `createCodingSessionRequestSchema` that requires `workspace`
- Backend router now switches on `agentType` to select the correct schema — Chat ignores body, Coding validates `workspace` as required
- Frontend `chat.createSession()` no longer accepts options
- CodingPage guards `selectedWorkspace` before creating a session

## Test plan

- [ ] Verify Chat agent session creation works without sending any body
- [ ] Verify Coding agent session creation requires `workspace` (returns 400 without it)
- [ ] Verify CodingPage won't create a session when no workspace is selected
- [ ] Backend lint, typecheck, and tests pass (510 tests)
- [ ] Frontend lint, typecheck, and tests pass (97 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)