### PR TITLE
chore: update model capacity metadata

### DIFF
--- a/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
+++ b/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
@@ -14,6 +14,7 @@ const DEFAULT_MAX_INPUT_TOKENS = 200_000;
 const KNOWN_MODELS = new Map([
   ['claude-opus-4.6-1m', {maxOutputTokens: 64_000, maxInputTokens: 1_000_000}],
   ['claude-opus-4.6', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
+  ['claude-opus-4.7', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
   ['claude-sonnet-4.6', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
   ['claude-sonnet-4', {maxOutputTokens: 16_000, maxInputTokens: 216_000}],
   ['claude-sonnet-4.5', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],

--- a/apps/backend/src/agent-core/model-capacity/model-capacity.test.ts
+++ b/apps/backend/src/agent-core/model-capacity/model-capacity.test.ts
@@ -34,6 +34,12 @@ describe('modelCapacity', () => {
       expect(await modelCapacity.getMaxOutputTokens(config)).toBe(128_000);
     });
 
+    it('returns known limits for GPT-5.5', async () => {
+      const config = makeConfig({apiFormat: 'openai', model: 'gpt-5.5'});
+      expect(await modelCapacity.getMaxOutputTokens(config)).toBe(128_000);
+      expect(await modelCapacity.getMaxInputTokens(config)).toBe(400_000);
+    });
+
     it('returns known output limit via openai-responses format', async () => {
       const config = makeConfig({
         apiFormat: 'openai-responses',
@@ -62,6 +68,16 @@ describe('modelCapacity', () => {
   });
 
   describe('Claude path', () => {
+    it('returns known limits for a Copilot Claude model', async () => {
+      const config = makeConfig({
+        apiFormat: 'claude',
+        model: 'claude-opus-4.7',
+      });
+      expect(await modelCapacity.getMaxOutputTokens(config)).toBe(32_000);
+      expect(await modelCapacity.getMaxInputTokens(config)).toBe(200_000);
+      expect(mockRetrieve).not.toHaveBeenCalled();
+    });
+
     it('returns limits from the Anthropic Models API', async () => {
       mockRetrieve.mockResolvedValue({
         max_tokens: 128_000,

--- a/apps/backend/src/agent-core/model-capacity/openai-capacity.ts
+++ b/apps/backend/src/agent-core/model-capacity/openai-capacity.ts
@@ -18,6 +18,7 @@ const KNOWN_MODELS = new Map([
   ['gpt-5.3-codex', {maxOutputTokens: 128_000, maxInputTokens: 400_000}],
   ['gpt-5.4-mini', {maxOutputTokens: 128_000, maxInputTokens: 400_000}],
   ['gpt-5.4', {maxOutputTokens: 128_000, maxInputTokens: 400_000}],
+  ['gpt-5.5', {maxOutputTokens: 128_000, maxInputTokens: 400_000}],
   ['gemini-2.5-pro', {maxOutputTokens: 64_000, maxInputTokens: 128_000}],
   [
     'gemini-3-flash-preview',


### PR DESCRIPTION
## Summary
- Add capacity metadata for `claude-opus-4.7` from the Copilot models endpoint.
- Add capacity metadata for `gpt-5.5` from the Copilot models endpoint.
- Cover both static-capacity entries with model-capacity tests.

## Test Plan
- `bun run --filter '@omnicraft/backend' test src/agent-core/model-capacity/model-capacity.test.ts`\n- `bun run --filter '@omnicraft/backend' lint`\n- `bun run --filter '@omnicraft/backend' typecheck`