### PR TITLE
Add sensitive path blocklist for agent file tools

### DIFF
--- a/apps/backend/src/agent/tools/file/edit-file.test.ts
+++ b/apps/backend/src/agent/tools/file/edit-file.test.ts
@@ -187,6 +187,22 @@ describe('editFileTool', () => {
   });
 
   describe('error cases', () => {
+    it('denies editing blocked direct paths before reading content', async () => {
+      const filePath = await writeFile('.env', 'SECRET=old');
+      const stat = await fs.stat(filePath);
+      context.fileStatTracker.set(filePath, stat.size, stat.mtimeMs);
+
+      const result = await editFileTool.execute(
+        {filePath: '.env', oldString: 'old', newString: 'new'},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+      await expect(fs.readFile(filePath, 'utf-8')).resolves.toBe('SECRET=old');
+    });
+
     it('returns error for nonexistent file', async () => {
       const result = await editFileTool.execute(
         {filePath: 'nope.txt', oldString: 'a', newString: 'b'},

--- a/apps/backend/src/agent/tools/file/edit-file.ts
+++ b/apps/backend/src/agent/tools/file/edit-file.ts
@@ -16,6 +16,12 @@ import type {
   ToolExecutionContext,
 } from '@/agent-core/tool/index.js';
 
+import {
+  checkExistingFileAccess,
+  checkLexicalFileAccess,
+} from './file-access-policy.js';
+import {formatBlockedFileAccessMessage} from './file-access-policy-messages.js';
+
 const MAX_DIFF_SIZE = 4_096; // 4KB
 const MAX_FILE_SIZE = 10_485_760; // 10MB
 
@@ -52,6 +58,12 @@ export const editFileTool: ToolDefinition<typeof parameters, EditFileResult> = {
     // 1. Resolve path
     const absolutePath = path.resolve(workingDirectory, args.filePath);
 
+    const lexicalPolicyResult = checkLexicalFileAccess(absolutePath);
+    if (!lexicalPolicyResult.allowed) {
+      const message = formatBlockedFileAccessMessage(args.filePath);
+      return {data: {message}, content: message, status: 'failure'};
+    }
+
     // 2. Read file
     let stat: Stats;
     try {
@@ -70,6 +82,12 @@ export const editFileTool: ToolDefinition<typeof parameters, EditFileResult> = {
         content: `Error: Not a file: ${args.filePath}`,
         status: 'failure',
       };
+    }
+
+    const policyResult = await checkExistingFileAccess(absolutePath);
+    if (!policyResult.allowed) {
+      const message = formatBlockedFileAccessMessage(args.filePath);
+      return {data: {message}, content: message, status: 'failure'};
     }
 
     if (stat.size > MAX_FILE_SIZE) {

--- a/apps/backend/src/agent/tools/file/file-access-policy-messages.test.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy-messages.test.ts
@@ -1,0 +1,20 @@
+import {describe, expect, it} from 'vitest';
+
+import {
+  formatBlockedFileAccessMessage,
+  skippedByFileAccessPolicyMessage,
+} from './file-access-policy-messages.js';
+
+describe('file-access-policy-messages', () => {
+  it('formats blocked direct-operation messages for the LLM', () => {
+    expect(formatBlockedFileAccessMessage('/blocked')).toBe(
+      'Error: Access denied by file access policy: /blocked. This operation would access a blocked sensitive path. Review the file access operation. If this operation is necessary, stop and ask the user to perform it manually.',
+    );
+  });
+
+  it('exports the skipped-path policy note for broad searches', () => {
+    expect(skippedByFileAccessPolicyMessage).toBe(
+      'Some paths were skipped because they are blocked by file access policy. Do not try to bypass this policy. If accessing those paths is necessary, stop and ask the user to perform the operation manually.',
+    );
+  });
+});

--- a/apps/backend/src/agent/tools/file/file-access-policy-messages.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy-messages.ts
@@ -1,0 +1,13 @@
+export const skippedByFileAccessPolicyMessage =
+  'Some paths were skipped because they are blocked by file access policy. ' +
+  'Do not try to bypass this policy. If accessing those paths is necessary, ' +
+  'stop and ask the user to perform the operation manually.';
+
+export function formatBlockedFileAccessMessage(requestedPath: string): string {
+  return (
+    `Error: Access denied by file access policy: ${requestedPath}. ` +
+    'This operation would access a blocked sensitive path. ' +
+    'Review the file access operation. If this operation is necessary, ' +
+    'stop and ask the user to perform it manually.'
+  );
+}

--- a/apps/backend/src/agent/tools/file/file-access-policy.test.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy.test.ts
@@ -14,6 +14,8 @@ import {
   checkLexicalFileAccess,
   checkNewFileAccess,
   getFileAccessPolicyGlobIgnorePatterns,
+  hasFileAccessPolicyIgnoredDescendant,
+  isAllowedOsRootAliasSymlinkPath,
   isPathThroughSymbolicLink,
   isSymbolicLinkPath,
 } from './file-access-policy.js';
@@ -94,6 +96,38 @@ describe('file-access-policy', () => {
     expect(await isPathThroughSymbolicLink(tempDir, childPath)).toBe(false);
   });
 
+  it('does not treat normal temp paths as symlinked solely because of OS root aliases', async () => {
+    const tempWorkspace = await fs.mkdtemp(path.join(os.tmpdir(), 'fap-os-'));
+    try {
+      const childPath = path.join(tempWorkspace, 'sub', 'file.ts');
+      await fs.mkdir(path.dirname(childPath), {recursive: true});
+      await fs.writeFile(childPath, '');
+
+      expect(await isPathThroughSymbolicLink(tempWorkspace, childPath)).toBe(
+        false,
+      );
+    } finally {
+      await fs.rm(tempWorkspace, {recursive: true, force: true});
+    }
+  });
+
+  it('only allows known OS-managed root alias symlinks', () => {
+    const allowsMacOsAliases = process.platform === 'darwin';
+
+    expect(isAllowedOsRootAliasSymlinkPath('/var', '/private/var')).toBe(
+      allowsMacOsAliases,
+    );
+    expect(isAllowedOsRootAliasSymlinkPath('/tmp', '/private/tmp')).toBe(
+      allowsMacOsAliases,
+    );
+    expect(
+      isAllowedOsRootAliasSymlinkPath('/workspace-link', '/real-workspace'),
+    ).toBe(false);
+    expect(isAllowedOsRootAliasSymlinkPath('/var', '/elsewhere/var')).toBe(
+      false,
+    );
+  });
+
   it('returns glob ignores for blocked segments and descendant blocked roots', () => {
     const blockedRoot = path.join(tempDir, 'nested', 'sensitive-root');
     const policy: SensitivePathPolicy = {
@@ -110,6 +144,21 @@ describe('file-access-policy', () => {
         'nested/sensitive-root',
         'nested/sensitive-root/**',
       ]),
+    );
+  });
+
+  it('detects existing descendants that policy glob ignores would prune', async () => {
+    const blockedRoot = path.join(tempDir, 'nested', 'sensitive-root');
+    const policy: SensitivePathPolicy = {
+      ...testPolicy,
+      blockedRoots: [blockedRoot],
+    };
+    await fs.mkdir(path.join(tempDir, '.git'), {recursive: true});
+    await fs.writeFile(path.join(tempDir, '.git', 'config'), '[core]');
+    await fs.mkdir(blockedRoot, {recursive: true});
+
+    expect(await hasFileAccessPolicyIgnoredDescendant(tempDir, policy)).toBe(
+      true,
     );
   });
 

--- a/apps/backend/src/agent/tools/file/file-access-policy.test.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy.test.ts
@@ -4,13 +4,17 @@ import path from 'node:path';
 
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 
+import {createSensitivePathPolicy} from '@/helpers/sensitive-path-policy.js';
+
 import {
   checkExistingFileAccess,
+  checkLexicalFileAccess,
   checkNewFileAccess,
   isSymbolicLinkPath,
 } from './file-access-policy.js';
 
 describe('file-access-policy', () => {
+  const originalDataDir = process.env.DATA_DIR;
   let tempDir: string;
 
   beforeEach(async () => {
@@ -18,6 +22,11 @@ describe('file-access-policy', () => {
   });
 
   afterEach(async () => {
+    if (originalDataDir === undefined) {
+      delete process.env.DATA_DIR;
+    } else {
+      process.env.DATA_DIR = originalDataDir;
+    }
     await fs.rm(tempDir, {recursive: true, force: true});
   });
 
@@ -46,6 +55,26 @@ describe('file-access-policy', () => {
     });
   });
 
+  it('uses an explicit policy instead of ambient DATA_DIR for existing file checks', async () => {
+    process.env.DATA_DIR = os.tmpdir();
+    const envFile = path.join(tempDir, '.env');
+    const link = path.join(tempDir, 'env-link');
+    const policy = createSensitivePathPolicy({
+      homeDir: path.join(tempDir, '..', 'explicit-home'),
+      dataDir: path.join(tempDir, '..', 'explicit-data'),
+    });
+    await fs.writeFile(envFile, 'SECRET=value');
+    await fs.symlink(envFile, link);
+
+    const result = await checkExistingFileAccess(link, policy);
+
+    expect(result).toEqual({
+      allowed: false,
+      blockedPath: envFile,
+      reason: 'blocked-pattern',
+    });
+  });
+
   it('blocks new paths through a symlinked parent when only the real target is blocked', async () => {
     const gitDir = path.join(tempDir, '.git');
     const linkToGit = path.join(tempDir, 'link-to-git');
@@ -55,5 +84,25 @@ describe('file-access-policy', () => {
     const result = await checkNewFileAccess(path.join(linkToGit, 'new-config'));
 
     expect(result.allowed).toBe(false);
+  });
+
+  it('uses an explicit policy for lexical and new file checks', async () => {
+    process.env.DATA_DIR = os.tmpdir();
+    const policy = createSensitivePathPolicy({
+      homeDir: path.join(tempDir, '..', 'explicit-home'),
+      dataDir: path.join(tempDir, '..', 'explicit-data'),
+    });
+    const newEnvFile = path.join(tempDir, 'nested', '.env.local');
+
+    expect(
+      checkLexicalFileAccess(path.join(tempDir, 'safe.txt'), policy),
+    ).toEqual({
+      allowed: true,
+    });
+    expect(await checkNewFileAccess(newEnvFile, policy)).toEqual({
+      allowed: false,
+      blockedPath: newEnvFile,
+      reason: 'blocked-pattern',
+    });
   });
 });

--- a/apps/backend/src/agent/tools/file/file-access-policy.test.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy.test.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+import {
+  checkExistingFileAccess,
+  checkNewFileAccess,
+  isSymbolicLinkPath,
+} from './file-access-policy.js';
+
+describe('file-access-policy', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'fap-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, {recursive: true, force: true});
+  });
+
+  it('detects symbolic links', async () => {
+    const target = path.join(tempDir, 'target.txt');
+    const link = path.join(tempDir, 'link.txt');
+    await fs.writeFile(target, 'content');
+    await fs.symlink(target, link);
+
+    expect(await isSymbolicLinkPath(link)).toBe(true);
+    expect(await isSymbolicLinkPath(target)).toBe(false);
+  });
+
+  it('blocks existing paths whose real target is blocked', async () => {
+    const envFile = path.join(tempDir, '.env');
+    const link = path.join(tempDir, 'env-link');
+    await fs.writeFile(envFile, 'SECRET=value');
+    await fs.symlink(envFile, link);
+
+    const result = await checkExistingFileAccess(link);
+
+    expect(result).toEqual({
+      allowed: false,
+      blockedPath: envFile,
+      reason: 'blocked-pattern',
+    });
+  });
+
+  it('blocks new paths through a symlinked parent when only the real target is blocked', async () => {
+    const gitDir = path.join(tempDir, '.git');
+    const linkToGit = path.join(tempDir, 'link-to-git');
+    await fs.mkdir(gitDir);
+    await fs.symlink(gitDir, linkToGit, 'dir');
+
+    const result = await checkNewFileAccess(path.join(linkToGit, 'new-config'));
+
+    expect(result.allowed).toBe(false);
+  });
+});

--- a/apps/backend/src/agent/tools/file/file-access-policy.test.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy.test.ts
@@ -4,7 +4,10 @@ import path from 'node:path';
 
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 
-import {createSensitivePathPolicy} from '@/helpers/sensitive-path-policy.js';
+import {
+  createSensitivePathPolicy,
+  type SensitivePathPolicy,
+} from '@/helpers/sensitive-path-policy.js';
 
 import {
   checkExistingFileAccess,
@@ -16,9 +19,14 @@ import {
 describe('file-access-policy', () => {
   const originalDataDir = process.env.DATA_DIR;
   let tempDir: string;
+  let testPolicy: SensitivePathPolicy;
 
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'fap-test-'));
+    testPolicy = createSensitivePathPolicy({
+      homeDir: path.join(tempDir, '..', 'explicit-home'),
+      dataDir: path.join(tempDir, '..', 'explicit-data'),
+    });
   });
 
   afterEach(async () => {
@@ -46,7 +54,7 @@ describe('file-access-policy', () => {
     await fs.writeFile(envFile, 'SECRET=value');
     await fs.symlink(envFile, link);
 
-    const result = await checkExistingFileAccess(link);
+    const result = await checkExistingFileAccess(link, testPolicy);
 
     expect(result).toEqual({
       allowed: false,
@@ -59,14 +67,10 @@ describe('file-access-policy', () => {
     process.env.DATA_DIR = os.tmpdir();
     const envFile = path.join(tempDir, '.env');
     const link = path.join(tempDir, 'env-link');
-    const policy = createSensitivePathPolicy({
-      homeDir: path.join(tempDir, '..', 'explicit-home'),
-      dataDir: path.join(tempDir, '..', 'explicit-data'),
-    });
     await fs.writeFile(envFile, 'SECRET=value');
     await fs.symlink(envFile, link);
 
-    const result = await checkExistingFileAccess(link, policy);
+    const result = await checkExistingFileAccess(link, testPolicy);
 
     expect(result).toEqual({
       allowed: false,
@@ -81,25 +85,24 @@ describe('file-access-policy', () => {
     await fs.mkdir(gitDir);
     await fs.symlink(gitDir, linkToGit, 'dir');
 
-    const result = await checkNewFileAccess(path.join(linkToGit, 'new-config'));
+    const result = await checkNewFileAccess(
+      path.join(linkToGit, 'new-config'),
+      testPolicy,
+    );
 
     expect(result.allowed).toBe(false);
   });
 
   it('uses an explicit policy for lexical and new file checks', async () => {
     process.env.DATA_DIR = os.tmpdir();
-    const policy = createSensitivePathPolicy({
-      homeDir: path.join(tempDir, '..', 'explicit-home'),
-      dataDir: path.join(tempDir, '..', 'explicit-data'),
-    });
     const newEnvFile = path.join(tempDir, 'nested', '.env.local');
 
     expect(
-      checkLexicalFileAccess(path.join(tempDir, 'safe.txt'), policy),
+      checkLexicalFileAccess(path.join(tempDir, 'safe.txt'), testPolicy),
     ).toEqual({
       allowed: true,
     });
-    expect(await checkNewFileAccess(newEnvFile, policy)).toEqual({
+    expect(await checkNewFileAccess(newEnvFile, testPolicy)).toEqual({
       allowed: false,
       blockedPath: newEnvFile,
       reason: 'blocked-pattern',

--- a/apps/backend/src/agent/tools/file/file-access-policy.test.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy.test.ts
@@ -63,6 +63,18 @@ describe('file-access-policy', () => {
     );
   });
 
+  it('detects paths whose base is below a symlinked ancestor', async () => {
+    const realWorkspace = path.join(tempDir, 'real-workspace');
+    const workspaceLink = path.join(tempDir, 'workspace-link');
+    const baseDir = path.join(workspaceLink, 'sub');
+    const childPath = path.join(baseDir, 'file.ts');
+    await fs.mkdir(path.join(realWorkspace, 'sub'), {recursive: true});
+    await fs.writeFile(path.join(realWorkspace, 'sub', 'file.ts'), '');
+    await fs.symlink(realWorkspace, workspaceLink, 'dir');
+
+    expect(await isPathThroughSymbolicLink(baseDir, childPath)).toBe(true);
+  });
+
   it('detects paths through a symlinked intermediate component', async () => {
     const targetDir = path.join(tempDir, 'target');
     const linkDir = path.join(tempDir, 'link');

--- a/apps/backend/src/agent/tools/file/file-access-policy.test.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy.test.ts
@@ -157,9 +157,24 @@ describe('file-access-policy', () => {
     await fs.writeFile(path.join(tempDir, '.git', 'config'), '[core]');
     await fs.mkdir(blockedRoot, {recursive: true});
 
-    expect(await hasFileAccessPolicyIgnoredDescendant(tempDir, policy)).toBe(
-      true,
-    );
+    expect(
+      await hasFileAccessPolicyIgnoredDescendant(tempDir, '**/*', policy),
+    ).toBe(true);
+  });
+
+  it('does not report ignored descendants outside the active glob scope', async () => {
+    await fs.mkdir(path.join(tempDir, '.git'), {recursive: true});
+    await fs.writeFile(path.join(tempDir, '.git', 'config'), '[core]');
+    await fs.mkdir(path.join(tempDir, 'src'), {recursive: true});
+    await fs.writeFile(path.join(tempDir, 'src', 'app.ts'), '');
+
+    expect(
+      await hasFileAccessPolicyIgnoredDescendant(
+        tempDir,
+        'src/*.ts',
+        testPolicy,
+      ),
+    ).toBe(false);
   });
 
   it('blocks existing paths whose real target is blocked', async () => {

--- a/apps/backend/src/agent/tools/file/file-access-policy.test.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy.test.ts
@@ -13,6 +13,8 @@ import {
   checkExistingFileAccess,
   checkLexicalFileAccess,
   checkNewFileAccess,
+  getFileAccessPolicyGlobIgnorePatterns,
+  isPathThroughSymbolicLink,
   isSymbolicLinkPath,
 } from './file-access-policy.js';
 
@@ -46,6 +48,57 @@ describe('file-access-policy', () => {
 
     expect(await isSymbolicLinkPath(link)).toBe(true);
     expect(await isSymbolicLinkPath(target)).toBe(false);
+  });
+
+  it('detects paths under a symlinked base directory', async () => {
+    const realWorkspace = path.join(tempDir, 'real-workspace');
+    const workspaceLink = path.join(tempDir, 'workspace-link');
+    const childPath = path.join(workspaceLink, 'sub', 'file.ts');
+    await fs.mkdir(path.join(realWorkspace, 'sub'), {recursive: true});
+    await fs.writeFile(path.join(realWorkspace, 'sub', 'file.ts'), '');
+    await fs.symlink(realWorkspace, workspaceLink, 'dir');
+
+    expect(await isPathThroughSymbolicLink(workspaceLink, childPath)).toBe(
+      true,
+    );
+  });
+
+  it('detects paths through a symlinked intermediate component', async () => {
+    const targetDir = path.join(tempDir, 'target');
+    const linkDir = path.join(tempDir, 'link');
+    const childPath = path.join(linkDir, 'file.ts');
+    await fs.mkdir(targetDir);
+    await fs.writeFile(path.join(targetDir, 'file.ts'), '');
+    await fs.symlink(targetDir, linkDir, 'dir');
+
+    expect(await isPathThroughSymbolicLink(tempDir, childPath)).toBe(true);
+  });
+
+  it('allows normal paths under a normal base directory', async () => {
+    const childPath = path.join(tempDir, 'sub', 'file.ts');
+    await fs.mkdir(path.dirname(childPath), {recursive: true});
+    await fs.writeFile(childPath, '');
+
+    expect(await isPathThroughSymbolicLink(tempDir, childPath)).toBe(false);
+  });
+
+  it('returns glob ignores for blocked segments and descendant blocked roots', () => {
+    const blockedRoot = path.join(tempDir, 'nested', 'sensitive-root');
+    const policy: SensitivePathPolicy = {
+      ...testPolicy,
+      blockedRoots: [blockedRoot],
+    };
+
+    expect(getFileAccessPolicyGlobIgnorePatterns(tempDir, policy)).toEqual(
+      expect.arrayContaining([
+        '.git',
+        '.git/**',
+        '**/.git',
+        '**/.git/**',
+        'nested/sensitive-root',
+        'nested/sensitive-root/**',
+      ]),
+    );
   });
 
   it('blocks existing paths whose real target is blocked', async () => {

--- a/apps/backend/src/agent/tools/file/file-access-policy.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy.ts
@@ -78,39 +78,14 @@ export async function isPathThroughSymbolicLink(
   const resolvedPath = path.resolve(absolutePath);
   const relativePath = path.relative(resolvedBaseDir, resolvedPath);
 
-  try {
-    const baseStat = await fs.lstat(resolvedBaseDir);
-    if (baseStat.isSymbolicLink()) return true;
-  } catch {
-    return missingPathIsSymbolicLink;
-  }
-
   if (relativePath === '') {
-    return false;
+    return pathHasSymbolicLinkComponent(
+      resolvedBaseDir,
+      missingPathIsSymbolicLink,
+    );
   }
 
-  if (
-    relativePath.startsWith(`..${path.sep}`) ||
-    relativePath === '..' ||
-    path.isAbsolute(relativePath)
-  ) {
-    return true;
-  }
-
-  let currentPath = resolvedBaseDir;
-  const pathParts = relativePath.split(path.sep).filter((part) => part !== '');
-
-  for (const pathPart of pathParts) {
-    currentPath = path.join(currentPath, pathPart);
-    try {
-      const stat = await fs.lstat(currentPath);
-      if (stat.isSymbolicLink()) return true;
-    } catch {
-      return missingPathIsSymbolicLink;
-    }
-  }
-
-  return false;
+  return pathHasSymbolicLinkComponent(resolvedPath, missingPathIsSymbolicLink);
 }
 
 export function getFileAccessPolicyGlobIgnorePatterns(
@@ -194,4 +169,29 @@ function isNotFoundError(error: unknown): boolean {
 
 function toPosixPath(filePath: string): string {
   return filePath.split(path.sep).join('/');
+}
+
+async function pathHasSymbolicLinkComponent(
+  absolutePath: string,
+  missingPathIsSymbolicLink: boolean,
+): Promise<boolean> {
+  const resolvedPath = path.resolve(absolutePath);
+  const root = path.parse(resolvedPath).root;
+  const pathParts = resolvedPath
+    .slice(root.length)
+    .split(path.sep)
+    .filter((part) => part !== '');
+
+  let currentPath = root;
+  for (const [index, pathPart] of pathParts.entries()) {
+    currentPath = path.join(currentPath, pathPart);
+    try {
+      const stat = await fs.lstat(currentPath);
+      if (stat.isSymbolicLink() && index > 0) return true;
+    } catch {
+      return missingPathIsSymbolicLink;
+    }
+  }
+
+  return false;
 }

--- a/apps/backend/src/agent/tools/file/file-access-policy.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy.ts
@@ -1,0 +1,102 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import {getDefaultSensitivePathPolicy} from '@/helpers/default-sensitive-path-policy.js';
+import {
+  checkSensitivePathAccess,
+  type FileAccessPolicyResult,
+} from '@/helpers/sensitive-path-policy.js';
+
+export function checkLexicalFileAccess(
+  absolutePath: string,
+): FileAccessPolicyResult {
+  return checkSensitivePathAccess(
+    path.resolve(absolutePath),
+    getDefaultSensitivePathPolicy(),
+  );
+}
+
+export async function checkExistingFileAccess(
+  absolutePath: string,
+): Promise<FileAccessPolicyResult> {
+  const lexicalResult = checkLexicalFileAccess(absolutePath);
+  if (!lexicalResult.allowed) return lexicalResult;
+
+  const realPath = await fs.realpath(absolutePath);
+  const realResult = checkLexicalFileAccess(realPath);
+  if (realResult.allowed) return realResult;
+
+  const linkTargetResult = await checkSymbolicLinkTargetAccess(absolutePath);
+  if (linkTargetResult !== undefined && !linkTargetResult.allowed) {
+    return linkTargetResult;
+  }
+
+  return realResult;
+}
+
+export async function checkNewFileAccess(
+  absolutePath: string,
+): Promise<FileAccessPolicyResult> {
+  const resolvedPath = path.resolve(absolutePath);
+  const lexicalResult = checkLexicalFileAccess(resolvedPath);
+  if (!lexicalResult.allowed) return lexicalResult;
+
+  const {existingParent, missingParts} =
+    await findNearestExistingParent(resolvedPath);
+  const realParent = await fs.realpath(existingParent);
+  const intendedRealPath = path.join(realParent, ...missingParts);
+
+  return checkLexicalFileAccess(intendedRealPath);
+}
+
+export async function isSymbolicLinkPath(
+  absolutePath: string,
+): Promise<boolean> {
+  try {
+    const stat = await fs.lstat(absolutePath);
+    return stat.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+async function findNearestExistingParent(absolutePath: string): Promise<{
+  existingParent: string;
+  missingParts: string[];
+}> {
+  const root = path.parse(absolutePath).root;
+  let currentPath = absolutePath;
+  const missingParts: string[] = [];
+
+  while (currentPath !== root) {
+    try {
+      await fs.lstat(currentPath);
+      return {existingParent: currentPath, missingParts};
+    } catch (error) {
+      if (!isNotFoundError(error)) throw error;
+      missingParts.unshift(path.basename(currentPath));
+      currentPath = path.dirname(currentPath);
+    }
+  }
+
+  return {existingParent: root, missingParts};
+}
+
+async function checkSymbolicLinkTargetAccess(
+  absolutePath: string,
+): Promise<FileAccessPolicyResult | undefined> {
+  try {
+    const stat = await fs.lstat(absolutePath);
+    if (!stat.isSymbolicLink()) return undefined;
+
+    const linkTarget = await fs.readlink(absolutePath);
+    const resolvedTarget = path.resolve(path.dirname(absolutePath), linkTarget);
+    return checkLexicalFileAccess(resolvedTarget);
+  } catch {
+    return undefined;
+  }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}

--- a/apps/backend/src/agent/tools/file/file-access-policy.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy.ts
@@ -64,6 +64,42 @@ export async function isSymbolicLinkPath(
   }
 }
 
+export async function isPathThroughSymbolicLink(
+  baseDir: string,
+  absolutePath: string,
+): Promise<boolean> {
+  const resolvedBaseDir = path.resolve(baseDir);
+  const resolvedPath = path.resolve(absolutePath);
+  const relativePath = path.relative(resolvedBaseDir, resolvedPath);
+
+  if (relativePath === '') {
+    return isSymbolicLinkPath(resolvedPath);
+  }
+
+  if (
+    relativePath.startsWith(`..${path.sep}`) ||
+    relativePath === '..' ||
+    path.isAbsolute(relativePath)
+  ) {
+    return true;
+  }
+
+  let currentPath = resolvedBaseDir;
+  const pathParts = relativePath.split(path.sep).filter((part) => part !== '');
+
+  for (const pathPart of pathParts) {
+    currentPath = path.join(currentPath, pathPart);
+    try {
+      const stat = await fs.lstat(currentPath);
+      if (stat.isSymbolicLink()) return true;
+    } catch {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 async function findNearestExistingParent(absolutePath: string): Promise<{
   existingParent: string;
   missingParts: string[];

--- a/apps/backend/src/agent/tools/file/file-access-policy.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy.ts
@@ -8,6 +8,10 @@ import {
   type SensitivePathPolicy,
 } from '@/helpers/sensitive-path-policy.js';
 
+interface SymbolicLinkPathOptions {
+  readonly missingPathIsSymbolicLink?: boolean;
+}
+
 export function checkLexicalFileAccess(
   absolutePath: string,
   policy: SensitivePathPolicy = getDefaultSensitivePathPolicy(),
@@ -67,13 +71,22 @@ export async function isSymbolicLinkPath(
 export async function isPathThroughSymbolicLink(
   baseDir: string,
   absolutePath: string,
+  options: SymbolicLinkPathOptions = {},
 ): Promise<boolean> {
+  const missingPathIsSymbolicLink = options.missingPathIsSymbolicLink ?? true;
   const resolvedBaseDir = path.resolve(baseDir);
   const resolvedPath = path.resolve(absolutePath);
   const relativePath = path.relative(resolvedBaseDir, resolvedPath);
 
+  try {
+    const baseStat = await fs.lstat(resolvedBaseDir);
+    if (baseStat.isSymbolicLink()) return true;
+  } catch {
+    return missingPathIsSymbolicLink;
+  }
+
   if (relativePath === '') {
-    return isSymbolicLinkPath(resolvedPath);
+    return false;
   }
 
   if (
@@ -93,11 +106,48 @@ export async function isPathThroughSymbolicLink(
       const stat = await fs.lstat(currentPath);
       if (stat.isSymbolicLink()) return true;
     } catch {
-      return true;
+      return missingPathIsSymbolicLink;
     }
   }
 
   return false;
+}
+
+export function getFileAccessPolicyGlobIgnorePatterns(
+  searchDir: string,
+  policy: SensitivePathPolicy = getDefaultSensitivePathPolicy(),
+): string[] {
+  const patterns = new Set<string>();
+
+  for (const blockedSegment of [...policy.blockedSegments].sort()) {
+    const segmentPattern = toPosixPath(blockedSegment);
+    patterns.add(segmentPattern);
+    patterns.add(`${segmentPattern}/**`);
+    patterns.add(`**/${segmentPattern}`);
+    patterns.add(`**/${segmentPattern}/**`);
+  }
+
+  const resolvedSearchDir = path.resolve(searchDir);
+  for (const blockedRoot of policy.blockedRoots) {
+    const relativeRoot = path.relative(
+      resolvedSearchDir,
+      path.resolve(blockedRoot),
+    );
+    if (
+      relativeRoot === '' ||
+      relativeRoot === '..' ||
+      relativeRoot.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativeRoot)
+    ) {
+      continue;
+    }
+
+    const rootPattern = toPosixPath(relativeRoot);
+    patterns.add(rootPattern);
+    patterns.add(`${rootPattern}/**`);
+  }
+
+  return [...patterns];
 }
 
 async function findNearestExistingParent(absolutePath: string): Promise<{
@@ -140,4 +190,8 @@ async function checkSymbolicLinkTargetAccess(
 
 function isNotFoundError(error: unknown): boolean {
   return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}
+
+function toPosixPath(filePath: string): string {
+  return filePath.split(path.sep).join('/');
 }

--- a/apps/backend/src/agent/tools/file/file-access-policy.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy.ts
@@ -5,28 +5,31 @@ import {getDefaultSensitivePathPolicy} from '@/helpers/default-sensitive-path-po
 import {
   checkSensitivePathAccess,
   type FileAccessPolicyResult,
+  type SensitivePathPolicy,
 } from '@/helpers/sensitive-path-policy.js';
 
 export function checkLexicalFileAccess(
   absolutePath: string,
+  policy: SensitivePathPolicy = getDefaultSensitivePathPolicy(),
 ): FileAccessPolicyResult {
-  return checkSensitivePathAccess(
-    path.resolve(absolutePath),
-    getDefaultSensitivePathPolicy(),
-  );
+  return checkSensitivePathAccess(path.resolve(absolutePath), policy);
 }
 
 export async function checkExistingFileAccess(
   absolutePath: string,
+  policy: SensitivePathPolicy = getDefaultSensitivePathPolicy(),
 ): Promise<FileAccessPolicyResult> {
-  const lexicalResult = checkLexicalFileAccess(absolutePath);
+  const lexicalResult = checkLexicalFileAccess(absolutePath, policy);
   if (!lexicalResult.allowed) return lexicalResult;
 
   const realPath = await fs.realpath(absolutePath);
-  const realResult = checkLexicalFileAccess(realPath);
+  const realResult = checkLexicalFileAccess(realPath, policy);
   if (realResult.allowed) return realResult;
 
-  const linkTargetResult = await checkSymbolicLinkTargetAccess(absolutePath);
+  const linkTargetResult = await checkSymbolicLinkTargetAccess(
+    absolutePath,
+    policy,
+  );
   if (linkTargetResult !== undefined && !linkTargetResult.allowed) {
     return linkTargetResult;
   }
@@ -36,9 +39,10 @@ export async function checkExistingFileAccess(
 
 export async function checkNewFileAccess(
   absolutePath: string,
+  policy: SensitivePathPolicy = getDefaultSensitivePathPolicy(),
 ): Promise<FileAccessPolicyResult> {
   const resolvedPath = path.resolve(absolutePath);
-  const lexicalResult = checkLexicalFileAccess(resolvedPath);
+  const lexicalResult = checkLexicalFileAccess(resolvedPath, policy);
   if (!lexicalResult.allowed) return lexicalResult;
 
   const {existingParent, missingParts} =
@@ -46,7 +50,7 @@ export async function checkNewFileAccess(
   const realParent = await fs.realpath(existingParent);
   const intendedRealPath = path.join(realParent, ...missingParts);
 
-  return checkLexicalFileAccess(intendedRealPath);
+  return checkLexicalFileAccess(intendedRealPath, policy);
 }
 
 export async function isSymbolicLinkPath(
@@ -84,6 +88,7 @@ async function findNearestExistingParent(absolutePath: string): Promise<{
 
 async function checkSymbolicLinkTargetAccess(
   absolutePath: string,
+  policy: SensitivePathPolicy,
 ): Promise<FileAccessPolicyResult | undefined> {
   try {
     const stat = await fs.lstat(absolutePath);
@@ -91,7 +96,7 @@ async function checkSymbolicLinkTargetAccess(
 
     const linkTarget = await fs.readlink(absolutePath);
     const resolvedTarget = path.resolve(path.dirname(absolutePath), linkTarget);
-    return checkLexicalFileAccess(resolvedTarget);
+    return checkLexicalFileAccess(resolvedTarget, policy);
   } catch {
     return undefined;
   }

--- a/apps/backend/src/agent/tools/file/file-access-policy.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy.ts
@@ -129,42 +129,12 @@ export function getFileAccessPolicyGlobIgnorePatterns(
 
 export async function hasFileAccessPolicyIgnoredDescendant(
   searchDir: string,
+  pattern: string | string[],
   policy: SensitivePathPolicy = getDefaultSensitivePathPolicy(),
 ): Promise<boolean> {
   const resolvedSearchDir = path.resolve(searchDir);
 
-  for (const blockedRoot of policy.blockedRoots) {
-    const relativeRoot = path.relative(
-      resolvedSearchDir,
-      path.resolve(blockedRoot),
-    );
-    if (
-      relativeRoot === '' ||
-      relativeRoot === '..' ||
-      relativeRoot.startsWith(`..${path.sep}`) ||
-      path.isAbsolute(relativeRoot)
-    ) {
-      continue;
-    }
-
-    try {
-      await fs.lstat(blockedRoot);
-      return true;
-    } catch {
-      // Missing blocked roots did not prune anything.
-    }
-  }
-
-  const blockedSegmentPatterns = [...policy.blockedSegments]
-    .sort()
-    .flatMap((blockedSegment) => {
-      const segmentPattern = toPosixPath(blockedSegment);
-      return [segmentPattern, `**/${segmentPattern}`];
-    });
-
-  if (blockedSegmentPatterns.length === 0) return false;
-
-  const stream = fg.stream(blockedSegmentPatterns, {
+  const stream = fg.stream(pattern, {
     cwd: resolvedSearchDir,
     onlyFiles: false,
     dot: true,
@@ -173,7 +143,12 @@ export async function hasFileAccessPolicyIgnoredDescendant(
   });
 
   for await (const entry of stream) {
-    if (typeof entry === 'string') return true;
+    if (typeof entry !== 'string') continue;
+    const entryPolicy = checkLexicalFileAccess(
+      path.join(resolvedSearchDir, entry),
+      policy,
+    );
+    if (!entryPolicy.allowed) return true;
   }
 
   return false;

--- a/apps/backend/src/agent/tools/file/file-access-policy.ts
+++ b/apps/backend/src/agent/tools/file/file-access-policy.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
+import fg from 'fast-glob';
+
 import {getDefaultSensitivePathPolicy} from '@/helpers/default-sensitive-path-policy.js';
 import {
   checkSensitivePathAccess,
@@ -125,6 +127,58 @@ export function getFileAccessPolicyGlobIgnorePatterns(
   return [...patterns];
 }
 
+export async function hasFileAccessPolicyIgnoredDescendant(
+  searchDir: string,
+  policy: SensitivePathPolicy = getDefaultSensitivePathPolicy(),
+): Promise<boolean> {
+  const resolvedSearchDir = path.resolve(searchDir);
+
+  for (const blockedRoot of policy.blockedRoots) {
+    const relativeRoot = path.relative(
+      resolvedSearchDir,
+      path.resolve(blockedRoot),
+    );
+    if (
+      relativeRoot === '' ||
+      relativeRoot === '..' ||
+      relativeRoot.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativeRoot)
+    ) {
+      continue;
+    }
+
+    try {
+      await fs.lstat(blockedRoot);
+      return true;
+    } catch {
+      // Missing blocked roots did not prune anything.
+    }
+  }
+
+  const blockedSegmentPatterns = [...policy.blockedSegments]
+    .sort()
+    .flatMap((blockedSegment) => {
+      const segmentPattern = toPosixPath(blockedSegment);
+      return [segmentPattern, `**/${segmentPattern}`];
+    });
+
+  if (blockedSegmentPatterns.length === 0) return false;
+
+  const stream = fg.stream(blockedSegmentPatterns, {
+    cwd: resolvedSearchDir,
+    onlyFiles: false,
+    dot: true,
+    followSymbolicLinks: false,
+    unique: true,
+  });
+
+  for await (const entry of stream) {
+    if (typeof entry === 'string') return true;
+  }
+
+  return false;
+}
+
 async function findNearestExistingParent(absolutePath: string): Promise<{
   existingParent: string;
   missingParts: string[];
@@ -187,11 +241,37 @@ async function pathHasSymbolicLinkComponent(
     currentPath = path.join(currentPath, pathPart);
     try {
       const stat = await fs.lstat(currentPath);
-      if (stat.isSymbolicLink() && index > 0) return true;
+      if (stat.isSymbolicLink()) {
+        if (index === 0) {
+          const linkTarget = await fs.readlink(currentPath);
+          if (isAllowedOsRootAliasSymlinkPath(currentPath, linkTarget)) {
+            continue;
+          }
+        }
+        return true;
+      }
     } catch {
       return missingPathIsSymbolicLink;
     }
   }
 
   return false;
+}
+
+export function isAllowedOsRootAliasSymlinkPath(
+  linkPath: string,
+  linkTarget: string,
+): boolean {
+  if (process.platform !== 'darwin') return false;
+
+  const resolvedLinkPath = path.resolve(linkPath);
+  const resolvedTarget = path.resolve(
+    path.dirname(resolvedLinkPath),
+    linkTarget,
+  );
+
+  return (
+    (resolvedLinkPath === '/var' && resolvedTarget === '/private/var') ||
+    (resolvedLinkPath === '/tmp' && resolvedTarget === '/private/tmp')
+  );
 }

--- a/apps/backend/src/agent/tools/file/find-files.test.ts
+++ b/apps/backend/src/agent/tools/file/find-files.test.ts
@@ -308,6 +308,24 @@ describe('findFilesTool', () => {
       expect(result.content).toContain('Access denied by file access policy');
     });
 
+    it('denies a search root below a symlinked directory', async () => {
+      await writeFile('real-src/subdir/file.ts', '');
+      await fs.symlink(
+        path.join(tmpDir, 'real-src'),
+        path.join(tmpDir, 'src-link'),
+        'dir',
+      );
+
+      const result = await findFilesTool.execute(
+        {pattern: '**/*.ts', path: 'src-link/subdir'},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+    });
+
     it('returns error for nonexistent directory', async () => {
       const result = await findFilesTool.execute(
         {pattern: '**/*.ts', path: 'nonexistent'},

--- a/apps/backend/src/agent/tools/file/find-files.test.ts
+++ b/apps/backend/src/agent/tools/file/find-files.test.ts
@@ -243,6 +243,24 @@ describe('findFilesTool', () => {
       );
     });
 
+    it('does not append the policy note for ignored sensitive directories outside the glob scope', async () => {
+      await writeFile('.git/config', '[core]');
+      await writeFile('src/app.ts', '');
+
+      const result = await findFilesTool.execute(
+        {pattern: 'src/*.ts'},
+        context,
+      );
+
+      expect(result.status).toBe('success');
+      assert(result.status === 'success');
+      expect(result.content).toContain('src/app.ts');
+      expect(result.content).not.toContain(
+        'Some paths were skipped because they are blocked by file access policy',
+      );
+      expect(result.data.files).toEqual(['src/app.ts']);
+    });
+
     it('skips symlinked files', async () => {
       const target = await writeFile('target.ts', '');
       await fs.symlink(target, path.join(tmpDir, 'link.ts'));

--- a/apps/backend/src/agent/tools/file/find-files.test.ts
+++ b/apps/backend/src/agent/tools/file/find-files.test.ts
@@ -243,6 +243,27 @@ describe('findFilesTool', () => {
         'Some paths were skipped because they are blocked by file access policy',
       );
     });
+
+    it('denies a symlinked working directory before searching', async () => {
+      const realWorkspace = path.join(tmpDir, 'real-workspace');
+      const workspaceLink = path.join(tmpDir, 'workspace-link');
+      await fs.mkdir(path.join(realWorkspace, 'sub'), {recursive: true});
+      await fs.writeFile(path.join(realWorkspace, 'sub', 'file.ts'), '');
+      await fs.symlink(realWorkspace, workspaceLink, 'dir');
+      const linkContext = createMockContext({
+        workingDirectory: workspaceLink,
+        fileCache: new FileContentCache(),
+      });
+
+      const result = await findFilesTool.execute(
+        {pattern: '**/*.ts', path: 'sub'},
+        linkContext,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+    });
   });
 
   describe('error cases', () => {
@@ -288,6 +309,20 @@ describe('findFilesTool', () => {
       expect(result.status).toBe('failure');
       assert(result.status === 'failure');
       expect(result.content).toContain('Access denied by file access policy');
+    });
+
+    it('denies blocked file roots before checking directory type', async () => {
+      await writeFile('.env', 'SECRET=value');
+
+      const result = await findFilesTool.execute(
+        {pattern: '**/*', path: '.env'},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+      expect(result.content).not.toContain('Not a directory');
     });
 
     it('denies a symlinked search root whose target is allowed', async () => {

--- a/apps/backend/src/agent/tools/file/find-files.test.ts
+++ b/apps/backend/src/agent/tools/file/find-files.test.ts
@@ -139,6 +139,27 @@ describe('findFilesTool', () => {
       expect(result.data.files).toHaveLength(1);
     });
 
+    it('searches allowed absolute paths outside the working directory', async () => {
+      const externalDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'fft-external-'),
+      );
+      try {
+        await fs.writeFile(path.join(externalDir, 'external.ts'), '');
+
+        const result = await findFilesTool.execute(
+          {pattern: '**/*.ts', path: externalDir},
+          context,
+        );
+
+        expect(result.status).toBe('success');
+        assert(result.status === 'success');
+        expect(result.content).toContain('external.ts');
+        expect(result.data.files).toContain('external.ts');
+      } finally {
+        await fs.rm(externalDir, {recursive: true, force: true});
+      }
+    });
+
     it('supports brace expansion (or semantics)', async () => {
       await writeFile('a.ts', '');
       await writeFile('b.tsx', '');
@@ -257,6 +278,28 @@ describe('findFilesTool', () => {
 
       const result = await findFilesTool.execute(
         {pattern: '**/*.ts', path: 'sub'},
+        linkContext,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+    });
+
+    it('denies a working directory below a symlinked ancestor', async () => {
+      const realWorkspace = path.join(tmpDir, 'real-workspace');
+      const workspaceLink = path.join(tmpDir, 'workspace-link');
+      const linkSubdir = path.join(workspaceLink, 'sub');
+      await fs.mkdir(path.join(realWorkspace, 'sub'), {recursive: true});
+      await fs.writeFile(path.join(realWorkspace, 'sub', 'file.ts'), '');
+      await fs.symlink(realWorkspace, workspaceLink, 'dir');
+      const linkContext = createMockContext({
+        workingDirectory: linkSubdir,
+        fileCache: new FileContentCache(),
+      });
+
+      const result = await findFilesTool.execute(
+        {pattern: '**/*.ts'},
         linkContext,
       );
 

--- a/apps/backend/src/agent/tools/file/find-files.test.ts
+++ b/apps/backend/src/agent/tools/file/find-files.test.ts
@@ -93,13 +93,13 @@ describe('findFilesTool', () => {
     });
 
     it('matches dotfiles when dot is in pattern', async () => {
-      await writeFile('.env', '');
+      await writeFile('.env.example', '');
       await writeFile('.gitignore', '');
       await writeFile('readme.md', '');
 
       const result = await findFilesTool.execute({pattern: '.*'}, context);
 
-      expect(result.content).toContain('.env');
+      expect(result.content).toContain('.env.example');
       expect(result.content).toContain('.gitignore');
       expect(result.content).not.toContain('readme.md');
       expect(result.status).toBe('success');
@@ -187,6 +187,40 @@ describe('findFilesTool', () => {
       expect(result.data.files).toHaveLength(100);
       expect(result.data.truncated).toBe(true);
     });
+
+    it('skips blocked paths and appends the policy note', async () => {
+      await writeFile('src/app.ts', '');
+      await writeFile('.env', 'SECRET=value');
+      await writeFile('.git/config', '[core]');
+
+      const result = await findFilesTool.execute({pattern: '**/*'}, context);
+
+      expect(result.status).toBe('success');
+      assert(result.status === 'success');
+      expect(result.content).toContain('src/app.ts');
+      expect(result.content).not.toContain('.env');
+      expect(result.content).not.toContain('.git/config');
+      expect(result.content).toContain(
+        'Some paths were skipped because they are blocked by file access policy',
+      );
+      expect(result.data.files).toContain('src/app.ts');
+      expect(result.data.files).not.toContain('.env');
+    });
+
+    it('skips symlinked files', async () => {
+      const target = await writeFile('target.ts', '');
+      await fs.symlink(target, path.join(tmpDir, 'link.ts'));
+
+      const result = await findFilesTool.execute({pattern: '**/*.ts'}, context);
+
+      expect(result.status).toBe('success');
+      assert(result.status === 'success');
+      expect(result.data.files).toContain('target.ts');
+      expect(result.data.files).not.toContain('link.ts');
+      expect(result.content).toContain(
+        'Some paths were skipped because they are blocked by file access policy',
+      );
+    });
   });
 
   describe('error cases', () => {
@@ -214,6 +248,24 @@ describe('findFilesTool', () => {
       expect(result.status).toBe('failure');
       assert(result.status === 'failure');
       expect(result.data.message).toBeTruthy();
+    });
+
+    it('denies a search root whose real target is blocked', async () => {
+      await fs.mkdir(path.join(tmpDir, '.git'), {recursive: true});
+      await fs.symlink(
+        path.join(tmpDir, '.git'),
+        path.join(tmpDir, 'git-link'),
+        'dir',
+      );
+
+      const result = await findFilesTool.execute(
+        {pattern: '**/*', path: 'git-link'},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
     });
 
     it('returns error for nonexistent directory', async () => {

--- a/apps/backend/src/agent/tools/file/find-files.test.ts
+++ b/apps/backend/src/agent/tools/file/find-files.test.ts
@@ -228,6 +228,21 @@ describe('findFilesTool', () => {
       expect(result.data.files).not.toContain('.env');
     });
 
+    it('appends the policy note when ignored sensitive directories are pruned', async () => {
+      await writeFile('.git/config', '[core]');
+
+      const result = await findFilesTool.execute({pattern: '**/*'}, context);
+
+      expect(result.status).toBe('success');
+      assert(result.status === 'success');
+      expect(result.data.files).toHaveLength(0);
+      expect(result.content).toContain('No files found matching');
+      expect(result.content).not.toContain('.git/config');
+      expect(result.content).toContain(
+        'Some paths were skipped because they are blocked by file access policy',
+      );
+    });
+
     it('skips symlinked files', async () => {
       const target = await writeFile('target.ts', '');
       await fs.symlink(target, path.join(tmpDir, 'link.ts'));

--- a/apps/backend/src/agent/tools/file/find-files.test.ts
+++ b/apps/backend/src/agent/tools/file/find-files.test.ts
@@ -221,6 +221,28 @@ describe('findFilesTool', () => {
         'Some paths were skipped because they are blocked by file access policy',
       );
     });
+
+    it('skips explicit traversal through symlinked directories', async () => {
+      await writeFile('real-project/.git/config', '[core]');
+      await fs.symlink(
+        path.join(tmpDir, 'real-project', '.git'),
+        path.join(tmpDir, 'safe-link'),
+        'dir',
+      );
+
+      const result = await findFilesTool.execute(
+        {pattern: 'safe-link/**'},
+        context,
+      );
+
+      expect(result.status).toBe('success');
+      assert(result.status === 'success');
+      expect(result.data.files).not.toContain('safe-link/config');
+      expect(result.content).not.toContain('safe-link/config');
+      expect(result.content).toContain(
+        'Some paths were skipped because they are blocked by file access policy',
+      );
+    });
   });
 
   describe('error cases', () => {
@@ -260,6 +282,24 @@ describe('findFilesTool', () => {
 
       const result = await findFilesTool.execute(
         {pattern: '**/*', path: 'git-link'},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+    });
+
+    it('denies a symlinked search root whose target is allowed', async () => {
+      await writeFile('real-src/file.ts', '');
+      await fs.symlink(
+        path.join(tmpDir, 'real-src'),
+        path.join(tmpDir, 'src-link'),
+        'dir',
+      );
+
+      const result = await findFilesTool.execute(
+        {pattern: '**/*', path: 'src-link'},
         context,
       );
 

--- a/apps/backend/src/agent/tools/file/find-files.ts
+++ b/apps/backend/src/agent/tools/file/find-files.ts
@@ -19,6 +19,7 @@ import type {
 import {
   checkExistingFileAccess,
   checkLexicalFileAccess,
+  getFileAccessPolicyGlobIgnorePatterns,
   isPathThroughSymbolicLink,
 } from './file-access-policy.js';
 import {
@@ -55,6 +56,29 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
       // 1. Resolve search directory
       const searchDir = path.resolve(workingDirectory, args.path ?? '.');
 
+      const lexicalRootPolicy = checkLexicalFileAccess(searchDir);
+      if (!lexicalRootPolicy.allowed) {
+        const message = formatBlockedFileAccessMessage(args.path ?? searchDir);
+        return {
+          data: {message},
+          content: message,
+          status: 'failure',
+        };
+      }
+
+      if (
+        await isPathThroughSymbolicLink(workingDirectory, searchDir, {
+          missingPathIsSymbolicLink: false,
+        })
+      ) {
+        const message = formatBlockedFileAccessMessage(args.path ?? searchDir);
+        return {
+          data: {message},
+          content: message,
+          status: 'failure',
+        };
+      }
+
       // 2. Verify directory exists
       let stat: Stats;
       try {
@@ -76,10 +100,7 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
       }
 
       const rootPolicy = await checkExistingFileAccess(searchDir);
-      if (
-        !rootPolicy.allowed ||
-        (await isPathThroughSymbolicLink(workingDirectory, searchDir))
-      ) {
+      if (!rootPolicy.allowed) {
         const message = formatBlockedFileAccessMessage(args.path ?? searchDir);
         return {
           data: {message},
@@ -94,6 +115,7 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
         onlyFiles: false,
         dot: true,
         followSymbolicLinks: false,
+        ignore: getFileAccessPolicyGlobIgnorePatterns(searchDir),
       });
 
       const entries: string[] = [];

--- a/apps/backend/src/agent/tools/file/find-files.ts
+++ b/apps/backend/src/agent/tools/file/find-files.ts
@@ -16,6 +16,15 @@ import type {
   ToolExecutionContext,
 } from '@/agent-core/tool/index.js';
 
+import {
+  checkExistingFileAccess,
+  checkLexicalFileAccess,
+  isSymbolicLinkPath,
+} from './file-access-policy.js';
+import {
+  formatBlockedFileAccessMessage,
+  skippedByFileAccessPolicyMessage,
+} from './file-access-policy-messages.js';
 import {searchFilesTool} from './search-files.js';
 
 const MAX_RESULTS = 100;
@@ -34,6 +43,9 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
     description:
       'Searches for files matching a glob pattern and returns their paths. ' +
       'Use this to locate files by name or extension (e.g., find all TypeScript files, locate a config file). ' +
+      'Symlinked directories and files are not traversed or returned. ' +
+      'If expected files are missing from results, review whether they are behind a symlink; ' +
+      'do not attempt to bypass file access policy. ' +
       `To search file contents instead, use ${searchFilesTool.name}.`,
     parameters,
     suppressToolEvents: false,
@@ -63,20 +75,53 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
         };
       }
 
+      const rootPolicy = await checkExistingFileAccess(searchDir);
+      if (!rootPolicy.allowed) {
+        const message = formatBlockedFileAccessMessage(args.path ?? searchDir);
+        return {
+          data: {message},
+          content: message,
+          status: 'failure',
+        };
+      }
+
       // 3. Run fast-glob with stream
       const stream = fg.stream(args.pattern, {
         cwd: searchDir,
-        onlyFiles: true,
+        onlyFiles: false,
         dot: true,
+        followSymbolicLinks: false,
       });
 
       const entries: string[] = [];
       let timedOut = false;
+      let skippedByPolicy = false;
 
       try {
         const startTime = Date.now();
         for await (const entry of stream) {
           assert(typeof entry === 'string');
+          const absoluteEntryPath = path.join(searchDir, entry);
+          const entryPolicy = checkLexicalFileAccess(absoluteEntryPath);
+          if (
+            !entryPolicy.allowed ||
+            (await isSymbolicLinkPath(absoluteEntryPath))
+          ) {
+            skippedByPolicy = true;
+            continue;
+          }
+
+          let entryStat: Stats;
+          try {
+            entryStat = await fs.stat(absoluteEntryPath);
+          } catch {
+            continue;
+          }
+
+          if (!entryStat.isFile()) {
+            continue;
+          }
+
           entries.push(entry);
           if (entries.length >= MAX_RESULTS) {
             break;
@@ -104,13 +149,17 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
       // 5. Format output
       const displayPath = args.path ?? workingDirectory;
       const hitLimit = entries.length >= MAX_RESULTS;
+      const policyNote = skippedByPolicy
+        ? `\n${skippedByFileAccessPolicyMessage}`
+        : '';
 
       if (entries.length === 0 && timedOut) {
+        const message = `No files found matching "${args.pattern}" in ${displayPath} (search timed out after 30s).${policyNote}`;
         return {
           data: {
-            message: `No files found matching "${args.pattern}" in ${displayPath} (search timed out after 30s).`,
+            message,
           },
-          content: `No files found matching "${args.pattern}" in ${displayPath} (search timed out after 30s).`,
+          content: message,
           status: 'failure',
         };
       }
@@ -124,7 +173,7 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
         };
         return {
           data,
-          content: `No files found matching "${args.pattern}" in ${displayPath}.`,
+          content: `No files found matching "${args.pattern}" in ${displayPath}.${policyNote}`,
           status: 'success',
         };
       }
@@ -135,9 +184,9 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
         const header = `Found ${entries.length} files matching "${args.pattern}" in ${displayPath} (search timed out after 30s):`;
         return {
           data: {
-            message: `${header} Results may be incomplete. Use a more specific pattern to narrow down.`,
+            message: `${header} Results may be incomplete. Use a more specific pattern to narrow down.${policyNote}`,
           },
-          content: `${header}\n${body}\nResults may be incomplete. Use a more specific pattern to narrow down.`,
+          content: `${header}\n${body}\nResults may be incomplete. Use a more specific pattern to narrow down.${policyNote}`,
           status: 'failure',
         };
       }
@@ -152,7 +201,7 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
         };
         return {
           data,
-          content: `${header}\n${body}\nUse a more specific pattern to narrow down.`,
+          content: `${header}\n${body}\nUse a more specific pattern to narrow down.${policyNote}`,
           status: 'success',
         };
       }
@@ -164,6 +213,10 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
         files: entries,
         truncated: false,
       };
-      return {data, content: `${header}\n${body}`, status: 'success'};
+      return {
+        data,
+        content: `${header}\n${body}${policyNote}`,
+        status: 'success',
+      };
     },
   };

--- a/apps/backend/src/agent/tools/file/find-files.ts
+++ b/apps/backend/src/agent/tools/file/find-files.ts
@@ -121,8 +121,10 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
 
       const entries: string[] = [];
       let timedOut = false;
-      let skippedByPolicy =
-        await hasFileAccessPolicyIgnoredDescendant(searchDir);
+      let skippedByPolicy = await hasFileAccessPolicyIgnoredDescendant(
+        searchDir,
+        args.pattern,
+      );
 
       try {
         const startTime = Date.now();

--- a/apps/backend/src/agent/tools/file/find-files.ts
+++ b/apps/backend/src/agent/tools/file/find-files.ts
@@ -20,6 +20,7 @@ import {
   checkExistingFileAccess,
   checkLexicalFileAccess,
   getFileAccessPolicyGlobIgnorePatterns,
+  hasFileAccessPolicyIgnoredDescendant,
   isPathThroughSymbolicLink,
 } from './file-access-policy.js';
 import {
@@ -120,7 +121,8 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
 
       const entries: string[] = [];
       let timedOut = false;
-      let skippedByPolicy = false;
+      let skippedByPolicy =
+        await hasFileAccessPolicyIgnoredDescendant(searchDir);
 
       try {
         const startTime = Date.now();

--- a/apps/backend/src/agent/tools/file/find-files.ts
+++ b/apps/backend/src/agent/tools/file/find-files.ts
@@ -19,6 +19,7 @@ import type {
 import {
   checkExistingFileAccess,
   checkLexicalFileAccess,
+  isPathThroughSymbolicLink,
   isSymbolicLinkPath,
 } from './file-access-policy.js';
 import {
@@ -76,7 +77,7 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
       }
 
       const rootPolicy = await checkExistingFileAccess(searchDir);
-      if (!rootPolicy.allowed) {
+      if (!rootPolicy.allowed || (await isSymbolicLinkPath(searchDir))) {
         const message = formatBlockedFileAccessMessage(args.path ?? searchDir);
         return {
           data: {message},
@@ -105,8 +106,15 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
           const entryPolicy = checkLexicalFileAccess(absoluteEntryPath);
           if (
             !entryPolicy.allowed ||
-            (await isSymbolicLinkPath(absoluteEntryPath))
+            (await isPathThroughSymbolicLink(searchDir, absoluteEntryPath))
           ) {
+            skippedByPolicy = true;
+            continue;
+          }
+
+          const realEntryPolicy =
+            await checkExistingFileAccess(absoluteEntryPath);
+          if (!realEntryPolicy.allowed) {
             skippedByPolicy = true;
             continue;
           }

--- a/apps/backend/src/agent/tools/file/find-files.ts
+++ b/apps/backend/src/agent/tools/file/find-files.ts
@@ -20,7 +20,6 @@ import {
   checkExistingFileAccess,
   checkLexicalFileAccess,
   isPathThroughSymbolicLink,
-  isSymbolicLinkPath,
 } from './file-access-policy.js';
 import {
   formatBlockedFileAccessMessage,
@@ -77,7 +76,10 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
       }
 
       const rootPolicy = await checkExistingFileAccess(searchDir);
-      if (!rootPolicy.allowed || (await isSymbolicLinkPath(searchDir))) {
+      if (
+        !rootPolicy.allowed ||
+        (await isPathThroughSymbolicLink(workingDirectory, searchDir))
+      ) {
         const message = formatBlockedFileAccessMessage(args.path ?? searchDir);
         return {
           data: {message},
@@ -106,7 +108,10 @@ export const findFilesTool: ToolDefinition<typeof parameters, FindFilesResult> =
           const entryPolicy = checkLexicalFileAccess(absoluteEntryPath);
           if (
             !entryPolicy.allowed ||
-            (await isPathThroughSymbolicLink(searchDir, absoluteEntryPath))
+            (await isPathThroughSymbolicLink(
+              workingDirectory,
+              absoluteEntryPath,
+            ))
           ) {
             skippedByPolicy = true;
             continue;

--- a/apps/backend/src/agent/tools/file/read-file.test.ts
+++ b/apps/backend/src/agent/tools/file/read-file.test.ts
@@ -208,6 +208,8 @@ describe('readFileTool', () => {
       expect(result.status).toBe('failure');
       assert(result.status === 'failure');
       expect(result.content).toContain('Access denied by file access policy');
+      expect(result.content).toContain('env-link');
+      expect(result.content).not.toContain(target);
     });
 
     it('returns error for nonexistent file', async () => {

--- a/apps/backend/src/agent/tools/file/read-file.test.ts
+++ b/apps/backend/src/agent/tools/file/read-file.test.ts
@@ -183,6 +183,33 @@ describe('readFileTool', () => {
   });
 
   describe('error cases', () => {
+    it('denies blocked direct paths before reading', async () => {
+      await writeFile('.env', 'SECRET=value');
+
+      const result = await readFileTool.execute({filePath: '.env'}, context);
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+      expect(result.content).toContain('Review the file access operation');
+      expect(result.content).toContain('ask the user to perform it manually');
+    });
+
+    it('denies symlink paths whose real target is blocked', async () => {
+      const target = await writeFile('.env.local', 'SECRET=value');
+      const link = path.join(tmpDir, 'env-link');
+      await fs.symlink(target, link);
+
+      const result = await readFileTool.execute(
+        {filePath: 'env-link'},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+    });
+
     it('returns error for nonexistent file', async () => {
       const result = await readFileTool.execute(
         {filePath: 'nope.txt'},

--- a/apps/backend/src/agent/tools/file/read-file.ts
+++ b/apps/backend/src/agent/tools/file/read-file.ts
@@ -15,6 +15,11 @@ import type {
 } from '@/agent-core/tool/index.js';
 
 import {
+  checkExistingFileAccess,
+  checkLexicalFileAccess,
+} from './file-access-policy.js';
+import {formatBlockedFileAccessMessage} from './file-access-policy-messages.js';
+import {
   countLines,
   formatWithLineNumbers,
   isBinaryFile,
@@ -47,6 +52,12 @@ export const readFileTool: ToolDefinition<typeof parameters, ReadFileResult> = {
     // 1. Resolve path
     const absolutePath = path.resolve(workingDirectory, args.filePath);
 
+    const lexicalPolicyResult = checkLexicalFileAccess(absolutePath);
+    if (!lexicalPolicyResult.allowed) {
+      const message = formatBlockedFileAccessMessage(args.filePath);
+      return {data: {message}, content: message, status: 'failure'};
+    }
+
     // 2. Stat
     let stat: Stats;
     try {
@@ -65,6 +76,12 @@ export const readFileTool: ToolDefinition<typeof parameters, ReadFileResult> = {
         content: `Error: Not a file: ${args.filePath}`,
         status: 'failure',
       };
+    }
+
+    const policyResult = await checkExistingFileAccess(absolutePath);
+    if (!policyResult.allowed) {
+      const message = formatBlockedFileAccessMessage(args.filePath);
+      return {data: {message}, content: message, status: 'failure'};
     }
 
     // 3. Binary check

--- a/apps/backend/src/agent/tools/file/search-files.test.ts
+++ b/apps/backend/src/agent/tools/file/search-files.test.ts
@@ -278,6 +278,23 @@ describe('searchFilesTool', () => {
       expect(result.data.matches.map((m) => m.file)).toEqual(['src/app.ts']);
     });
 
+    it('appends the policy note when ignored sensitive directories are pruned', async () => {
+      await writeFile('.git/config', 'target\n');
+
+      const result = await searchFilesTool.execute(
+        {pattern: 'target'},
+        context,
+      );
+
+      expect(result.status).toBe('success');
+      assert(result.status === 'success');
+      expect(result.data.matches).toHaveLength(0);
+      expect(result.content).not.toContain('.git/config');
+      expect(result.content).toContain(
+        'Some paths were skipped because they are blocked by file access policy',
+      );
+    });
+
     it('skips symlinked files', async () => {
       const target = await writeFile('target.ts', 'target\n');
       await fs.symlink(target, path.join(tmpDir, 'link.ts'));

--- a/apps/backend/src/agent/tools/file/search-files.test.ts
+++ b/apps/backend/src/agent/tools/file/search-files.test.ts
@@ -236,6 +236,44 @@ describe('searchFilesTool', () => {
       expect(result.data.truncated).toBe(true);
     });
 
+    it('skips blocked paths and appends the policy note', async () => {
+      await writeFile('src/app.ts', 'target\n');
+      await writeFile('.env', 'target\n');
+      await writeFile('.git/config', 'target\n');
+
+      const result = await searchFilesTool.execute(
+        {pattern: 'target'},
+        context,
+      );
+
+      expect(result.status).toBe('success');
+      assert(result.status === 'success');
+      expect(result.content).toContain('src/app.ts:1: target');
+      expect(result.content).not.toContain('.env');
+      expect(result.content).not.toContain('.git/config');
+      expect(result.content).toContain(
+        'Some paths were skipped because they are blocked by file access policy',
+      );
+      expect(result.data.matches.map((m) => m.file)).toEqual(['src/app.ts']);
+    });
+
+    it('skips symlinked files', async () => {
+      const target = await writeFile('target.ts', 'target\n');
+      await fs.symlink(target, path.join(tmpDir, 'link.ts'));
+
+      const result = await searchFilesTool.execute(
+        {pattern: 'target'},
+        context,
+      );
+
+      expect(result.status).toBe('success');
+      assert(result.status === 'success');
+      expect(result.data.matches.map((m) => m.file)).toEqual(['target.ts']);
+      expect(result.content).toContain(
+        'Some paths were skipped because they are blocked by file access policy',
+      );
+    });
+
     it('returns partial results on timeout', async () => {
       await writeFile('a.ts', 'match\n');
 
@@ -268,6 +306,24 @@ describe('searchFilesTool', () => {
       expect(result.status).toBe('failure');
       assert(result.status === 'failure');
       expect(result.data.message).toBeTruthy();
+    });
+
+    it('denies a search root whose real target is blocked', async () => {
+      await fs.mkdir(path.join(tmpDir, '.git'), {recursive: true});
+      await fs.symlink(
+        path.join(tmpDir, '.git'),
+        path.join(tmpDir, 'git-link'),
+        'dir',
+      );
+
+      const result = await searchFilesTool.execute(
+        {pattern: 'anything', path: 'git-link'},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
     });
 
     it('returns error for invalid regex', async () => {

--- a/apps/backend/src/agent/tools/file/search-files.test.ts
+++ b/apps/backend/src/agent/tools/file/search-files.test.ts
@@ -274,6 +274,29 @@ describe('searchFilesTool', () => {
       );
     });
 
+    it('skips explicit traversal through symlinked directories', async () => {
+      await writeFile('real-project/.git/config', 'target\n');
+      await fs.symlink(
+        path.join(tmpDir, 'real-project', '.git'),
+        path.join(tmpDir, 'safe-link'),
+        'dir',
+      );
+
+      const result = await searchFilesTool.execute(
+        {pattern: 'target', filePattern: 'safe-link/**'},
+        context,
+      );
+
+      expect(result.status).toBe('success');
+      assert(result.status === 'success');
+      expect(result.data.matches).toHaveLength(0);
+      expect(result.content).not.toContain('safe-link/config');
+      expect(result.content).not.toContain('target');
+      expect(result.content).toContain(
+        'Some paths were skipped because they are blocked by file access policy',
+      );
+    });
+
     it('returns partial results on timeout', async () => {
       await writeFile('a.ts', 'match\n');
 
@@ -318,6 +341,24 @@ describe('searchFilesTool', () => {
 
       const result = await searchFilesTool.execute(
         {pattern: 'anything', path: 'git-link'},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+    });
+
+    it('denies a symlinked search root whose target is allowed', async () => {
+      await writeFile('real-src/file.ts', 'target\n');
+      await fs.symlink(
+        path.join(tmpDir, 'real-src'),
+        path.join(tmpDir, 'src-link'),
+        'dir',
+      );
+
+      const result = await searchFilesTool.execute(
+        {pattern: 'target', path: 'src-link'},
         context,
       );
 

--- a/apps/backend/src/agent/tools/file/search-files.test.ts
+++ b/apps/backend/src/agent/tools/file/search-files.test.ts
@@ -291,10 +291,34 @@ describe('searchFilesTool', () => {
       assert(result.status === 'success');
       expect(result.data.matches).toHaveLength(0);
       expect(result.content).not.toContain('safe-link/config');
-      expect(result.content).not.toContain('target');
+      expect(result.content).toContain('No matches found for /target/');
       expect(result.content).toContain(
         'Some paths were skipped because they are blocked by file access policy',
       );
+    });
+
+    it('denies a symlinked working directory before searching', async () => {
+      const realWorkspace = path.join(tmpDir, 'real-workspace');
+      const workspaceLink = path.join(tmpDir, 'workspace-link');
+      await fs.mkdir(path.join(realWorkspace, 'sub'), {recursive: true});
+      await fs.writeFile(
+        path.join(realWorkspace, 'sub', 'file.ts'),
+        'target\n',
+      );
+      await fs.symlink(realWorkspace, workspaceLink, 'dir');
+      const linkContext = createMockContext({
+        workingDirectory: workspaceLink,
+        fileCache: new FileContentCache(),
+      });
+
+      const result = await searchFilesTool.execute(
+        {pattern: 'target', path: 'sub'},
+        linkContext,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
     });
 
     it('returns partial results on timeout', async () => {
@@ -347,6 +371,20 @@ describe('searchFilesTool', () => {
       expect(result.status).toBe('failure');
       assert(result.status === 'failure');
       expect(result.content).toContain('Access denied by file access policy');
+    });
+
+    it('denies blocked file roots before checking directory type', async () => {
+      await writeFile('.env', 'target\n');
+
+      const result = await searchFilesTool.execute(
+        {pattern: 'target', path: '.env'},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+      expect(result.content).not.toContain('Not a directory');
     });
 
     it('denies a symlinked search root whose target is allowed', async () => {

--- a/apps/backend/src/agent/tools/file/search-files.test.ts
+++ b/apps/backend/src/agent/tools/file/search-files.test.ts
@@ -169,6 +169,27 @@ describe('searchFilesTool', () => {
       expect(result.data.matches).toHaveLength(1);
     });
 
+    it('searches allowed absolute paths outside the working directory', async () => {
+      const externalDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), 'sft-external-'),
+      );
+      try {
+        await fs.writeFile(path.join(externalDir, 'external.ts'), 'target\n');
+
+        const result = await searchFilesTool.execute(
+          {pattern: 'target', path: externalDir},
+          context,
+        );
+
+        expect(result.status).toBe('success');
+        assert(result.status === 'success');
+        expect(result.content).toContain('external.ts:1: target');
+        expect(result.data.matches.map((m) => m.file)).toEqual(['external.ts']);
+      } finally {
+        await fs.rm(externalDir, {recursive: true, force: true});
+      }
+    });
+
     it('returns no-match message when nothing found', async () => {
       await writeFile('a.ts', 'hello\n');
 
@@ -313,6 +334,31 @@ describe('searchFilesTool', () => {
 
       const result = await searchFilesTool.execute(
         {pattern: 'target', path: 'sub'},
+        linkContext,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+    });
+
+    it('denies a working directory below a symlinked ancestor', async () => {
+      const realWorkspace = path.join(tmpDir, 'real-workspace');
+      const workspaceLink = path.join(tmpDir, 'workspace-link');
+      const linkSubdir = path.join(workspaceLink, 'sub');
+      await fs.mkdir(path.join(realWorkspace, 'sub'), {recursive: true});
+      await fs.writeFile(
+        path.join(realWorkspace, 'sub', 'file.ts'),
+        'target\n',
+      );
+      await fs.symlink(realWorkspace, workspaceLink, 'dir');
+      const linkContext = createMockContext({
+        workingDirectory: linkSubdir,
+        fileCache: new FileContentCache(),
+      });
+
+      const result = await searchFilesTool.execute(
+        {pattern: 'target'},
         linkContext,
       );
 

--- a/apps/backend/src/agent/tools/file/search-files.test.ts
+++ b/apps/backend/src/agent/tools/file/search-files.test.ts
@@ -295,6 +295,23 @@ describe('searchFilesTool', () => {
       );
     });
 
+    it('does not append the policy note for ignored sensitive directories outside the file pattern scope', async () => {
+      await writeFile('.git/config', 'target\n');
+      await writeFile('src/app.ts', 'target\n');
+
+      const result = await searchFilesTool.execute(
+        {pattern: 'target', filePattern: 'src/*.ts'},
+        context,
+      );
+
+      expect(result.status).toBe('success');
+      assert(result.status === 'success');
+      expect(result.data.matches.map((m) => m.file)).toEqual(['src/app.ts']);
+      expect(result.content).not.toContain(
+        'Some paths were skipped because they are blocked by file access policy',
+      );
+    });
+
     it('skips symlinked files', async () => {
       const target = await writeFile('target.ts', 'target\n');
       await fs.symlink(target, path.join(tmpDir, 'link.ts'));

--- a/apps/backend/src/agent/tools/file/search-files.test.ts
+++ b/apps/backend/src/agent/tools/file/search-files.test.ts
@@ -367,6 +367,24 @@ describe('searchFilesTool', () => {
       expect(result.content).toContain('Access denied by file access policy');
     });
 
+    it('denies a search root below a symlinked directory', async () => {
+      await writeFile('real-src/subdir/file.ts', 'target\n');
+      await fs.symlink(
+        path.join(tmpDir, 'real-src'),
+        path.join(tmpDir, 'src-link'),
+        'dir',
+      );
+
+      const result = await searchFilesTool.execute(
+        {pattern: 'target', path: 'src-link/subdir'},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+    });
+
     it('returns error for invalid regex', async () => {
       await writeFile('a.ts', 'hello\n');
 

--- a/apps/backend/src/agent/tools/file/search-files.ts
+++ b/apps/backend/src/agent/tools/file/search-files.ts
@@ -19,6 +19,15 @@ import type {
   ToolExecutionContext,
 } from '@/agent-core/tool/index.js';
 
+import {
+  checkExistingFileAccess,
+  checkLexicalFileAccess,
+  isSymbolicLinkPath,
+} from './file-access-policy.js';
+import {
+  formatBlockedFileAccessMessage,
+  skippedByFileAccessPolicyMessage,
+} from './file-access-policy-messages.js';
 import {isBinaryFile} from './helpers.js';
 
 const MAX_MATCHES = 100;
@@ -85,7 +94,10 @@ export const searchFilesTool: ToolDefinition<
   displayName: 'Search Files',
   description:
     'Searches file contents for a regex pattern and returns matching lines with file paths and line numbers. ' +
-    'Use this to find where a specific string or pattern appears across files.',
+    'Use this to find where a specific string or pattern appears across files. ' +
+    'Symlinked directories and files are not traversed or searched. ' +
+    'If expected matches are missing, review whether the files are behind a symlink; ' +
+    'do not attempt to bypass file access policy.',
   parameters,
   suppressToolEvents: false,
   async execute(args: SearchFilesArgs, context: ToolExecutionContext) {
@@ -110,6 +122,16 @@ export const searchFilesTool: ToolDefinition<
       return {
         data: {message: `Not a directory: ${args.path}`},
         content: `Error: Not a directory: ${args.path}`,
+        status: 'failure',
+      };
+    }
+
+    const rootPolicy = await checkExistingFileAccess(searchDir);
+    if (!rootPolicy.allowed) {
+      const message = formatBlockedFileAccessMessage(args.path ?? searchDir);
+      return {
+        data: {message},
+        content: message,
         status: 'failure',
       };
     }
@@ -142,13 +164,15 @@ export const searchFilesTool: ToolDefinition<
     // 4. Enumerate files and search concurrently
     const stream = fg.stream(args.filePattern ?? '**/*', {
       cwd: searchDir,
-      onlyFiles: true,
+      onlyFiles: false,
       dot: true,
+      followSymbolicLinks: false,
     });
 
     const results: FileSearchResult[] = [];
     let totalMatches = 0;
     let timedOut = false;
+    let skippedByPolicy = false;
     const startTime = Date.now();
     const controller = new AbortController();
 
@@ -164,6 +188,23 @@ export const searchFilesTool: ToolDefinition<
 
         assert(typeof entry === 'string');
         const absolutePath = path.join(searchDir, entry);
+        const entryPolicy = checkLexicalFileAccess(absolutePath);
+        if (!entryPolicy.allowed || (await isSymbolicLinkPath(absolutePath))) {
+          skippedByPolicy = true;
+          continue;
+        }
+
+        let entryStat: Stats;
+        try {
+          entryStat = await fs.stat(absolutePath);
+        } catch {
+          continue;
+        }
+
+        if (!entryStat.isFile()) {
+          continue;
+        }
+
         const relativePath = entry;
 
         const task = (async () => {
@@ -224,6 +265,9 @@ export const searchFilesTool: ToolDefinition<
     // 6. Format output
     const displayPath = args.path ?? workingDirectory;
     const hitLimit = totalMatches >= MAX_MATCHES;
+    const policyNote = skippedByPolicy
+      ? `\n${skippedByFileAccessPolicyMessage}`
+      : '';
 
     // Build flat matches for structured data
     const flatMatches = results.flatMap((r) =>
@@ -235,11 +279,12 @@ export const searchFilesTool: ToolDefinition<
     );
 
     if (totalMatches === 0 && timedOut) {
+      const message = `No matches found for /${args.pattern}/ in ${displayPath} (search timed out after 30s).${policyNote}`;
       return {
         data: {
-          message: `No matches found for /${args.pattern}/ in ${displayPath} (search timed out after 30s).`,
+          message,
         },
-        content: `No matches found for /${args.pattern}/ in ${displayPath} (search timed out after 30s).`,
+        content: message,
         status: 'failure',
       };
     }
@@ -253,7 +298,7 @@ export const searchFilesTool: ToolDefinition<
       };
       return {
         data,
-        content: `No matches found for /${args.pattern}/ in ${displayPath}.`,
+        content: `No matches found for /${args.pattern}/ in ${displayPath}.${policyNote}`,
         status: 'success',
       };
     }
@@ -275,9 +320,9 @@ export const searchFilesTool: ToolDefinition<
       const header = `Found ${count} matches for /${args.pattern}/ in ${displayPath} (search timed out after 30s):`;
       return {
         data: {
-          message: `${header} Results may be incomplete. Use a more specific pattern to narrow down.`,
+          message: `${header} Results may be incomplete. Use a more specific pattern to narrow down.${policyNote}`,
         },
-        content: `${header}\n${body}\nResults may be incomplete. Use a more specific pattern to narrow down.`,
+        content: `${header}\n${body}\nResults may be incomplete. Use a more specific pattern to narrow down.${policyNote}`,
         status: 'failure',
       };
     }
@@ -292,7 +337,7 @@ export const searchFilesTool: ToolDefinition<
       };
       return {
         data,
-        content: `${header}\n${body}\nUse a more specific pattern to narrow down.`,
+        content: `${header}\n${body}\nUse a more specific pattern to narrow down.${policyNote}`,
         status: 'success',
       };
     }
@@ -304,6 +349,10 @@ export const searchFilesTool: ToolDefinition<
       matches: flatMatches,
       truncated: false,
     };
-    return {data, content: `${header}\n${body}`, status: 'success'};
+    return {
+      data,
+      content: `${header}\n${body}${policyNote}`,
+      status: 'success',
+    };
   },
 };

--- a/apps/backend/src/agent/tools/file/search-files.ts
+++ b/apps/backend/src/agent/tools/file/search-files.ts
@@ -22,6 +22,7 @@ import type {
 import {
   checkExistingFileAccess,
   checkLexicalFileAccess,
+  isPathThroughSymbolicLink,
   isSymbolicLinkPath,
 } from './file-access-policy.js';
 import {
@@ -127,7 +128,7 @@ export const searchFilesTool: ToolDefinition<
     }
 
     const rootPolicy = await checkExistingFileAccess(searchDir);
-    if (!rootPolicy.allowed) {
+    if (!rootPolicy.allowed || (await isSymbolicLinkPath(searchDir))) {
       const message = formatBlockedFileAccessMessage(args.path ?? searchDir);
       return {
         data: {message},
@@ -189,7 +190,16 @@ export const searchFilesTool: ToolDefinition<
         assert(typeof entry === 'string');
         const absolutePath = path.join(searchDir, entry);
         const entryPolicy = checkLexicalFileAccess(absolutePath);
-        if (!entryPolicy.allowed || (await isSymbolicLinkPath(absolutePath))) {
+        if (
+          !entryPolicy.allowed ||
+          (await isPathThroughSymbolicLink(searchDir, absolutePath))
+        ) {
+          skippedByPolicy = true;
+          continue;
+        }
+
+        const realEntryPolicy = await checkExistingFileAccess(absolutePath);
+        if (!realEntryPolicy.allowed) {
           skippedByPolicy = true;
           continue;
         }
@@ -296,9 +306,12 @@ export const searchFilesTool: ToolDefinition<
         matches: [],
         truncated: false,
       };
+      const content = skippedByPolicy
+        ? `No matches found in ${displayPath}.${policyNote}`
+        : `No matches found for /${args.pattern}/ in ${displayPath}.`;
       return {
         data,
-        content: `No matches found for /${args.pattern}/ in ${displayPath}.${policyNote}`,
+        content,
         status: 'success',
       };
     }

--- a/apps/backend/src/agent/tools/file/search-files.ts
+++ b/apps/backend/src/agent/tools/file/search-files.ts
@@ -198,7 +198,10 @@ export const searchFilesTool: ToolDefinition<
     const results: FileSearchResult[] = [];
     let totalMatches = 0;
     let timedOut = false;
-    let skippedByPolicy = await hasFileAccessPolicyIgnoredDescendant(searchDir);
+    let skippedByPolicy = await hasFileAccessPolicyIgnoredDescendant(
+      searchDir,
+      args.filePattern ?? '**/*',
+    );
     const startTime = Date.now();
     const controller = new AbortController();
 

--- a/apps/backend/src/agent/tools/file/search-files.ts
+++ b/apps/backend/src/agent/tools/file/search-files.ts
@@ -22,6 +22,7 @@ import type {
 import {
   checkExistingFileAccess,
   checkLexicalFileAccess,
+  getFileAccessPolicyGlobIgnorePatterns,
   isPathThroughSymbolicLink,
 } from './file-access-policy.js';
 import {
@@ -106,6 +107,29 @@ export const searchFilesTool: ToolDefinition<
     // 1. Resolve search directory
     const searchDir = path.resolve(workingDirectory, args.path ?? '.');
 
+    const lexicalRootPolicy = checkLexicalFileAccess(searchDir);
+    if (!lexicalRootPolicy.allowed) {
+      const message = formatBlockedFileAccessMessage(args.path ?? searchDir);
+      return {
+        data: {message},
+        content: message,
+        status: 'failure',
+      };
+    }
+
+    if (
+      await isPathThroughSymbolicLink(workingDirectory, searchDir, {
+        missingPathIsSymbolicLink: false,
+      })
+    ) {
+      const message = formatBlockedFileAccessMessage(args.path ?? searchDir);
+      return {
+        data: {message},
+        content: message,
+        status: 'failure',
+      };
+    }
+
     // 2. Verify directory exists
     let stat: Stats;
     try {
@@ -127,10 +151,7 @@ export const searchFilesTool: ToolDefinition<
     }
 
     const rootPolicy = await checkExistingFileAccess(searchDir);
-    if (
-      !rootPolicy.allowed ||
-      (await isPathThroughSymbolicLink(workingDirectory, searchDir))
-    ) {
+    if (!rootPolicy.allowed) {
       const message = formatBlockedFileAccessMessage(args.path ?? searchDir);
       return {
         data: {message},
@@ -170,6 +191,7 @@ export const searchFilesTool: ToolDefinition<
       onlyFiles: false,
       dot: true,
       followSymbolicLinks: false,
+      ignore: getFileAccessPolicyGlobIgnorePatterns(searchDir),
     });
 
     const results: FileSearchResult[] = [];
@@ -308,12 +330,9 @@ export const searchFilesTool: ToolDefinition<
         matches: [],
         truncated: false,
       };
-      const content = skippedByPolicy
-        ? `No matches found in ${displayPath}.${policyNote}`
-        : `No matches found for /${args.pattern}/ in ${displayPath}.`;
       return {
         data,
-        content,
+        content: `No matches found for /${args.pattern}/ in ${displayPath}.${policyNote}`,
         status: 'success',
       };
     }

--- a/apps/backend/src/agent/tools/file/search-files.ts
+++ b/apps/backend/src/agent/tools/file/search-files.ts
@@ -23,7 +23,6 @@ import {
   checkExistingFileAccess,
   checkLexicalFileAccess,
   isPathThroughSymbolicLink,
-  isSymbolicLinkPath,
 } from './file-access-policy.js';
 import {
   formatBlockedFileAccessMessage,
@@ -128,7 +127,10 @@ export const searchFilesTool: ToolDefinition<
     }
 
     const rootPolicy = await checkExistingFileAccess(searchDir);
-    if (!rootPolicy.allowed || (await isSymbolicLinkPath(searchDir))) {
+    if (
+      !rootPolicy.allowed ||
+      (await isPathThroughSymbolicLink(workingDirectory, searchDir))
+    ) {
       const message = formatBlockedFileAccessMessage(args.path ?? searchDir);
       return {
         data: {message},
@@ -192,7 +194,7 @@ export const searchFilesTool: ToolDefinition<
         const entryPolicy = checkLexicalFileAccess(absolutePath);
         if (
           !entryPolicy.allowed ||
-          (await isPathThroughSymbolicLink(searchDir, absolutePath))
+          (await isPathThroughSymbolicLink(workingDirectory, absolutePath))
         ) {
           skippedByPolicy = true;
           continue;

--- a/apps/backend/src/agent/tools/file/search-files.ts
+++ b/apps/backend/src/agent/tools/file/search-files.ts
@@ -23,6 +23,7 @@ import {
   checkExistingFileAccess,
   checkLexicalFileAccess,
   getFileAccessPolicyGlobIgnorePatterns,
+  hasFileAccessPolicyIgnoredDescendant,
   isPathThroughSymbolicLink,
 } from './file-access-policy.js';
 import {
@@ -197,7 +198,7 @@ export const searchFilesTool: ToolDefinition<
     const results: FileSearchResult[] = [];
     let totalMatches = 0;
     let timedOut = false;
-    let skippedByPolicy = false;
+    let skippedByPolicy = await hasFileAccessPolicyIgnoredDescendant(searchDir);
     const startTime = Date.now();
     const controller = new AbortController();
 

--- a/apps/backend/src/agent/tools/file/write-file.test.ts
+++ b/apps/backend/src/agent/tools/file/write-file.test.ts
@@ -163,6 +163,19 @@ describe('writeFileTool', () => {
       await expect(fs.stat(path.join(tmpDir, '.env.local'))).rejects.toThrow();
     });
 
+    it('denies blocked paths before checking oversized content', async () => {
+      const bigContent = 'x'.repeat(1_048_577);
+      const result = await writeFileTool.execute(
+        {filePath: '.env.local', content: bigContent},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+      expect(result.content).not.toContain('Content exceeds');
+    });
+
     it('denies overwriting an existing blocked path', async () => {
       const filePath = path.join(tmpDir, '.env');
       await fs.writeFile(filePath, 'old');

--- a/apps/backend/src/agent/tools/file/write-file.test.ts
+++ b/apps/backend/src/agent/tools/file/write-file.test.ts
@@ -212,6 +212,24 @@ describe('writeFileTool', () => {
       expect(result.content).toContain('Access denied by file access policy');
     });
 
+    it('denies oversized writes through a symlinked parent before checking content size', async () => {
+      const realProject = path.join(tmpDir, 'real-project');
+      const linkProject = path.join(tmpDir, 'link-safe');
+      const bigContent = 'x'.repeat(1_048_577);
+      await fs.mkdir(path.join(realProject, '.git'), {recursive: true});
+      await fs.symlink(path.join(realProject, '.git'), linkProject, 'dir');
+
+      const result = await writeFileTool.execute(
+        {filePath: 'link-safe/config', content: bigContent},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+      expect(result.content).not.toContain('Content exceeds');
+    });
+
     it('returns a tool failure for allowed broken symlink paths', async () => {
       await fs.symlink(
         'missing-target.txt',

--- a/apps/backend/src/agent/tools/file/write-file.test.ts
+++ b/apps/backend/src/agent/tools/file/write-file.test.ts
@@ -212,6 +212,22 @@ describe('writeFileTool', () => {
       expect(result.content).toContain('Access denied by file access policy');
     });
 
+    it('returns a tool failure for allowed broken symlink paths', async () => {
+      await fs.symlink(
+        'missing-target.txt',
+        path.join(tmpDir, 'broken-link.txt'),
+      );
+
+      const result = await writeFileTool.execute(
+        {filePath: 'broken-link.txt', content: 'new'},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Error:');
+    });
+
     it('rejects content exceeding 1MB', async () => {
       const bigContent = 'x'.repeat(1_048_577);
       const result = await writeFileTool.execute(

--- a/apps/backend/src/agent/tools/file/write-file.test.ts
+++ b/apps/backend/src/agent/tools/file/write-file.test.ts
@@ -151,6 +151,54 @@ describe('writeFileTool', () => {
   });
 
   describe('error cases', () => {
+    it('denies writing a new blocked path', async () => {
+      const result = await writeFileTool.execute(
+        {filePath: '.env.local', content: 'SECRET=value'},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+      await expect(fs.stat(path.join(tmpDir, '.env.local'))).rejects.toThrow();
+    });
+
+    it('denies overwriting an existing blocked path', async () => {
+      const filePath = path.join(tmpDir, '.env');
+      await fs.writeFile(filePath, 'old');
+      context.fileStatTracker.set(
+        filePath,
+        3,
+        (await fs.stat(filePath)).mtimeMs,
+      );
+
+      const result = await writeFileTool.execute(
+        {filePath: '.env', content: 'new'},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+      await expect(fs.readFile(filePath, 'utf-8')).resolves.toBe('old');
+    });
+
+    it('denies new writes through a symlinked parent to a blocked real target', async () => {
+      const realProject = path.join(tmpDir, 'real-project');
+      const linkProject = path.join(tmpDir, 'link-project');
+      await fs.mkdir(path.join(realProject, '.git'), {recursive: true});
+      await fs.symlink(realProject, linkProject, 'dir');
+
+      const result = await writeFileTool.execute(
+        {filePath: 'link-project/.git/new-config', content: 'content'},
+        context,
+      );
+
+      expect(result.status).toBe('failure');
+      assert(result.status === 'failure');
+      expect(result.content).toContain('Access denied by file access policy');
+    });
+
     it('rejects content exceeding 1MB', async () => {
       const bigContent = 'x'.repeat(1_048_577);
       const result = await writeFileTool.execute(

--- a/apps/backend/src/agent/tools/file/write-file.ts
+++ b/apps/backend/src/agent/tools/file/write-file.ts
@@ -15,6 +15,12 @@ import type {
   ToolExecutionContext,
 } from '@/agent-core/tool/index.js';
 
+import {
+  checkExistingFileAccess,
+  checkLexicalFileAccess,
+  checkNewFileAccess,
+} from './file-access-policy.js';
+import {formatBlockedFileAccessMessage} from './file-access-policy-messages.js';
 import {countLines} from './helpers.js';
 
 const MAX_CONTENT_SIZE = 1_048_576; // 1MB
@@ -52,12 +58,34 @@ export const writeFileTool: ToolDefinition<typeof parameters, WriteFileResult> =
       // 2. Resolve path
       const absolutePath = path.resolve(workingDirectory, args.filePath);
 
+      const lexicalPolicyResult = checkLexicalFileAccess(absolutePath);
+      if (!lexicalPolicyResult.allowed) {
+        const message = formatBlockedFileAccessMessage(args.filePath);
+        return {
+          data: {message},
+          content: message,
+          status: 'failure',
+        };
+      }
+
       // 3. Check if file exists — if so, verify it was read first
       let existingStat: Stats | null = null;
       try {
         existingStat = await fs.stat(absolutePath);
       } catch {
         // File doesn't exist, which is fine for write_file
+      }
+
+      const policyResult = existingStat
+        ? await checkExistingFileAccess(absolutePath)
+        : await checkNewFileAccess(absolutePath);
+      if (!policyResult.allowed) {
+        const message = formatBlockedFileAccessMessage(args.filePath);
+        return {
+          data: {message},
+          content: message,
+          status: 'failure',
+        };
       }
 
       if (existingStat) {

--- a/apps/backend/src/agent/tools/file/write-file.ts
+++ b/apps/backend/src/agent/tools/file/write-file.ts
@@ -59,16 +59,7 @@ export const writeFileTool: ToolDefinition<typeof parameters, WriteFileResult> =
         };
       }
 
-      // 2. Check content size
-      if (Buffer.byteLength(args.content) > MAX_CONTENT_SIZE) {
-        return {
-          data: {message: `Content exceeds ${MAX_CONTENT_SIZE} byte limit`},
-          content: `Error: Content exceeds ${MAX_CONTENT_SIZE} byte limit`,
-          status: 'failure',
-        };
-      }
-
-      // 3. Check if file exists — if so, verify it was read first
+      // 2. Check if file exists — if so, verify it was read first
       let existingStat: Stats | null = null;
       try {
         existingStat = await fs.stat(absolutePath);
@@ -94,6 +85,15 @@ export const writeFileTool: ToolDefinition<typeof parameters, WriteFileResult> =
         return {
           data: {message},
           content: message,
+          status: 'failure',
+        };
+      }
+
+      // 3. Check content size
+      if (Buffer.byteLength(args.content) > MAX_CONTENT_SIZE) {
+        return {
+          data: {message: `Content exceeds ${MAX_CONTENT_SIZE} byte limit`},
+          content: `Error: Content exceeds ${MAX_CONTENT_SIZE} byte limit`,
           status: 'failure',
         };
       }

--- a/apps/backend/src/agent/tools/file/write-file.ts
+++ b/apps/backend/src/agent/tools/file/write-file.ts
@@ -46,16 +46,7 @@ export const writeFileTool: ToolDefinition<typeof parameters, WriteFileResult> =
     async execute(args: WriteFileArgs, context: ToolExecutionContext) {
       const {workingDirectory} = context;
 
-      // 1. Check content size
-      if (Buffer.byteLength(args.content) > MAX_CONTENT_SIZE) {
-        return {
-          data: {message: `Content exceeds ${MAX_CONTENT_SIZE} byte limit`},
-          content: `Error: Content exceeds ${MAX_CONTENT_SIZE} byte limit`,
-          status: 'failure',
-        };
-      }
-
-      // 2. Resolve path
+      // 1. Resolve path
       const absolutePath = path.resolve(workingDirectory, args.filePath);
 
       const lexicalPolicyResult = checkLexicalFileAccess(absolutePath);
@@ -64,6 +55,15 @@ export const writeFileTool: ToolDefinition<typeof parameters, WriteFileResult> =
         return {
           data: {message},
           content: message,
+          status: 'failure',
+        };
+      }
+
+      // 2. Check content size
+      if (Buffer.byteLength(args.content) > MAX_CONTENT_SIZE) {
+        return {
+          data: {message: `Content exceeds ${MAX_CONTENT_SIZE} byte limit`},
+          content: `Error: Content exceeds ${MAX_CONTENT_SIZE} byte limit`,
           status: 'failure',
         };
       }

--- a/apps/backend/src/agent/tools/file/write-file.ts
+++ b/apps/backend/src/agent/tools/file/write-file.ts
@@ -76,9 +76,19 @@ export const writeFileTool: ToolDefinition<typeof parameters, WriteFileResult> =
         // File doesn't exist, which is fine for write_file
       }
 
-      const policyResult = existingStat
-        ? await checkExistingFileAccess(absolutePath)
-        : await checkNewFileAccess(absolutePath);
+      let policyResult: Awaited<ReturnType<typeof checkExistingFileAccess>>;
+      try {
+        policyResult = existingStat
+          ? await checkExistingFileAccess(absolutePath)
+          : await checkNewFileAccess(absolutePath);
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          data: {message},
+          content: `Error: ${message}`,
+          status: 'failure',
+        };
+      }
       if (!policyResult.allowed) {
         const message = formatBlockedFileAccessMessage(args.filePath);
         return {

--- a/apps/backend/src/helpers/default-sensitive-path-policy.ts
+++ b/apps/backend/src/helpers/default-sensitive-path-policy.ts
@@ -1,0 +1,14 @@
+import os from 'node:os';
+
+import {getDataDir} from './env.js';
+import {
+  createSensitivePathPolicy,
+  type SensitivePathPolicy,
+} from './sensitive-path-policy.js';
+
+export function getDefaultSensitivePathPolicy(): SensitivePathPolicy {
+  return createSensitivePathPolicy({
+    homeDir: os.homedir(),
+    dataDir: getDataDir(),
+  });
+}

--- a/apps/backend/src/helpers/sensitive-path-policy.test.ts
+++ b/apps/backend/src/helpers/sensitive-path-policy.test.ts
@@ -1,0 +1,89 @@
+import path from 'node:path';
+
+import {describe, expect, it} from 'vitest';
+
+import {
+  checkSensitivePathAccess,
+  createSensitivePathPolicy,
+} from './sensitive-path-policy.js';
+
+describe('sensitive-path-policy', () => {
+  const root = path.join(path.sep, 'tmp', 'policy-test');
+  const homeDir = path.join(root, 'home');
+  const dataDir = path.join(root, 'data');
+  const policy = createSensitivePathPolicy({homeDir, dataDir});
+
+  it('blocks configured home sensitive roots and app data dir', () => {
+    const sshKey = path.join(homeDir, '.ssh', 'id_ed25519');
+    const appSettings = path.join(dataDir, 'settings.json');
+
+    expect(checkSensitivePathAccess(sshKey, policy)).toEqual({
+      allowed: false,
+      blockedPath: path.join(homeDir, '.ssh'),
+      reason: 'blocked-root',
+    });
+    expect(checkSensitivePathAccess(appSettings, policy)).toEqual({
+      allowed: false,
+      blockedPath: dataDir,
+      reason: 'blocked-root',
+    });
+  });
+
+  it('blocks VCS metadata segments but not sibling ignore files', () => {
+    const gitConfig = path.join(root, 'project', '.git', 'config');
+    const gitignore = path.join(root, 'project', '.gitignore');
+
+    expect(checkSensitivePathAccess(gitConfig, policy)).toEqual({
+      allowed: false,
+      blockedPath: path.join(root, 'project', '.git'),
+      reason: 'blocked-segment',
+    });
+    expect(checkSensitivePathAccess(gitignore, policy).allowed).toBe(true);
+  });
+
+  it('blocks env files except examples', () => {
+    expect(
+      checkSensitivePathAccess(path.join(root, '.env'), policy).allowed,
+    ).toBe(false);
+    expect(
+      checkSensitivePathAccess(path.join(root, '.env.local'), policy).allowed,
+    ).toBe(false);
+    expect(
+      checkSensitivePathAccess(path.join(root, '.env.example'), policy).allowed,
+    ).toBe(true);
+    expect(
+      checkSensitivePathAccess(path.join(root, '.env.sample'), policy).allowed,
+    ).toBe(true);
+    expect(
+      checkSensitivePathAccess(path.join(root, '.env.template'), policy)
+        .allowed,
+    ).toBe(true);
+  });
+
+  it('blocks credential filenames and private key extensions', () => {
+    const blocked = [
+      '.netrc',
+      '.git-credentials',
+      '.npmrc',
+      '.pypirc',
+      '.pgpass',
+      '.my.cnf',
+      '.bash_history',
+      '.zsh_history',
+      'credentials.json',
+      'server.pem',
+      'server.key',
+      'cert.p12',
+      'cert.pfx',
+      'id_rsa',
+      'id_ed25519',
+      'my-service-account-prod.json',
+    ];
+
+    for (const basename of blocked) {
+      expect(
+        checkSensitivePathAccess(path.join(root, basename), policy).allowed,
+      ).toBe(false);
+    }
+  });
+});

--- a/apps/backend/src/helpers/sensitive-path-policy.test.ts
+++ b/apps/backend/src/helpers/sensitive-path-policy.test.ts
@@ -86,4 +86,32 @@ describe('sensitive-path-policy', () => {
       ).toBe(false);
     }
   });
+
+  it('reports exact credential basenames as blocked-basename', () => {
+    for (const basename of ['.netrc', 'credentials.json', 'id_ed25519']) {
+      const targetPath = path.join(root, basename);
+
+      expect(checkSensitivePathAccess(targetPath, policy)).toEqual({
+        allowed: false,
+        blockedPath: targetPath,
+        reason: 'blocked-basename',
+      });
+    }
+  });
+
+  it('reports sensitive filename patterns as blocked-pattern', () => {
+    for (const basename of [
+      '.env.local',
+      'server.pem',
+      'my-service-account-prod.json',
+    ]) {
+      const targetPath = path.join(root, basename);
+
+      expect(checkSensitivePathAccess(targetPath, policy)).toEqual({
+        allowed: false,
+        blockedPath: targetPath,
+        reason: 'blocked-pattern',
+      });
+    }
+  });
 });

--- a/apps/backend/src/helpers/sensitive-path-policy.ts
+++ b/apps/backend/src/helpers/sensitive-path-policy.ts
@@ -1,0 +1,169 @@
+import path from 'node:path';
+
+import {isSubPathOrSelf} from './path-helpers.js';
+
+export type BlockedPathReason =
+  | 'blocked-root'
+  | 'blocked-segment'
+  | 'blocked-pattern';
+
+export type FileAccessPolicyResult =
+  | {allowed: true}
+  | {allowed: false; blockedPath: string; reason: BlockedPathReason};
+
+export interface SensitivePathPolicy {
+  blockedRoots: readonly string[];
+  blockedSegments: ReadonlySet<string>;
+  blockedBasenames: ReadonlySet<string>;
+}
+
+const HOME_RELATIVE_BLOCKED_ROOTS = [
+  '.ssh',
+  '.gnupg',
+  '.pki',
+  '.aws',
+  '.azure',
+  path.join('.config', 'gcloud'),
+  path.join('.config', 'gh'),
+  '.kube',
+  '.docker',
+  '.terraform.d',
+  path.join('Library', 'Keychains'),
+  path.join('Library', 'Application Support', 'Google', 'Chrome'),
+  path.join('Library', 'Application Support', 'Chromium'),
+  path.join('Library', 'Application Support', 'BraveSoftware'),
+  path.join('Library', 'Application Support', 'Firefox'),
+] as const;
+
+const BLOCKED_SEGMENTS = new Set(['.git', '.hg', '.svn']);
+
+const BLOCKED_BASENAMES = new Set([
+  '.netrc',
+  '.git-credentials',
+  '.npmrc',
+  '.pypirc',
+  '.pgpass',
+  '.my.cnf',
+  '.bash_history',
+  '.zsh_history',
+  '.fish_history',
+  '.psql_history',
+  '.mysql_history',
+  '.sqlite_history',
+  'credentials.json',
+  'id_rsa',
+  'id_dsa',
+  'id_ecdsa',
+  'id_ed25519',
+]);
+
+const ALLOWED_ENV_BASENAMES = new Set([
+  '.env.example',
+  '.env.sample',
+  '.env.template',
+]);
+
+export function createSensitivePathPolicy(options: {
+  homeDir: string;
+  dataDir: string;
+}): SensitivePathPolicy {
+  const homeDir = path.resolve(options.homeDir);
+  const dataDir = path.resolve(options.dataDir);
+
+  return {
+    blockedRoots: [
+      ...HOME_RELATIVE_BLOCKED_ROOTS.map((relativeRoot) =>
+        path.resolve(homeDir, relativeRoot),
+      ),
+      dataDir,
+    ],
+    blockedSegments: BLOCKED_SEGMENTS,
+    blockedBasenames: BLOCKED_BASENAMES,
+  };
+}
+
+export function checkSensitivePathAccess(
+  absolutePath: string,
+  policy: SensitivePathPolicy,
+): FileAccessPolicyResult {
+  const normalizedPath = path.resolve(absolutePath);
+
+  for (const blockedRoot of policy.blockedRoots) {
+    if (isSubPathOrSelf(blockedRoot, normalizedPath)) {
+      return {
+        allowed: false,
+        blockedPath: blockedRoot,
+        reason: 'blocked-root',
+      };
+    }
+  }
+
+  const blockedSegmentPath = findBlockedSegmentPath(
+    normalizedPath,
+    policy.blockedSegments,
+  );
+  if (blockedSegmentPath !== undefined) {
+    return {
+      allowed: false,
+      blockedPath: blockedSegmentPath,
+      reason: 'blocked-segment',
+    };
+  }
+
+  if (isBlockedBasename(path.basename(normalizedPath), policy)) {
+    return {
+      allowed: false,
+      blockedPath: normalizedPath,
+      reason: 'blocked-pattern',
+    };
+  }
+
+  return {allowed: true};
+}
+
+function findBlockedSegmentPath(
+  absolutePath: string,
+  blockedSegments: ReadonlySet<string>,
+): string | undefined {
+  const root = path.parse(absolutePath).root;
+  const relativeParts = absolutePath.slice(root.length).split(path.sep);
+  const pathParts: string[] = [];
+
+  for (const part of relativeParts) {
+    if (part.length === 0) continue;
+    pathParts.push(part);
+
+    if (blockedSegments.has(part)) {
+      return path.join(root, ...pathParts);
+    }
+  }
+
+  return undefined;
+}
+
+function isBlockedBasename(
+  basename: string,
+  policy: SensitivePathPolicy,
+): boolean {
+  const normalizedBasename = basename.toLowerCase();
+
+  if (policy.blockedBasenames.has(normalizedBasename)) {
+    return true;
+  }
+
+  if (
+    (normalizedBasename === '.env' || normalizedBasename.startsWith('.env.')) &&
+    !ALLOWED_ENV_BASENAMES.has(normalizedBasename)
+  ) {
+    return true;
+  }
+
+  return (
+    normalizedBasename.endsWith('.pem') ||
+    normalizedBasename.endsWith('.key') ||
+    normalizedBasename.endsWith('.p12') ||
+    normalizedBasename.endsWith('.pfx') ||
+    (normalizedBasename.includes('service-account') &&
+      normalizedBasename.endsWith('.json'))
+  );
+}

--- a/apps/backend/src/helpers/sensitive-path-policy.ts
+++ b/apps/backend/src/helpers/sensitive-path-policy.ts
@@ -5,6 +5,7 @@ import {isSubPathOrSelf} from './path-helpers.js';
 export type BlockedPathReason =
   | 'blocked-root'
   | 'blocked-segment'
+  | 'blocked-basename'
   | 'blocked-pattern';
 
 export type FileAccessPolicyResult =
@@ -110,7 +111,17 @@ export function checkSensitivePathAccess(
     };
   }
 
-  if (isBlockedBasename(path.basename(normalizedPath), policy)) {
+  const basename = path.basename(normalizedPath);
+
+  if (isBlockedExactBasename(basename, policy)) {
+    return {
+      allowed: false,
+      blockedPath: normalizedPath,
+      reason: 'blocked-basename',
+    };
+  }
+
+  if (isBlockedBasenamePattern(basename)) {
     return {
       allowed: false,
       blockedPath: normalizedPath,
@@ -141,15 +152,15 @@ function findBlockedSegmentPath(
   return undefined;
 }
 
-function isBlockedBasename(
+function isBlockedExactBasename(
   basename: string,
   policy: SensitivePathPolicy,
 ): boolean {
-  const normalizedBasename = basename.toLowerCase();
+  return policy.blockedBasenames.has(basename.toLowerCase());
+}
 
-  if (policy.blockedBasenames.has(normalizedBasename)) {
-    return true;
-  }
+function isBlockedBasenamePattern(basename: string): boolean {
+  const normalizedBasename = basename.toLowerCase();
 
   if (
     (normalizedBasename === '.env' || normalizedBasename.startsWith('.env.')) &&

--- a/apps/backend/src/services/file-access-settings/helpers.test.ts
+++ b/apps/backend/src/services/file-access-settings/helpers.test.ts
@@ -101,4 +101,27 @@ describe('normalizeAndValidatePaths', () => {
       {path: '/nonexistent', reason: PathValidationError.NOT_FOUND},
     ]);
   });
+
+  it('rejects blocked workspace roots', async () => {
+    const gitDir = path.join(tempDir, '.git');
+    await fs.mkdir(gitDir);
+
+    const {errors} = await normalizeAndValidatePaths([{path: gitDir}]);
+
+    expect(errors).toEqual([
+      {path: gitDir, reason: PathValidationError.BLOCKED},
+    ]);
+  });
+
+  it('allows normal workspaces that contain blocked descendants', async () => {
+    await fs.mkdir(path.join(tempDir, '.git'));
+    await fs.writeFile(path.join(tempDir, '.env'), 'SECRET=value');
+
+    const {normalized, errors} = await normalizeAndValidatePaths([
+      {path: tempDir},
+    ]);
+
+    expect(errors).toEqual([]);
+    expect(normalized).toEqual([{path: tempDir}]);
+  });
 });

--- a/apps/backend/src/services/file-access-settings/helpers.test.ts
+++ b/apps/backend/src/services/file-access-settings/helpers.test.ts
@@ -8,14 +8,29 @@ import {normalizeAndValidatePaths} from './helpers.js';
 import {PathValidationError} from './types.js';
 
 describe('normalizeAndValidatePaths', () => {
+  let originalDataDir: string | undefined;
+  let tempRoot: string;
   let tempDir: string;
+  let dataDir: string;
 
   beforeEach(async () => {
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'validate-paths-'));
+    originalDataDir = process.env.DATA_DIR;
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'validate-paths-'));
+    tempDir = path.join(tempRoot, 'workspace');
+    dataDir = path.join(tempRoot, 'data-dir');
+    process.env.DATA_DIR = dataDir;
+
+    await fs.mkdir(tempDir);
   });
 
   afterEach(async () => {
-    await fs.rm(tempDir, {recursive: true});
+    if (originalDataDir === undefined) {
+      delete process.env.DATA_DIR;
+    } else {
+      process.env.DATA_DIR = originalDataDir;
+    }
+
+    await fs.rm(tempRoot, {recursive: true, force: true});
   });
 
   it('returns empty errors for valid directory', async () => {
@@ -110,6 +125,16 @@ describe('normalizeAndValidatePaths', () => {
 
     expect(errors).toEqual([
       {path: gitDir, reason: PathValidationError.BLOCKED},
+    ]);
+  });
+
+  it('rejects configured data dir workspace roots', async () => {
+    await fs.mkdir(dataDir);
+
+    const {errors} = await normalizeAndValidatePaths([{path: dataDir}]);
+
+    expect(errors).toEqual([
+      {path: dataDir, reason: PathValidationError.BLOCKED},
     ]);
   });
 

--- a/apps/backend/src/services/file-access-settings/helpers.ts
+++ b/apps/backend/src/services/file-access-settings/helpers.ts
@@ -20,6 +20,7 @@ export async function normalizeAndValidatePaths(
   const errors: InvalidPathEntry[] = [];
   const seen = new Set<string>();
   const normalized: Workspace[] = [];
+  const sensitivePathPolicy = getDefaultSensitivePathPolicy();
 
   for (const entry of entries) {
     if (!path.isAbsolute(entry.path)) {
@@ -34,10 +35,7 @@ export async function normalizeAndValidatePaths(
     }
     seen.add(resolvedPath);
 
-    const policy = checkSensitivePathAccess(
-      resolvedPath,
-      getDefaultSensitivePathPolicy(),
-    );
+    const policy = checkSensitivePathAccess(resolvedPath, sensitivePathPolicy);
     if (!policy.allowed) {
       errors.push({path: entry.path, reason: PathValidationError.BLOCKED});
       continue;

--- a/apps/backend/src/services/file-access-settings/helpers.ts
+++ b/apps/backend/src/services/file-access-settings/helpers.ts
@@ -3,7 +3,9 @@ import path from 'node:path';
 
 import type {Workspace} from '@omnicraft/settings-schema';
 
+import {getDefaultSensitivePathPolicy} from '@/helpers/default-sensitive-path-policy.js';
 import {checkDirectoryAccess} from '@/helpers/fs.js';
+import {checkSensitivePathAccess} from '@/helpers/sensitive-path-policy.js';
 
 import {type InvalidPathEntry, PathValidationError} from './types.js';
 
@@ -31,6 +33,15 @@ export async function normalizeAndValidatePaths(
       continue;
     }
     seen.add(resolvedPath);
+
+    const policy = checkSensitivePathAccess(
+      resolvedPath,
+      getDefaultSensitivePathPolicy(),
+    );
+    if (!policy.allowed) {
+      errors.push({path: entry.path, reason: PathValidationError.BLOCKED});
+      continue;
+    }
 
     const reason = await validateSinglePath(resolvedPath);
     if (reason) {

--- a/apps/backend/src/services/file-access-settings/types.ts
+++ b/apps/backend/src/services/file-access-settings/types.ts
@@ -4,6 +4,7 @@ export enum PathValidationError {
   NOT_FOUND = 'NOT_FOUND',
   NOT_DIRECTORY = 'NOT_DIRECTORY',
   NOT_ACCESSIBLE = 'NOT_ACCESSIBLE',
+  BLOCKED = 'BLOCKED',
 }
 
 export interface InvalidPathEntry {

--- a/docs/superpowers/plans/2026-04-25-agent-file-tool-blocklist.md
+++ b/docs/superpowers/plans/2026-04-25-agent-file-tool-blocklist.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add a default sensitive-path blocklist to agent file tools and workspace validation.
 
-**Architecture:** Create one shared backend policy helper in `apps/backend/src/helpers/sensitive-path-policy.ts` so both agent file tools and file-access settings validation use the same rules. Direct file tools fail blocked operations with the standard policy message; broad search tools skip blocked/symlinked entries and append a policy note. Workspace settings reject a blocked workspace root with `PathValidationError.BLOCKED`.
+**Architecture:** Create one shared pure backend policy helper in `apps/backend/src/helpers/sensitive-path-policy.ts` so both agent file tools and file-access settings validation use the same blocklist rules without filesystem or LLM-message concerns. Use a small default-policy factory for production home/data-dir defaults, and file-tool-local adapters for realpath, symlink, and LLM-facing message behavior. Workspace settings reject a blocked workspace root with `PathValidationError.BLOCKED`.
 
 **Tech Stack:** TypeScript, Node.js `fs/promises`, `path`, `os`, fast-glob, Vitest, Bun workspace scripts.
 
@@ -13,9 +13,19 @@
 ## File Structure
 
 - Create: `apps/backend/src/helpers/sensitive-path-policy.ts`
-  - Owns default blocked root construction, basename/pattern checks, lexical checks, realpath checks, nearest-existing-parent checks for new writes, symlink detection, and standard messages.
+  - Pure policy module. Owns blocked root construction from caller-provided `homeDir` and `dataDir`, basename/pattern checks, lexical checks, and structured policy results.
 - Create: `apps/backend/src/helpers/sensitive-path-policy.test.ts`
-  - Unit tests for all policy rules and symlink/nearest-parent behavior.
+  - Unit tests for pure policy rules.
+- Create: `apps/backend/src/helpers/default-sensitive-path-policy.ts`
+  - Builds the default policy from `os.homedir()` and `getDataDir()`.
+- Create: `apps/backend/src/agent/tools/file/file-access-policy.ts`
+  - File-tool adapter. Owns realpath checks, nearest-existing-parent checks for new writes, and symlink detection.
+- Create: `apps/backend/src/agent/tools/file/file-access-policy.test.ts`
+  - Unit tests for file-tool filesystem policy adaptation.
+- Create: `apps/backend/src/agent/tools/file/file-access-policy-messages.ts`
+  - Owns LLM-facing denial and skipped-path messages for file tools.
+- Create: `apps/backend/src/agent/tools/file/file-access-policy-messages.test.ts`
+  - Verifies exact file-tool policy message text.
 - Modify: `apps/backend/src/agent/tools/file/read-file.ts`
   - Calls policy before reading blocked paths.
 - Modify: `apps/backend/src/agent/tools/file/write-file.ts`
@@ -43,97 +53,81 @@ bun run --filter '@omnicraft/backend' test -- src/helpers/sensitive-path-policy.
 
 ---
 
-### Task 1: Add Sensitive Path Policy Helper
+### Task 1: Add Pure Policy and File-Tool Adapters
 
 **Files:**
 
 - Create: `apps/backend/src/helpers/sensitive-path-policy.ts`
 - Create: `apps/backend/src/helpers/sensitive-path-policy.test.ts`
+- Create: `apps/backend/src/helpers/default-sensitive-path-policy.ts`
+- Create: `apps/backend/src/agent/tools/file/file-access-policy.ts`
+- Create: `apps/backend/src/agent/tools/file/file-access-policy.test.ts`
+- Create: `apps/backend/src/agent/tools/file/file-access-policy-messages.ts`
+- Create: `apps/backend/src/agent/tools/file/file-access-policy-messages.test.ts`
 
 - [ ] **Step 1: Write the failing policy tests**
 
 Create `apps/backend/src/helpers/sensitive-path-policy.test.ts`:
 
 ```ts
-import fs from 'node:fs/promises';
-import os from 'node:os';
 import path from 'node:path';
 
-import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {describe, expect, it} from 'vitest';
 
 import {
-  checkExistingPathAccess,
-  checkLexicalPathAccess,
-  checkNewPathAccess,
-  FILE_ACCESS_POLICY_SKIPPED_MESSAGE,
-  formatFileAccessPolicyDeniedMessage,
-  isSymbolicLinkPath,
+  checkSensitivePathAccess,
+  createSensitivePathPolicy,
 } from './sensitive-path-policy.js';
 
 describe('sensitive-path-policy', () => {
-  let tempDir: string;
-  let homeDir: string;
-  let dataDir: string;
-
-  beforeEach(async () => {
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spp-test-'));
-    homeDir = path.join(tempDir, 'home');
-    dataDir = path.join(tempDir, 'data');
-    await fs.mkdir(homeDir, {recursive: true});
-    await fs.mkdir(dataDir, {recursive: true});
-  });
-
-  afterEach(async () => {
-    await fs.rm(tempDir, {recursive: true, force: true});
-  });
-
-  function options() {
-    return {homeDir, dataDir};
-  }
-
-  it('exports standard policy messages', () => {
-    expect(formatFileAccessPolicyDeniedMessage('/blocked')).toBe(
-      'Error: Access denied by file access policy: /blocked. This operation would access a blocked sensitive path. Review the file access operation. If this operation is necessary, stop and ask the user to perform it manually.',
-    );
-    expect(FILE_ACCESS_POLICY_SKIPPED_MESSAGE).toBe(
-      'Some paths were skipped because they are blocked by file access policy. Do not try to bypass this policy. If accessing those paths is necessary, stop and ask the user to perform the operation manually.',
-    );
-  });
+  const root = path.join(path.sep, 'tmp', 'policy-test');
+  const homeDir = path.join(root, 'home');
+  const dataDir = path.join(root, 'data');
+  const policy = createSensitivePathPolicy({homeDir, dataDir});
 
   it('blocks configured home sensitive roots and app data dir', () => {
     const sshKey = path.join(homeDir, '.ssh', 'id_ed25519');
     const appSettings = path.join(dataDir, 'settings.json');
 
-    expect(checkLexicalPathAccess(sshKey, options()).allowed).toBe(false);
-    expect(checkLexicalPathAccess(appSettings, options()).allowed).toBe(false);
+    expect(checkSensitivePathAccess(sshKey, policy)).toEqual({
+      allowed: false,
+      blockedPath: path.join(homeDir, '.ssh'),
+      reason: 'blocked-root',
+    });
+    expect(checkSensitivePathAccess(appSettings, policy)).toEqual({
+      allowed: false,
+      blockedPath: dataDir,
+      reason: 'blocked-root',
+    });
   });
 
   it('blocks VCS metadata segments but not sibling ignore files', () => {
-    const gitConfig = path.join(tempDir, 'project', '.git', 'config');
-    const gitignore = path.join(tempDir, 'project', '.gitignore');
+    const gitConfig = path.join(root, 'project', '.git', 'config');
+    const gitignore = path.join(root, 'project', '.gitignore');
 
-    expect(checkLexicalPathAccess(gitConfig, options()).allowed).toBe(false);
-    expect(checkLexicalPathAccess(gitignore, options()).allowed).toBe(true);
+    expect(checkSensitivePathAccess(gitConfig, policy)).toEqual({
+      allowed: false,
+      blockedPath: path.join(root, 'project', '.git'),
+      reason: 'blocked-segment',
+    });
+    expect(checkSensitivePathAccess(gitignore, policy).allowed).toBe(true);
   });
 
   it('blocks env files except examples', () => {
     expect(
-      checkLexicalPathAccess(path.join(tempDir, '.env'), options()).allowed,
+      checkSensitivePathAccess(path.join(root, '.env'), policy).allowed,
     ).toBe(false);
     expect(
-      checkLexicalPathAccess(path.join(tempDir, '.env.local'), options())
-        .allowed,
+      checkSensitivePathAccess(path.join(root, '.env.local'), policy).allowed,
     ).toBe(false);
     expect(
-      checkLexicalPathAccess(path.join(tempDir, '.env.example'), options())
-        .allowed,
+      checkSensitivePathAccess(path.join(root, '.env.example'), policy).allowed,
     ).toBe(true);
     expect(
-      checkLexicalPathAccess(path.join(tempDir, '.env.sample'), options())
-        .allowed,
+      checkSensitivePathAccess(path.join(root, '.env.sample'), policy).allowed,
     ).toBe(true);
     expect(
-      checkLexicalPathAccess(path.join(tempDir, '.env.template'), options())
+      checkSensitivePathAccess(path.join(root, '.env.template'), policy)
         .allowed,
     ).toBe(true);
   });
@@ -160,9 +154,39 @@ describe('sensitive-path-policy', () => {
 
     for (const basename of blocked) {
       expect(
-        checkLexicalPathAccess(path.join(tempDir, basename), options()).allowed,
+        checkSensitivePathAccess(path.join(root, basename), policy).allowed,
       ).toBe(false);
     }
+  });
+});
+```
+
+- [ ] **Step 2: Write the failing file-tool adapter tests**
+
+Create `apps/backend/src/agent/tools/file/file-access-policy.test.ts`:
+
+```ts
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+import {
+  checkExistingFileAccess,
+  checkNewFileAccess,
+  isSymbolicLinkPath,
+} from './file-access-policy.js';
+
+describe('file-access-policy', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'fap-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, {recursive: true, force: true});
   });
 
   it('detects symbolic links', async () => {
@@ -181,71 +205,87 @@ describe('sensitive-path-policy', () => {
     await fs.writeFile(envFile, 'SECRET=value');
     await fs.symlink(envFile, link);
 
-    const result = await checkExistingPathAccess(link, options());
+    const result = await checkExistingFileAccess(link);
 
-    expect(result.allowed).toBe(false);
-    expect(result.allowed ? '' : result.message).toContain(
-      'Access denied by file access policy',
-    );
+    expect(result).toEqual({
+      allowed: false,
+      blockedPath: envFile,
+      reason: 'blocked-pattern',
+    });
   });
 
   it('blocks new paths through a symlinked parent when only the real target is blocked', async () => {
-    const linkToData = path.join(tempDir, 'link-to-data');
-    await fs.symlink(dataDir, linkToData, 'dir');
+    const gitDir = path.join(tempDir, '.git');
+    const linkToGit = path.join(tempDir, 'link-to-git');
+    await fs.mkdir(gitDir);
+    await fs.symlink(gitDir, linkToGit, 'dir');
 
-    const result = await checkNewPathAccess(
-      path.join(linkToData, 'new-settings.json'),
-      options(),
-    );
+    const result = await checkNewFileAccess(path.join(linkToGit, 'new-config'));
 
     expect(result.allowed).toBe(false);
   });
 });
 ```
 
-- [ ] **Step 2: Run policy tests to verify they fail**
+- [ ] **Step 3: Write the failing file-tool message tests**
+
+Create `apps/backend/src/agent/tools/file/file-access-policy-messages.test.ts`:
+
+```ts
+import {describe, expect, it} from 'vitest';
+
+import {
+  formatBlockedFileAccessMessage,
+  skippedByFileAccessPolicyMessage,
+} from './file-access-policy-messages.js';
+
+describe('file-access-policy-messages', () => {
+  it('formats blocked direct-operation messages for the LLM', () => {
+    expect(formatBlockedFileAccessMessage('/blocked')).toBe(
+      'Error: Access denied by file access policy: /blocked. This operation would access a blocked sensitive path. Review the file access operation. If this operation is necessary, stop and ask the user to perform it manually.',
+    );
+  });
+
+  it('exports the skipped-path policy note for broad searches', () => {
+    expect(skippedByFileAccessPolicyMessage).toBe(
+      'Some paths were skipped because they are blocked by file access policy. Do not try to bypass this policy. If accessing those paths is necessary, stop and ask the user to perform the operation manually.',
+    );
+  });
+});
+```
+
+- [ ] **Step 4: Run policy, file-adapter, and message tests to verify they fail**
 
 Run:
 
 ```bash
-bun run --filter '@omnicraft/backend' test -- src/helpers/sensitive-path-policy.test.ts
+bun run --filter '@omnicraft/backend' test -- src/helpers/sensitive-path-policy.test.ts src/agent/tools/file/file-access-policy.test.ts src/agent/tools/file/file-access-policy-messages.test.ts
 ```
 
-Expected: FAIL because `./sensitive-path-policy.js` does not exist.
+Expected: FAIL because the new modules do not exist.
 
-- [ ] **Step 3: Implement the policy helper**
+- [ ] **Step 5: Implement the pure policy helper**
 
 Create `apps/backend/src/helpers/sensitive-path-policy.ts`:
 
 ```ts
-import fs from 'node:fs/promises';
-import os from 'node:os';
 import path from 'node:path';
 
-import {getDataDir} from './env.js';
 import {isSubPathOrSelf} from './path-helpers.js';
-
-export const FILE_ACCESS_POLICY_SKIPPED_MESSAGE =
-  'Some paths were skipped because they are blocked by file access policy. ' +
-  'Do not try to bypass this policy. If accessing those paths is necessary, ' +
-  'stop and ask the user to perform the operation manually.';
-
-export function formatFileAccessPolicyDeniedMessage(filePath: string): string {
-  return (
-    `Error: Access denied by file access policy: ${filePath}. ` +
-    'This operation would access a blocked sensitive path. ' +
-    'Review the file access operation. If this operation is necessary, ' +
-    'stop and ask the user to perform it manually.'
-  );
-}
 
 export type FileAccessPolicyResult =
   | {allowed: true}
-  | {allowed: false; message: string};
+  | {allowed: false; blockedPath: string; reason: BlockedPathReason};
 
-export interface SensitivePathPolicyOptions {
-  readonly homeDir?: string;
-  readonly dataDir?: string;
+export type BlockedPathReason =
+  | 'blocked-root'
+  | 'blocked-segment'
+  | 'blocked-basename'
+  | 'blocked-pattern';
+
+export interface SensitivePathPolicy {
+  readonly homeDir: string;
+  readonly dataDir: string;
 }
 
 const BLOCKED_HOME_RELATIVE_ROOTS = [
@@ -295,71 +335,146 @@ const ALLOWED_ENV_BASENAMES = new Set([
   '.env.template',
 ]);
 
-function getPolicyRoots(options: SensitivePathPolicyOptions = {}): string[] {
-  const homeDir = path.resolve(options.homeDir ?? os.homedir());
-  const dataDir = path.resolve(options.dataDir ?? getDataDir());
+export function createSensitivePathPolicy(options: {
+  readonly homeDir: string;
+  readonly dataDir: string;
+}): SensitivePathPolicy {
+  return {
+    homeDir: path.resolve(options.homeDir),
+    dataDir: path.resolve(options.dataDir),
+  };
+}
+
+function getPolicyRoots(policy: SensitivePathPolicy): string[] {
   return [
-    dataDir,
+    policy.dataDir,
     ...BLOCKED_HOME_RELATIVE_ROOTS.map((relativeRoot) =>
-      path.resolve(homeDir, relativeRoot),
+      path.resolve(policy.homeDir, relativeRoot),
     ),
   ];
 }
 
-function hasBlockedSegment(absolutePath: string): boolean {
-  return path
-    .resolve(absolutePath)
-    .split(path.sep)
-    .some((segment) => BLOCKED_PATH_SEGMENTS.has(segment));
-}
-
-function hasBlockedBasename(absolutePath: string): boolean {
-  const basename = path.basename(absolutePath).toLowerCase();
-  if (ALLOWED_ENV_BASENAMES.has(basename)) return false;
-  if (basename === '.env' || basename.startsWith('.env.')) return true;
-  if (BLOCKED_BASENAMES.has(basename)) return true;
-  if (BLOCKED_EXTENSIONS.has(path.extname(basename))) return true;
-  return basename.endsWith('.json') && basename.includes('service-account');
-}
-
-function isBlockedPath(
-  absolutePath: string,
-  options: SensitivePathPolicyOptions = {},
-): boolean {
+function getBlockedSegmentPath(absolutePath: string): string | null {
   const resolvedPath = path.resolve(absolutePath);
-  if (hasBlockedSegment(resolvedPath)) return true;
-  if (hasBlockedBasename(resolvedPath)) return true;
-  return getPolicyRoots(options).some((root) =>
+  const root = path.parse(resolvedPath).root;
+  const parts = resolvedPath.slice(root.length).split(path.sep);
+  const blockedIndex = parts.findIndex((segment) =>
+    BLOCKED_PATH_SEGMENTS.has(segment),
+  );
+  if (blockedIndex === -1) return null;
+  return path.join(root, ...parts.slice(0, blockedIndex + 1));
+}
+
+function getBlockedBasenameReason(
+  absolutePath: string,
+): BlockedPathReason | null {
+  const basename = path.basename(absolutePath).toLowerCase();
+  if (ALLOWED_ENV_BASENAMES.has(basename)) return null;
+  if (basename === '.env' || basename.startsWith('.env.')) {
+    return 'blocked-pattern';
+  }
+  if (BLOCKED_BASENAMES.has(basename)) return 'blocked-basename';
+  if (BLOCKED_EXTENSIONS.has(path.extname(basename))) {
+    return 'blocked-pattern';
+  }
+  if (basename.endsWith('.json') && basename.includes('service-account')) {
+    return 'blocked-pattern';
+  }
+  return null;
+}
+
+function checkBlockedPath(
+  absolutePath: string,
+  policy: SensitivePathPolicy,
+): FileAccessPolicyResult {
+  const resolvedPath = path.resolve(absolutePath);
+  const blockedSegmentPath = getBlockedSegmentPath(resolvedPath);
+  if (blockedSegmentPath !== null) {
+    return {
+      allowed: false,
+      blockedPath: blockedSegmentPath,
+      reason: 'blocked-segment',
+    };
+  }
+
+  const basenameReason = getBlockedBasenameReason(resolvedPath);
+  if (basenameReason !== null) {
+    return {
+      allowed: false,
+      blockedPath: resolvedPath,
+      reason: basenameReason,
+    };
+  }
+
+  const blockedRoot = getPolicyRoots(policy).find((root) =>
     isSubPathOrSelf(root, resolvedPath),
+  );
+  if (blockedRoot !== undefined) {
+    return {allowed: false, blockedPath: blockedRoot, reason: 'blocked-root'};
+  }
+
+  return {allowed: true};
+}
+
+export function checkSensitivePathAccess(
+  absolutePath: string,
+  policy: SensitivePathPolicy,
+): FileAccessPolicyResult {
+  return checkBlockedPath(absolutePath, policy);
+}
+```
+
+- [ ] **Step 6: Implement the default policy factory**
+
+Create `apps/backend/src/helpers/default-sensitive-path-policy.ts`:
+
+```ts
+import os from 'node:os';
+
+import {getDataDir} from './env.js';
+import {
+  createSensitivePathPolicy,
+  type SensitivePathPolicy,
+} from './sensitive-path-policy.js';
+
+export function getDefaultSensitivePathPolicy(): SensitivePathPolicy {
+  return createSensitivePathPolicy({
+    homeDir: os.homedir(),
+    dataDir: getDataDir(),
+  });
+}
+```
+
+- [ ] **Step 7: Implement the file-tool filesystem adapter**
+
+Create `apps/backend/src/agent/tools/file/file-access-policy.ts`:
+
+```ts
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import {getDefaultSensitivePathPolicy} from '@/helpers/default-sensitive-path-policy.js';
+import {
+  checkSensitivePathAccess,
+  type FileAccessPolicyResult,
+} from '@/helpers/sensitive-path-policy.js';
+
+export function checkLexicalFileAccess(
+  absolutePath: string,
+): FileAccessPolicyResult {
+  return checkSensitivePathAccess(
+    absolutePath,
+    getDefaultSensitivePathPolicy(),
   );
 }
 
-function denied(absolutePath: string): FileAccessPolicyResult {
-  return {
-    allowed: false,
-    message: formatFileAccessPolicyDeniedMessage(absolutePath),
-  };
-}
-
-export function checkLexicalPathAccess(
+export async function checkExistingFileAccess(
   absolutePath: string,
-  options: SensitivePathPolicyOptions = {},
-): FileAccessPolicyResult {
-  const resolvedPath = path.resolve(absolutePath);
-  if (isBlockedPath(resolvedPath, options)) return denied(resolvedPath);
-  return {allowed: true};
-}
-
-export async function checkExistingPathAccess(
-  absolutePath: string,
-  options: SensitivePathPolicyOptions = {},
 ): Promise<FileAccessPolicyResult> {
-  const lexical = checkLexicalPathAccess(absolutePath, options);
+  const lexical = checkLexicalFileAccess(absolutePath);
   if (!lexical.allowed) return lexical;
   const realPath = await fs.realpath(absolutePath);
-  const real = checkLexicalPathAccess(realPath, options);
-  if (!real.allowed) return denied(path.resolve(absolutePath));
-  return {allowed: true};
+  return checkLexicalFileAccess(realPath);
 }
 
 async function findNearestExistingParent(absolutePath: string): Promise<{
@@ -387,20 +502,17 @@ async function findNearestExistingParent(absolutePath: string): Promise<{
   }
 }
 
-export async function checkNewPathAccess(
+export async function checkNewFileAccess(
   absolutePath: string,
-  options: SensitivePathPolicyOptions = {},
 ): Promise<FileAccessPolicyResult> {
-  const lexical = checkLexicalPathAccess(absolutePath, options);
+  const lexical = checkLexicalFileAccess(absolutePath);
   if (!lexical.allowed) return lexical;
 
   const {existingParent, suffixParts} =
     await findNearestExistingParent(absolutePath);
   const realParent = await fs.realpath(existingParent);
   const reconstructedTarget = path.join(realParent, ...suffixParts);
-  const real = checkLexicalPathAccess(reconstructedTarget, options);
-  if (!real.allowed) return denied(path.resolve(absolutePath));
-  return {allowed: true};
+  return checkLexicalFileAccess(reconstructedTarget);
 }
 
 export async function isSymbolicLinkPath(
@@ -414,20 +526,40 @@ export async function isSymbolicLinkPath(
 }
 ```
 
-- [ ] **Step 4: Run policy tests to verify they pass**
+- [ ] **Step 8: Implement the file-tool message helper**
+
+Create `apps/backend/src/agent/tools/file/file-access-policy-messages.ts`:
+
+```ts
+export const skippedByFileAccessPolicyMessage =
+  'Some paths were skipped because they are blocked by file access policy. ' +
+  'Do not try to bypass this policy. If accessing those paths is necessary, ' +
+  'stop and ask the user to perform the operation manually.';
+
+export function formatBlockedFileAccessMessage(requestedPath: string): string {
+  return (
+    `Error: Access denied by file access policy: ${requestedPath}. ` +
+    'This operation would access a blocked sensitive path. ' +
+    'Review the file access operation. If this operation is necessary, ' +
+    'stop and ask the user to perform it manually.'
+  );
+}
+```
+
+- [ ] **Step 9: Run policy, file-adapter, and message tests to verify they pass**
 
 Run:
 
 ```bash
-bun run --filter '@omnicraft/backend' test -- src/helpers/sensitive-path-policy.test.ts
+bun run --filter '@omnicraft/backend' test -- src/helpers/sensitive-path-policy.test.ts src/agent/tools/file/file-access-policy.test.ts src/agent/tools/file/file-access-policy-messages.test.ts
 ```
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit policy helper**
+- [ ] **Step 10: Commit policy, adapter, and message helpers**
 
 ```bash
-git add apps/backend/src/helpers/sensitive-path-policy.ts apps/backend/src/helpers/sensitive-path-policy.test.ts
+git add apps/backend/src/helpers/sensitive-path-policy.ts apps/backend/src/helpers/sensitive-path-policy.test.ts apps/backend/src/helpers/default-sensitive-path-policy.ts apps/backend/src/agent/tools/file/file-access-policy.ts apps/backend/src/agent/tools/file/file-access-policy.test.ts apps/backend/src/agent/tools/file/file-access-policy-messages.ts apps/backend/src/agent/tools/file/file-access-policy-messages.test.ts
 git commit -m "feat: add sensitive path policy helper"
 ```
 
@@ -562,19 +694,22 @@ Add this import to `apps/backend/src/agent/tools/file/read-file.ts`:
 
 ```ts
 import {
-  checkExistingPathAccess,
-  checkLexicalPathAccess,
-} from '@/helpers/sensitive-path-policy.js';
+  checkExistingFileAccess,
+  checkLexicalFileAccess,
+} from './file-access-policy.js';
+
+import {formatBlockedFileAccessMessage} from './file-access-policy-messages.js';
 ```
 
 Immediately after resolving `absolutePath`, insert:
 
 ```ts
-const lexicalPolicy = checkLexicalPathAccess(absolutePath);
+const lexicalPolicy = checkLexicalFileAccess(absolutePath);
 if (!lexicalPolicy.allowed) {
+  const message = formatBlockedFileAccessMessage(args.filePath);
   return {
-    data: {message: lexicalPolicy.message},
-    content: lexicalPolicy.message,
+    data: {message},
+    content: message,
     status: 'failure',
   };
 }
@@ -584,11 +719,12 @@ Keep the existing stat block that returns `File not found` for missing files.
 After the `!stat.isFile()` branch and before the binary check, insert:
 
 ```ts
-const realPolicy = await checkExistingPathAccess(absolutePath);
+const realPolicy = await checkExistingFileAccess(absolutePath);
 if (!realPolicy.allowed) {
+  const message = formatBlockedFileAccessMessage(args.filePath);
   return {
-    data: {message: realPolicy.message},
-    content: realPolicy.message,
+    data: {message},
+    content: message,
     status: 'failure',
   };
 }
@@ -600,20 +736,23 @@ Add this import to `apps/backend/src/agent/tools/file/write-file.ts`:
 
 ```ts
 import {
-  checkExistingPathAccess,
-  checkLexicalPathAccess,
-  checkNewPathAccess,
-} from '@/helpers/sensitive-path-policy.js';
+  checkExistingFileAccess,
+  checkLexicalFileAccess,
+  checkNewFileAccess,
+} from './file-access-policy.js';
+
+import {formatBlockedFileAccessMessage} from './file-access-policy-messages.js';
 ```
 
 Immediately after resolving `absolutePath`, insert:
 
 ```ts
-const lexicalPolicy = checkLexicalPathAccess(absolutePath);
+const lexicalPolicy = checkLexicalFileAccess(absolutePath);
 if (!lexicalPolicy.allowed) {
+  const message = formatBlockedFileAccessMessage(args.filePath);
   return {
-    data: {message: lexicalPolicy.message},
-    content: lexicalPolicy.message,
+    data: {message},
+    content: message,
     status: 'failure',
   };
 }
@@ -623,12 +762,13 @@ After the existing `fs.stat(absolutePath)` attempt and before file-stat-tracker 
 
 ```ts
 const policyResult = existingStat
-  ? await checkExistingPathAccess(absolutePath)
-  : await checkNewPathAccess(absolutePath);
+  ? await checkExistingFileAccess(absolutePath)
+  : await checkNewFileAccess(absolutePath);
 if (!policyResult.allowed) {
+  const message = formatBlockedFileAccessMessage(args.filePath);
   return {
-    data: {message: policyResult.message},
-    content: policyResult.message,
+    data: {message},
+    content: message,
     status: 'failure',
   };
 }
@@ -640,19 +780,22 @@ Add this import to `apps/backend/src/agent/tools/file/edit-file.ts`:
 
 ```ts
 import {
-  checkExistingPathAccess,
-  checkLexicalPathAccess,
-} from '@/helpers/sensitive-path-policy.js';
+  checkExistingFileAccess,
+  checkLexicalFileAccess,
+} from './file-access-policy.js';
+
+import {formatBlockedFileAccessMessage} from './file-access-policy-messages.js';
 ```
 
 Immediately after resolving `absolutePath`, insert:
 
 ```ts
-const lexicalPolicy = checkLexicalPathAccess(absolutePath);
+const lexicalPolicy = checkLexicalFileAccess(absolutePath);
 if (!lexicalPolicy.allowed) {
+  const message = formatBlockedFileAccessMessage(args.filePath);
   return {
-    data: {message: lexicalPolicy.message},
-    content: lexicalPolicy.message,
+    data: {message},
+    content: message,
     status: 'failure',
   };
 }
@@ -661,11 +804,12 @@ if (!lexicalPolicy.allowed) {
 After the existing stat success and `stat.isFile()` check, insert:
 
 ```ts
-const realPolicy = await checkExistingPathAccess(absolutePath);
+const realPolicy = await checkExistingFileAccess(absolutePath);
 if (!realPolicy.allowed) {
+  const message = formatBlockedFileAccessMessage(args.filePath);
   return {
-    data: {message: realPolicy.message},
-    content: realPolicy.message,
+    data: {message},
+    content: message,
     status: 'failure',
   };
 }
@@ -837,21 +981,26 @@ Add this import:
 
 ```ts
 import {
-  checkExistingPathAccess,
-  checkLexicalPathAccess,
-  FILE_ACCESS_POLICY_SKIPPED_MESSAGE,
+  checkExistingFileAccess,
+  checkLexicalFileAccess,
   isSymbolicLinkPath,
-} from '@/helpers/sensitive-path-policy.js';
+} from './file-access-policy.js';
+
+import {
+  formatBlockedFileAccessMessage,
+  skippedByFileAccessPolicyMessage,
+} from './file-access-policy-messages.js';
 ```
 
 After verifying `searchDir` exists and is a directory, insert:
 
 ```ts
-const rootPolicy = await checkExistingPathAccess(searchDir);
+const rootPolicy = await checkExistingFileAccess(searchDir);
 if (!rootPolicy.allowed) {
+  const message = formatBlockedFileAccessMessage(args.path ?? searchDir);
   return {
-    data: {message: rootPolicy.message},
-    content: rootPolicy.message,
+    data: {message},
+    content: message,
     status: 'failure',
   };
 }
@@ -878,7 +1027,7 @@ Inside the `for await` loop, replace the direct `entries.push(entry);` with:
 
 ```ts
 const absoluteEntryPath = path.join(searchDir, entry);
-const entryPolicy = checkLexicalPathAccess(absoluteEntryPath);
+const entryPolicy = checkLexicalFileAccess(absoluteEntryPath);
 if (!entryPolicy.allowed || (await isSymbolicLinkPath(absoluteEntryPath))) {
   skippedByPolicy = true;
   continue;
@@ -891,7 +1040,7 @@ When building successful content bodies, append the note with:
 
 ```ts
 const policyNote = skippedByPolicy
-  ? `\n${FILE_ACCESS_POLICY_SKIPPED_MESSAGE}`
+  ? `\n${skippedByFileAccessPolicyMessage}`
   : '';
 ```
 
@@ -920,21 +1069,26 @@ Add this import:
 
 ```ts
 import {
-  checkExistingPathAccess,
-  checkLexicalPathAccess,
-  FILE_ACCESS_POLICY_SKIPPED_MESSAGE,
+  checkExistingFileAccess,
+  checkLexicalFileAccess,
   isSymbolicLinkPath,
-} from '@/helpers/sensitive-path-policy.js';
+} from './file-access-policy.js';
+
+import {
+  formatBlockedFileAccessMessage,
+  skippedByFileAccessPolicyMessage,
+} from './file-access-policy-messages.js';
 ```
 
 After verifying `searchDir` exists and is a directory, insert:
 
 ```ts
-const rootPolicy = await checkExistingPathAccess(searchDir);
+const rootPolicy = await checkExistingFileAccess(searchDir);
 if (!rootPolicy.allowed) {
+  const message = formatBlockedFileAccessMessage(args.path ?? searchDir);
   return {
-    data: {message: rootPolicy.message},
-    content: rootPolicy.message,
+    data: {message},
+    content: message,
     status: 'failure',
   };
 }
@@ -960,7 +1114,7 @@ let skippedByPolicy = false;
 Inside the `for await` loop, after computing `absolutePath`, insert before creating `task`:
 
 ```ts
-const entryPolicy = checkLexicalPathAccess(absolutePath);
+const entryPolicy = checkLexicalFileAccess(absolutePath);
 if (!entryPolicy.allowed || (await isSymbolicLinkPath(absolutePath))) {
   skippedByPolicy = true;
   continue;
@@ -971,7 +1125,7 @@ Before output branches, create:
 
 ```ts
 const policyNote = skippedByPolicy
-  ? `\n${FILE_ACCESS_POLICY_SKIPPED_MESSAGE}`
+  ? `\n${skippedByFileAccessPolicyMessage}`
   : '';
 ```
 
@@ -1075,13 +1229,17 @@ Modify `apps/backend/src/services/file-access-settings/helpers.ts`.
 Add import:
 
 ```ts
-import {checkLexicalPathAccess} from '@/helpers/sensitive-path-policy.js';
+import {getDefaultSensitivePathPolicy} from '@/helpers/default-sensitive-path-policy.js';
+import {checkSensitivePathAccess} from '@/helpers/sensitive-path-policy.js';
 ```
 
 Inside `normalizeAndValidatePaths`, after the duplicate check and before `validateSinglePath(resolvedPath)`, insert:
 
 ```ts
-const policy = checkLexicalPathAccess(resolvedPath);
+const policy = checkSensitivePathAccess(
+  resolvedPath,
+  getDefaultSensitivePathPolicy(),
+);
 if (!policy.allowed) {
   errors.push({path: entry.path, reason: PathValidationError.BLOCKED});
   continue;
@@ -1159,10 +1317,10 @@ Run:
 
 ```bash
 git diff --stat HEAD~4..HEAD
-git diff HEAD~4..HEAD -- apps/backend/src/helpers/sensitive-path-policy.ts apps/backend/src/agent/tools/file apps/backend/src/services/file-access-settings
+git diff HEAD~4..HEAD -- apps/backend/src/helpers/sensitive-path-policy.ts apps/backend/src/helpers/default-sensitive-path-policy.ts apps/backend/src/agent/tools/file apps/backend/src/services/file-access-settings
 ```
 
-Expected: All five file tools use `sensitive-path-policy`, search tools set `followSymbolicLinks: false`, and workspace validation uses `PathValidationError.BLOCKED`.
+Expected: `sensitive-path-policy.ts` is pure, file tools use the file-tool adapter/message helpers, search tools set `followSymbolicLinks: false`, and workspace validation uses `PathValidationError.BLOCKED`.
 
 - [ ] **Step 6: Commit verification fixes if needed**
 

--- a/docs/superpowers/plans/2026-04-25-agent-file-tool-blocklist.md
+++ b/docs/superpowers/plans/2026-04-25-agent-file-tool-blocklist.md
@@ -1,0 +1,1186 @@
+# Agent File Tool Blocklist Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a default sensitive-path blocklist to agent file tools and workspace validation.
+
+**Architecture:** Create one shared backend policy helper in `apps/backend/src/helpers/sensitive-path-policy.ts` so both agent file tools and file-access settings validation use the same rules. Direct file tools fail blocked operations with the standard policy message; broad search tools skip blocked/symlinked entries and append a policy note. Workspace settings reject a blocked workspace root with `PathValidationError.BLOCKED`.
+
+**Tech Stack:** TypeScript, Node.js `fs/promises`, `path`, `os`, fast-glob, Vitest, Bun workspace scripts.
+
+---
+
+## File Structure
+
+- Create: `apps/backend/src/helpers/sensitive-path-policy.ts`
+  - Owns default blocked root construction, basename/pattern checks, lexical checks, realpath checks, nearest-existing-parent checks for new writes, symlink detection, and standard messages.
+- Create: `apps/backend/src/helpers/sensitive-path-policy.test.ts`
+  - Unit tests for all policy rules and symlink/nearest-parent behavior.
+- Modify: `apps/backend/src/agent/tools/file/read-file.ts`
+  - Calls policy before reading blocked paths.
+- Modify: `apps/backend/src/agent/tools/file/write-file.ts`
+  - Calls policy before writing existing or new blocked paths.
+- Modify: `apps/backend/src/agent/tools/file/edit-file.ts`
+  - Calls policy before reading or writing blocked paths.
+- Modify: `apps/backend/src/agent/tools/file/find-files.ts`
+  - Disables symlink following, checks search root, skips symlinked/blocked results, appends policy note.
+- Modify: `apps/backend/src/agent/tools/file/search-files.ts`
+  - Disables symlink following, checks search root, skips symlinked/blocked files, appends policy note.
+- Modify: file tool tests under `apps/backend/src/agent/tools/file/*.test.ts`
+  - Adds integration coverage for policy failures/skips.
+- Modify: `apps/backend/src/services/file-access-settings/types.ts`
+  - Adds `PathValidationError.BLOCKED`.
+- Modify: `apps/backend/src/services/file-access-settings/helpers.ts`
+  - Rejects blocked workspace roots using shared policy.
+- Modify: `apps/backend/src/services/file-access-settings/helpers.test.ts`
+  - Adds workspace validation coverage.
+
+Run backend commands from the repo root with Bun filters, for example:
+
+```bash
+bun run --filter '@omnicraft/backend' test -- src/helpers/sensitive-path-policy.test.ts
+```
+
+---
+
+### Task 1: Add Sensitive Path Policy Helper
+
+**Files:**
+
+- Create: `apps/backend/src/helpers/sensitive-path-policy.ts`
+- Create: `apps/backend/src/helpers/sensitive-path-policy.test.ts`
+
+- [ ] **Step 1: Write the failing policy tests**
+
+Create `apps/backend/src/helpers/sensitive-path-policy.test.ts`:
+
+```ts
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+import {
+  checkExistingPathAccess,
+  checkLexicalPathAccess,
+  checkNewPathAccess,
+  FILE_ACCESS_POLICY_SKIPPED_MESSAGE,
+  formatFileAccessPolicyDeniedMessage,
+  isSymbolicLinkPath,
+} from './sensitive-path-policy.js';
+
+describe('sensitive-path-policy', () => {
+  let tempDir: string;
+  let homeDir: string;
+  let dataDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'spp-test-'));
+    homeDir = path.join(tempDir, 'home');
+    dataDir = path.join(tempDir, 'data');
+    await fs.mkdir(homeDir, {recursive: true});
+    await fs.mkdir(dataDir, {recursive: true});
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, {recursive: true, force: true});
+  });
+
+  function options() {
+    return {homeDir, dataDir};
+  }
+
+  it('exports standard policy messages', () => {
+    expect(formatFileAccessPolicyDeniedMessage('/blocked')).toBe(
+      'Error: Access denied by file access policy: /blocked. This operation would access a blocked sensitive path. Review the file access operation. If this operation is necessary, stop and ask the user to perform it manually.',
+    );
+    expect(FILE_ACCESS_POLICY_SKIPPED_MESSAGE).toBe(
+      'Some paths were skipped because they are blocked by file access policy. Do not try to bypass this policy. If accessing those paths is necessary, stop and ask the user to perform the operation manually.',
+    );
+  });
+
+  it('blocks configured home sensitive roots and app data dir', () => {
+    const sshKey = path.join(homeDir, '.ssh', 'id_ed25519');
+    const appSettings = path.join(dataDir, 'settings.json');
+
+    expect(checkLexicalPathAccess(sshKey, options()).allowed).toBe(false);
+    expect(checkLexicalPathAccess(appSettings, options()).allowed).toBe(false);
+  });
+
+  it('blocks VCS metadata segments but not sibling ignore files', () => {
+    const gitConfig = path.join(tempDir, 'project', '.git', 'config');
+    const gitignore = path.join(tempDir, 'project', '.gitignore');
+
+    expect(checkLexicalPathAccess(gitConfig, options()).allowed).toBe(false);
+    expect(checkLexicalPathAccess(gitignore, options()).allowed).toBe(true);
+  });
+
+  it('blocks env files except examples', () => {
+    expect(
+      checkLexicalPathAccess(path.join(tempDir, '.env'), options()).allowed,
+    ).toBe(false);
+    expect(
+      checkLexicalPathAccess(path.join(tempDir, '.env.local'), options())
+        .allowed,
+    ).toBe(false);
+    expect(
+      checkLexicalPathAccess(path.join(tempDir, '.env.example'), options())
+        .allowed,
+    ).toBe(true);
+    expect(
+      checkLexicalPathAccess(path.join(tempDir, '.env.sample'), options())
+        .allowed,
+    ).toBe(true);
+    expect(
+      checkLexicalPathAccess(path.join(tempDir, '.env.template'), options())
+        .allowed,
+    ).toBe(true);
+  });
+
+  it('blocks credential filenames and private key extensions', () => {
+    const blocked = [
+      '.netrc',
+      '.git-credentials',
+      '.npmrc',
+      '.pypirc',
+      '.pgpass',
+      '.my.cnf',
+      '.bash_history',
+      '.zsh_history',
+      'credentials.json',
+      'server.pem',
+      'server.key',
+      'cert.p12',
+      'cert.pfx',
+      'id_rsa',
+      'id_ed25519',
+      'my-service-account-prod.json',
+    ];
+
+    for (const basename of blocked) {
+      expect(
+        checkLexicalPathAccess(path.join(tempDir, basename), options()).allowed,
+      ).toBe(false);
+    }
+  });
+
+  it('detects symbolic links', async () => {
+    const target = path.join(tempDir, 'target.txt');
+    const link = path.join(tempDir, 'link.txt');
+    await fs.writeFile(target, 'content');
+    await fs.symlink(target, link);
+
+    expect(await isSymbolicLinkPath(link)).toBe(true);
+    expect(await isSymbolicLinkPath(target)).toBe(false);
+  });
+
+  it('blocks existing paths whose real target is blocked', async () => {
+    const envFile = path.join(tempDir, '.env');
+    const link = path.join(tempDir, 'env-link');
+    await fs.writeFile(envFile, 'SECRET=value');
+    await fs.symlink(envFile, link);
+
+    const result = await checkExistingPathAccess(link, options());
+
+    expect(result.allowed).toBe(false);
+    expect(result.allowed ? '' : result.message).toContain(
+      'Access denied by file access policy',
+    );
+  });
+
+  it('blocks new paths through a symlinked parent when only the real target is blocked', async () => {
+    const linkToData = path.join(tempDir, 'link-to-data');
+    await fs.symlink(dataDir, linkToData, 'dir');
+
+    const result = await checkNewPathAccess(
+      path.join(linkToData, 'new-settings.json'),
+      options(),
+    );
+
+    expect(result.allowed).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run policy tests to verify they fail**
+
+Run:
+
+```bash
+bun run --filter '@omnicraft/backend' test -- src/helpers/sensitive-path-policy.test.ts
+```
+
+Expected: FAIL because `./sensitive-path-policy.js` does not exist.
+
+- [ ] **Step 3: Implement the policy helper**
+
+Create `apps/backend/src/helpers/sensitive-path-policy.ts`:
+
+```ts
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {getDataDir} from './env.js';
+import {isSubPathOrSelf} from './path-helpers.js';
+
+export const FILE_ACCESS_POLICY_SKIPPED_MESSAGE =
+  'Some paths were skipped because they are blocked by file access policy. ' +
+  'Do not try to bypass this policy. If accessing those paths is necessary, ' +
+  'stop and ask the user to perform the operation manually.';
+
+export function formatFileAccessPolicyDeniedMessage(filePath: string): string {
+  return (
+    `Error: Access denied by file access policy: ${filePath}. ` +
+    'This operation would access a blocked sensitive path. ' +
+    'Review the file access operation. If this operation is necessary, ' +
+    'stop and ask the user to perform it manually.'
+  );
+}
+
+export type FileAccessPolicyResult =
+  | {allowed: true}
+  | {allowed: false; message: string};
+
+export interface SensitivePathPolicyOptions {
+  readonly homeDir?: string;
+  readonly dataDir?: string;
+}
+
+const BLOCKED_HOME_RELATIVE_ROOTS = [
+  '.ssh',
+  '.gnupg',
+  '.pki',
+  '.aws',
+  '.azure',
+  path.join('.config', 'gcloud'),
+  path.join('.config', 'gh'),
+  '.kube',
+  '.docker',
+  '.terraform.d',
+  path.join('Library', 'Keychains'),
+  path.join('Library', 'Application Support', 'Google', 'Chrome'),
+  path.join('Library', 'Application Support', 'Chromium'),
+  path.join('Library', 'Application Support', 'BraveSoftware'),
+  path.join('Library', 'Application Support', 'Firefox'),
+] as const;
+
+const BLOCKED_PATH_SEGMENTS = new Set(['.git', '.hg', '.svn']);
+
+const BLOCKED_BASENAMES = new Set([
+  '.netrc',
+  '.git-credentials',
+  '.npmrc',
+  '.pypirc',
+  '.pgpass',
+  '.my.cnf',
+  '.bash_history',
+  '.zsh_history',
+  '.fish_history',
+  '.psql_history',
+  '.mysql_history',
+  '.sqlite_history',
+  'credentials.json',
+  'id_rsa',
+  'id_dsa',
+  'id_ecdsa',
+  'id_ed25519',
+]);
+
+const BLOCKED_EXTENSIONS = new Set(['.pem', '.key', '.p12', '.pfx']);
+const ALLOWED_ENV_BASENAMES = new Set([
+  '.env.example',
+  '.env.sample',
+  '.env.template',
+]);
+
+function getPolicyRoots(options: SensitivePathPolicyOptions = {}): string[] {
+  const homeDir = path.resolve(options.homeDir ?? os.homedir());
+  const dataDir = path.resolve(options.dataDir ?? getDataDir());
+  return [
+    dataDir,
+    ...BLOCKED_HOME_RELATIVE_ROOTS.map((relativeRoot) =>
+      path.resolve(homeDir, relativeRoot),
+    ),
+  ];
+}
+
+function hasBlockedSegment(absolutePath: string): boolean {
+  return path
+    .resolve(absolutePath)
+    .split(path.sep)
+    .some((segment) => BLOCKED_PATH_SEGMENTS.has(segment));
+}
+
+function hasBlockedBasename(absolutePath: string): boolean {
+  const basename = path.basename(absolutePath).toLowerCase();
+  if (ALLOWED_ENV_BASENAMES.has(basename)) return false;
+  if (basename === '.env' || basename.startsWith('.env.')) return true;
+  if (BLOCKED_BASENAMES.has(basename)) return true;
+  if (BLOCKED_EXTENSIONS.has(path.extname(basename))) return true;
+  return basename.endsWith('.json') && basename.includes('service-account');
+}
+
+function isBlockedPath(
+  absolutePath: string,
+  options: SensitivePathPolicyOptions = {},
+): boolean {
+  const resolvedPath = path.resolve(absolutePath);
+  if (hasBlockedSegment(resolvedPath)) return true;
+  if (hasBlockedBasename(resolvedPath)) return true;
+  return getPolicyRoots(options).some((root) =>
+    isSubPathOrSelf(root, resolvedPath),
+  );
+}
+
+function denied(absolutePath: string): FileAccessPolicyResult {
+  return {
+    allowed: false,
+    message: formatFileAccessPolicyDeniedMessage(absolutePath),
+  };
+}
+
+export function checkLexicalPathAccess(
+  absolutePath: string,
+  options: SensitivePathPolicyOptions = {},
+): FileAccessPolicyResult {
+  const resolvedPath = path.resolve(absolutePath);
+  if (isBlockedPath(resolvedPath, options)) return denied(resolvedPath);
+  return {allowed: true};
+}
+
+export async function checkExistingPathAccess(
+  absolutePath: string,
+  options: SensitivePathPolicyOptions = {},
+): Promise<FileAccessPolicyResult> {
+  const lexical = checkLexicalPathAccess(absolutePath, options);
+  if (!lexical.allowed) return lexical;
+  const realPath = await fs.realpath(absolutePath);
+  const real = checkLexicalPathAccess(realPath, options);
+  if (!real.allowed) return denied(path.resolve(absolutePath));
+  return {allowed: true};
+}
+
+async function findNearestExistingParent(absolutePath: string): Promise<{
+  existingParent: string;
+  suffixParts: string[];
+}> {
+  const resolvedPath = path.resolve(absolutePath);
+  const suffixParts: string[] = [];
+  let current = resolvedPath;
+
+  while (true) {
+    try {
+      const stat = await fs.stat(current);
+      if (stat.isDirectory()) return {existingParent: current, suffixParts};
+      return {
+        existingParent: path.dirname(current),
+        suffixParts: [path.basename(current), ...suffixParts],
+      };
+    } catch {
+      const parent = path.dirname(current);
+      suffixParts.unshift(path.basename(current));
+      if (parent === current) return {existingParent: current, suffixParts: []};
+      current = parent;
+    }
+  }
+}
+
+export async function checkNewPathAccess(
+  absolutePath: string,
+  options: SensitivePathPolicyOptions = {},
+): Promise<FileAccessPolicyResult> {
+  const lexical = checkLexicalPathAccess(absolutePath, options);
+  if (!lexical.allowed) return lexical;
+
+  const {existingParent, suffixParts} =
+    await findNearestExistingParent(absolutePath);
+  const realParent = await fs.realpath(existingParent);
+  const reconstructedTarget = path.join(realParent, ...suffixParts);
+  const real = checkLexicalPathAccess(reconstructedTarget, options);
+  if (!real.allowed) return denied(path.resolve(absolutePath));
+  return {allowed: true};
+}
+
+export async function isSymbolicLinkPath(
+  absolutePath: string,
+): Promise<boolean> {
+  try {
+    return (await fs.lstat(absolutePath)).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+```
+
+- [ ] **Step 4: Run policy tests to verify they pass**
+
+Run:
+
+```bash
+bun run --filter '@omnicraft/backend' test -- src/helpers/sensitive-path-policy.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit policy helper**
+
+```bash
+git add apps/backend/src/helpers/sensitive-path-policy.ts apps/backend/src/helpers/sensitive-path-policy.test.ts
+git commit -m "feat: add sensitive path policy helper"
+```
+
+---
+
+### Task 2: Enforce Policy in Direct File Tools
+
+**Files:**
+
+- Modify: `apps/backend/src/agent/tools/file/read-file.ts`
+- Modify: `apps/backend/src/agent/tools/file/write-file.ts`
+- Modify: `apps/backend/src/agent/tools/file/edit-file.ts`
+- Test: `apps/backend/src/agent/tools/file/read-file.test.ts`
+- Test: `apps/backend/src/agent/tools/file/write-file.test.ts`
+- Test: `apps/backend/src/agent/tools/file/edit-file.test.ts`
+
+- [ ] **Step 1: Write failing `read_file` policy tests**
+
+Append inside `describe('error cases', ...)` in `apps/backend/src/agent/tools/file/read-file.test.ts`:
+
+```ts
+it('denies blocked direct paths before reading', async () => {
+  await writeFile('.env', 'SECRET=value');
+
+  const result = await readFileTool.execute({filePath: '.env'}, context);
+
+  expect(result.status).toBe('failure');
+  assert(result.status === 'failure');
+  expect(result.content).toContain('Access denied by file access policy');
+  expect(result.content).toContain('Review the file access operation');
+  expect(result.content).toContain('ask the user to perform it manually');
+});
+
+it('denies symlink paths whose real target is blocked', async () => {
+  const target = await writeFile('.env.local', 'SECRET=value');
+  const link = path.join(tmpDir, 'env-link');
+  await fs.symlink(target, link);
+
+  const result = await readFileTool.execute({filePath: 'env-link'}, context);
+
+  expect(result.status).toBe('failure');
+  assert(result.status === 'failure');
+  expect(result.content).toContain('Access denied by file access policy');
+});
+```
+
+- [ ] **Step 2: Write failing `write_file` policy tests**
+
+Append inside `describe('error cases', ...)` in `apps/backend/src/agent/tools/file/write-file.test.ts`:
+
+```ts
+it('denies writing a new blocked path', async () => {
+  const result = await writeFileTool.execute(
+    {filePath: '.env.local', content: 'SECRET=value'},
+    context,
+  );
+
+  expect(result.status).toBe('failure');
+  assert(result.status === 'failure');
+  expect(result.content).toContain('Access denied by file access policy');
+  await expect(fs.stat(path.join(tmpDir, '.env.local'))).rejects.toThrow();
+});
+
+it('denies overwriting an existing blocked path', async () => {
+  const filePath = path.join(tmpDir, '.env');
+  await fs.writeFile(filePath, 'old');
+  context.fileStatTracker.set(filePath, 3, (await fs.stat(filePath)).mtimeMs);
+
+  const result = await writeFileTool.execute(
+    {filePath: '.env', content: 'new'},
+    context,
+  );
+
+  expect(result.status).toBe('failure');
+  assert(result.status === 'failure');
+  expect(result.content).toContain('Access denied by file access policy');
+  await expect(fs.readFile(filePath, 'utf-8')).resolves.toBe('old');
+});
+
+it('denies new writes through a symlinked parent to a blocked real target', async () => {
+  const realProject = path.join(tmpDir, 'real-project');
+  const linkProject = path.join(tmpDir, 'link-project');
+  await fs.mkdir(path.join(realProject, '.git'), {recursive: true});
+  await fs.symlink(realProject, linkProject, 'dir');
+
+  const result = await writeFileTool.execute(
+    {filePath: 'link-project/.git/new-config', content: 'content'},
+    context,
+  );
+
+  expect(result.status).toBe('failure');
+  assert(result.status === 'failure');
+  expect(result.content).toContain('Access denied by file access policy');
+});
+```
+
+- [ ] **Step 3: Write failing `edit_file` policy test**
+
+Append inside `describe('error cases', ...)` in `apps/backend/src/agent/tools/file/edit-file.test.ts`:
+
+```ts
+it('denies editing blocked direct paths before reading content', async () => {
+  const filePath = await writeFile('.env', 'SECRET=old');
+  const stat = await fs.stat(filePath);
+  context.fileStatTracker.set(filePath, stat.size, stat.mtimeMs);
+
+  const result = await editFileTool.execute(
+    {filePath: '.env', oldString: 'old', newString: 'new'},
+    context,
+  );
+
+  expect(result.status).toBe('failure');
+  assert(result.status === 'failure');
+  expect(result.content).toContain('Access denied by file access policy');
+  await expect(fs.readFile(filePath, 'utf-8')).resolves.toBe('SECRET=old');
+});
+```
+
+- [ ] **Step 4: Run direct tool tests to verify they fail**
+
+Run:
+
+```bash
+bun run --filter '@omnicraft/backend' test -- src/agent/tools/file/read-file.test.ts src/agent/tools/file/write-file.test.ts src/agent/tools/file/edit-file.test.ts
+```
+
+Expected: FAIL because the direct file tools do not call the policy yet.
+
+- [ ] **Step 5: Enforce policy in `read-file.ts`**
+
+Add this import to `apps/backend/src/agent/tools/file/read-file.ts`:
+
+```ts
+import {
+  checkExistingPathAccess,
+  checkLexicalPathAccess,
+} from '@/helpers/sensitive-path-policy.js';
+```
+
+Immediately after resolving `absolutePath`, insert:
+
+```ts
+const lexicalPolicy = checkLexicalPathAccess(absolutePath);
+if (!lexicalPolicy.allowed) {
+  return {
+    data: {message: lexicalPolicy.message},
+    content: lexicalPolicy.message,
+    status: 'failure',
+  };
+}
+```
+
+Keep the existing stat block that returns `File not found` for missing files.
+After the `!stat.isFile()` branch and before the binary check, insert:
+
+```ts
+const realPolicy = await checkExistingPathAccess(absolutePath);
+if (!realPolicy.allowed) {
+  return {
+    data: {message: realPolicy.message},
+    content: realPolicy.message,
+    status: 'failure',
+  };
+}
+```
+
+- [ ] **Step 6: Enforce policy in `write-file.ts`**
+
+Add this import to `apps/backend/src/agent/tools/file/write-file.ts`:
+
+```ts
+import {
+  checkExistingPathAccess,
+  checkLexicalPathAccess,
+  checkNewPathAccess,
+} from '@/helpers/sensitive-path-policy.js';
+```
+
+Immediately after resolving `absolutePath`, insert:
+
+```ts
+const lexicalPolicy = checkLexicalPathAccess(absolutePath);
+if (!lexicalPolicy.allowed) {
+  return {
+    data: {message: lexicalPolicy.message},
+    content: lexicalPolicy.message,
+    status: 'failure',
+  };
+}
+```
+
+After the existing `fs.stat(absolutePath)` attempt and before file-stat-tracker checks, insert:
+
+```ts
+const policyResult = existingStat
+  ? await checkExistingPathAccess(absolutePath)
+  : await checkNewPathAccess(absolutePath);
+if (!policyResult.allowed) {
+  return {
+    data: {message: policyResult.message},
+    content: policyResult.message,
+    status: 'failure',
+  };
+}
+```
+
+- [ ] **Step 7: Enforce policy in `edit-file.ts`**
+
+Add this import to `apps/backend/src/agent/tools/file/edit-file.ts`:
+
+```ts
+import {
+  checkExistingPathAccess,
+  checkLexicalPathAccess,
+} from '@/helpers/sensitive-path-policy.js';
+```
+
+Immediately after resolving `absolutePath`, insert:
+
+```ts
+const lexicalPolicy = checkLexicalPathAccess(absolutePath);
+if (!lexicalPolicy.allowed) {
+  return {
+    data: {message: lexicalPolicy.message},
+    content: lexicalPolicy.message,
+    status: 'failure',
+  };
+}
+```
+
+After the existing stat success and `stat.isFile()` check, insert:
+
+```ts
+const realPolicy = await checkExistingPathAccess(absolutePath);
+if (!realPolicy.allowed) {
+  return {
+    data: {message: realPolicy.message},
+    content: realPolicy.message,
+    status: 'failure',
+  };
+}
+```
+
+- [ ] **Step 8: Run direct tool tests to verify they pass**
+
+Run:
+
+```bash
+bun run --filter '@omnicraft/backend' test -- src/agent/tools/file/read-file.test.ts src/agent/tools/file/write-file.test.ts src/agent/tools/file/edit-file.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit direct tool enforcement**
+
+```bash
+git add apps/backend/src/agent/tools/file/read-file.ts apps/backend/src/agent/tools/file/write-file.ts apps/backend/src/agent/tools/file/edit-file.ts apps/backend/src/agent/tools/file/read-file.test.ts apps/backend/src/agent/tools/file/write-file.test.ts apps/backend/src/agent/tools/file/edit-file.test.ts
+git commit -m "feat: block sensitive direct file operations"
+```
+
+---
+
+### Task 3: Enforce Policy in Recursive Search Tools
+
+**Files:**
+
+- Modify: `apps/backend/src/agent/tools/file/find-files.ts`
+- Modify: `apps/backend/src/agent/tools/file/search-files.ts`
+- Test: `apps/backend/src/agent/tools/file/find-files.test.ts`
+- Test: `apps/backend/src/agent/tools/file/search-files.test.ts`
+
+- [ ] **Step 1: Write failing `find_files` tests**
+
+Append inside `describe('success cases', ...)` in `apps/backend/src/agent/tools/file/find-files.test.ts`:
+
+```ts
+it('skips blocked paths and appends the policy note', async () => {
+  await writeFile('src/app.ts', '');
+  await writeFile('.env', 'SECRET=value');
+  await writeFile('.git/config', '[core]');
+
+  const result = await findFilesTool.execute({pattern: '**/*'}, context);
+
+  expect(result.status).toBe('success');
+  assert(result.status === 'success');
+  expect(result.content).toContain('src/app.ts');
+  expect(result.content).not.toContain('.env');
+  expect(result.content).not.toContain('.git/config');
+  expect(result.content).toContain(
+    'Some paths were skipped because they are blocked by file access policy',
+  );
+  expect(result.data.files).toContain('src/app.ts');
+  expect(result.data.files).not.toContain('.env');
+});
+
+it('skips symlinked files', async () => {
+  const target = await writeFile('target.ts', '');
+  await fs.symlink(target, path.join(tmpDir, 'link.ts'));
+
+  const result = await findFilesTool.execute({pattern: '**/*.ts'}, context);
+
+  expect(result.status).toBe('success');
+  assert(result.status === 'success');
+  expect(result.data.files).toContain('target.ts');
+  expect(result.data.files).not.toContain('link.ts');
+  expect(result.content).toContain(
+    'Some paths were skipped because they are blocked by file access policy',
+  );
+});
+```
+
+Append inside `describe('error cases', ...)` in the same file:
+
+```ts
+it('denies a search root whose real target is blocked', async () => {
+  await fs.mkdir(path.join(tmpDir, '.git'), {recursive: true});
+  await fs.symlink(
+    path.join(tmpDir, '.git'),
+    path.join(tmpDir, 'git-link'),
+    'dir',
+  );
+
+  const result = await findFilesTool.execute(
+    {pattern: '**/*', path: 'git-link'},
+    context,
+  );
+
+  expect(result.status).toBe('failure');
+  assert(result.status === 'failure');
+  expect(result.content).toContain('Access denied by file access policy');
+});
+```
+
+- [ ] **Step 2: Write failing `search_files` tests**
+
+Append inside `describe('success cases', ...)` in `apps/backend/src/agent/tools/file/search-files.test.ts`:
+
+```ts
+it('skips blocked paths and appends the policy note', async () => {
+  await writeFile('src/app.ts', 'target\n');
+  await writeFile('.env', 'target\n');
+  await writeFile('.git/config', 'target\n');
+
+  const result = await searchFilesTool.execute({pattern: 'target'}, context);
+
+  expect(result.status).toBe('success');
+  assert(result.status === 'success');
+  expect(result.content).toContain('src/app.ts:1: target');
+  expect(result.content).not.toContain('.env');
+  expect(result.content).not.toContain('.git/config');
+  expect(result.content).toContain(
+    'Some paths were skipped because they are blocked by file access policy',
+  );
+  expect(result.data.matches.map((m) => m.file)).toEqual(['src/app.ts']);
+});
+
+it('skips symlinked files', async () => {
+  const target = await writeFile('target.ts', 'target\n');
+  await fs.symlink(target, path.join(tmpDir, 'link.ts'));
+
+  const result = await searchFilesTool.execute({pattern: 'target'}, context);
+
+  expect(result.status).toBe('success');
+  assert(result.status === 'success');
+  expect(result.data.matches.map((m) => m.file)).toEqual(['target.ts']);
+  expect(result.content).toContain(
+    'Some paths were skipped because they are blocked by file access policy',
+  );
+});
+```
+
+Append inside `describe('error cases', ...)` in the same file:
+
+```ts
+it('denies a search root whose real target is blocked', async () => {
+  await fs.mkdir(path.join(tmpDir, '.git'), {recursive: true});
+  await fs.symlink(
+    path.join(tmpDir, '.git'),
+    path.join(tmpDir, 'git-link'),
+    'dir',
+  );
+
+  const result = await searchFilesTool.execute(
+    {pattern: 'anything', path: 'git-link'},
+    context,
+  );
+
+  expect(result.status).toBe('failure');
+  assert(result.status === 'failure');
+  expect(result.content).toContain('Access denied by file access policy');
+});
+```
+
+- [ ] **Step 3: Run recursive search tests to verify they fail**
+
+Run:
+
+```bash
+bun run --filter '@omnicraft/backend' test -- src/agent/tools/file/find-files.test.ts src/agent/tools/file/search-files.test.ts
+```
+
+Expected: FAIL because the tools still include blocked and symlinked entries.
+
+- [ ] **Step 4: Update `find-files.ts`**
+
+Add this import:
+
+```ts
+import {
+  checkExistingPathAccess,
+  checkLexicalPathAccess,
+  FILE_ACCESS_POLICY_SKIPPED_MESSAGE,
+  isSymbolicLinkPath,
+} from '@/helpers/sensitive-path-policy.js';
+```
+
+After verifying `searchDir` exists and is a directory, insert:
+
+```ts
+const rootPolicy = await checkExistingPathAccess(searchDir);
+if (!rootPolicy.allowed) {
+  return {
+    data: {message: rootPolicy.message},
+    content: rootPolicy.message,
+    status: 'failure',
+  };
+}
+```
+
+Add `followSymbolicLinks: false` to the fast-glob options:
+
+```ts
+const stream = fg.stream(args.pattern, {
+  cwd: searchDir,
+  onlyFiles: true,
+  dot: true,
+  followSymbolicLinks: false,
+});
+```
+
+Add a skipped flag next to `timedOut`:
+
+```ts
+let skippedByPolicy = false;
+```
+
+Inside the `for await` loop, replace the direct `entries.push(entry);` with:
+
+```ts
+const absoluteEntryPath = path.join(searchDir, entry);
+const entryPolicy = checkLexicalPathAccess(absoluteEntryPath);
+if (!entryPolicy.allowed || (await isSymbolicLinkPath(absoluteEntryPath))) {
+  skippedByPolicy = true;
+  continue;
+}
+
+entries.push(entry);
+```
+
+When building successful content bodies, append the note with:
+
+```ts
+const policyNote = skippedByPolicy
+  ? `\n${FILE_ACCESS_POLICY_SKIPPED_MESSAGE}`
+  : '';
+```
+
+Then append `${policyNote}` to the `content` string in the no-match, hit-limit,
+and normal-success returns. Example normal return:
+
+```ts
+return {
+  data,
+  content: `${header}\n${body}${policyNote}`,
+  status: 'success',
+};
+```
+
+Update the tool description string to include:
+
+```ts
+'Symlinked directories and files are not traversed or returned. ' +
+  'If expected files are missing from results, review whether they are behind a symlink; ' +
+  'do not attempt to bypass file access policy.';
+```
+
+- [ ] **Step 5: Update `search-files.ts`**
+
+Add this import:
+
+```ts
+import {
+  checkExistingPathAccess,
+  checkLexicalPathAccess,
+  FILE_ACCESS_POLICY_SKIPPED_MESSAGE,
+  isSymbolicLinkPath,
+} from '@/helpers/sensitive-path-policy.js';
+```
+
+After verifying `searchDir` exists and is a directory, insert:
+
+```ts
+const rootPolicy = await checkExistingPathAccess(searchDir);
+if (!rootPolicy.allowed) {
+  return {
+    data: {message: rootPolicy.message},
+    content: rootPolicy.message,
+    status: 'failure',
+  };
+}
+```
+
+Add `followSymbolicLinks: false` to the fast-glob options:
+
+```ts
+const stream = fg.stream(args.filePattern ?? '**/*', {
+  cwd: searchDir,
+  onlyFiles: true,
+  dot: true,
+  followSymbolicLinks: false,
+});
+```
+
+Add a skipped flag near `timedOut`:
+
+```ts
+let skippedByPolicy = false;
+```
+
+Inside the `for await` loop, after computing `absolutePath`, insert before creating `task`:
+
+```ts
+const entryPolicy = checkLexicalPathAccess(absolutePath);
+if (!entryPolicy.allowed || (await isSymbolicLinkPath(absolutePath))) {
+  skippedByPolicy = true;
+  continue;
+}
+```
+
+Before output branches, create:
+
+```ts
+const policyNote = skippedByPolicy
+  ? `\n${FILE_ACCESS_POLICY_SKIPPED_MESSAGE}`
+  : '';
+```
+
+Append `${policyNote}` to successful no-match, hit-limit, and normal-success content. Example normal return:
+
+```ts
+return {data, content: `${header}\n${body}${policyNote}`, status: 'success'};
+```
+
+Update the tool description string to include:
+
+```ts
+'Symlinked directories and files are not traversed or searched. ' +
+  'If expected matches are missing, review whether the files are behind a symlink; ' +
+  'do not attempt to bypass file access policy.';
+```
+
+- [ ] **Step 6: Run recursive search tests to verify they pass**
+
+Run:
+
+```bash
+bun run --filter '@omnicraft/backend' test -- src/agent/tools/file/find-files.test.ts src/agent/tools/file/search-files.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit recursive search enforcement**
+
+```bash
+git add apps/backend/src/agent/tools/file/find-files.ts apps/backend/src/agent/tools/file/search-files.ts apps/backend/src/agent/tools/file/find-files.test.ts apps/backend/src/agent/tools/file/search-files.test.ts
+git commit -m "feat: skip sensitive paths in file searches"
+```
+
+---
+
+### Task 4: Reject Blocked Workspace Roots
+
+**Files:**
+
+- Modify: `apps/backend/src/services/file-access-settings/types.ts`
+- Modify: `apps/backend/src/services/file-access-settings/helpers.ts`
+- Test: `apps/backend/src/services/file-access-settings/helpers.test.ts`
+
+- [ ] **Step 1: Write failing workspace validation tests**
+
+Append to `apps/backend/src/services/file-access-settings/helpers.test.ts`:
+
+```ts
+it('rejects blocked workspace roots', async () => {
+  const gitDir = path.join(tempDir, '.git');
+  await fs.mkdir(gitDir);
+
+  const {errors} = await normalizeAndValidatePaths([{path: gitDir}]);
+
+  expect(errors).toEqual([{path: gitDir, reason: PathValidationError.BLOCKED}]);
+});
+
+it('allows normal workspaces that contain blocked descendants', async () => {
+  await fs.mkdir(path.join(tempDir, '.git'));
+  await fs.writeFile(path.join(tempDir, '.env'), 'SECRET=value');
+
+  const {normalized, errors} = await normalizeAndValidatePaths([
+    {path: tempDir},
+  ]);
+
+  expect(errors).toEqual([]);
+  expect(normalized).toEqual([{path: tempDir}]);
+});
+```
+
+- [ ] **Step 2: Run workspace validation tests to verify they fail**
+
+Run:
+
+```bash
+bun run --filter '@omnicraft/backend' test -- src/services/file-access-settings/helpers.test.ts
+```
+
+Expected: FAIL because `PathValidationError.BLOCKED` does not exist and validation does not call the policy.
+
+- [ ] **Step 3: Add `BLOCKED` error enum**
+
+Modify `apps/backend/src/services/file-access-settings/types.ts`:
+
+```ts
+export enum PathValidationError {
+  NOT_ABSOLUTE = 'NOT_ABSOLUTE',
+  DUPLICATE = 'DUPLICATE',
+  NOT_FOUND = 'NOT_FOUND',
+  NOT_DIRECTORY = 'NOT_DIRECTORY',
+  NOT_ACCESSIBLE = 'NOT_ACCESSIBLE',
+  BLOCKED = 'BLOCKED',
+}
+```
+
+- [ ] **Step 4: Call the policy from workspace validation**
+
+Modify `apps/backend/src/services/file-access-settings/helpers.ts`.
+
+Add import:
+
+```ts
+import {checkLexicalPathAccess} from '@/helpers/sensitive-path-policy.js';
+```
+
+Inside `normalizeAndValidatePaths`, after the duplicate check and before `validateSinglePath(resolvedPath)`, insert:
+
+```ts
+const policy = checkLexicalPathAccess(resolvedPath);
+if (!policy.allowed) {
+  errors.push({path: entry.path, reason: PathValidationError.BLOCKED});
+  continue;
+}
+```
+
+- [ ] **Step 5: Run workspace validation tests to verify they pass**
+
+Run:
+
+```bash
+bun run --filter '@omnicraft/backend' test -- src/services/file-access-settings/helpers.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit workspace validation**
+
+```bash
+git add apps/backend/src/services/file-access-settings/types.ts apps/backend/src/services/file-access-settings/helpers.ts apps/backend/src/services/file-access-settings/helpers.test.ts
+git commit -m "feat: reject blocked file access workspaces"
+```
+
+---
+
+### Task 5: Final Verification and Cleanup
+
+**Files:**
+
+- Review only unless verification finds issues.
+
+- [ ] **Step 1: Run full backend tests**
+
+Run:
+
+```bash
+bun run --filter '@omnicraft/backend' test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run backend typecheck**
+
+Run:
+
+```bash
+bun run --filter '@omnicraft/backend' typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run backend lint**
+
+Run:
+
+```bash
+bun run --filter '@omnicraft/backend' lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run format check**
+
+Run:
+
+```bash
+bun run format:check
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect final diff for policy consistency**
+
+Run:
+
+```bash
+git diff --stat HEAD~4..HEAD
+git diff HEAD~4..HEAD -- apps/backend/src/helpers/sensitive-path-policy.ts apps/backend/src/agent/tools/file apps/backend/src/services/file-access-settings
+```
+
+Expected: All five file tools use `sensitive-path-policy`, search tools set `followSymbolicLinks: false`, and workspace validation uses `PathValidationError.BLOCKED`.
+
+- [ ] **Step 6: Commit verification fixes if needed**
+
+If Step 1-5 required fixes, commit them:
+
+```bash
+git add apps/backend/src
+git commit -m "fix: align sensitive path policy enforcement"
+```
+
+If no fixes were needed, do not create an empty commit.
+
+---
+
+## Implementation Notes
+
+- Do not add an LLM-facing option to follow symbolic links.
+- Do not block all dotfiles. `.gitignore`, `.prettierrc`, and similar project files must remain accessible unless they match a specific blocked rule.
+- Direct file operations should include the requested path in the denial message.
+- Recursive searches should avoid listing each skipped blocked path.
+- `run_command` remains out of scope for this implementation.

--- a/docs/superpowers/specs/2026-04-25-agent-file-tool-blocklist-design.md
+++ b/docs/superpowers/specs/2026-04-25-agent-file-tool-blocklist-design.md
@@ -100,40 +100,76 @@ Block pattern matches:
 
 ## Architecture
 
-Add one central backend policy helper used by file tools and workspace
+Add one central pure backend policy helper used by file tools and workspace
 validation:
 
 `apps/backend/src/helpers/sensitive-path-policy.ts`
 
 The helper owns:
 
-- default blocked root construction using `os.homedir()` and `getDataDir()`
+- blocked root construction from caller-provided `homeDir` and `dataDir`
 - normalized lexical path checks
-- realpath checks for existing paths
-- nearest-existing-parent resolution for writes to new paths
-- result helpers that format the standard policy failure and skipped-path
-  messages
+- structured policy results that identify the blocked requested path and reason
+
+The helper must not read the filesystem, read environment/default app settings,
+or format LLM-facing strings. Agent-specific filesystem adaptation and messages
+live near the agent file tools.
 
 Helper API:
 
 ```ts
 type FileAccessPolicyResult =
   | {allowed: true}
-  | {allowed: false; message: string};
+  | {
+      allowed: false;
+      blockedPath: string;
+      reason:
+        | 'blocked-root'
+        | 'blocked-segment'
+        | 'blocked-basename'
+        | 'blocked-pattern';
+    };
 
-async function checkExistingPathAccess(
+interface SensitivePathPolicy {
+  readonly homeDir: string;
+  readonly dataDir: string;
+}
+
+function createSensitivePathPolicy(options: {
+  homeDir: string;
+  dataDir: string;
+}): SensitivePathPolicy;
+
+function checkSensitivePathAccess(
   absolutePath: string,
-): Promise<FileAccessPolicyResult>;
-
-async function checkNewPathAccess(
-  absolutePath: string,
-): Promise<FileAccessPolicyResult>;
-
-function checkLexicalPathAccess(absolutePath: string): FileAccessPolicyResult;
+  policy: SensitivePathPolicy,
+): FileAccessPolicyResult;
 ```
 
-Every file tool and workspace validation path must call this policy module
-rather than duplicating blocklist logic locally.
+Workspace validation calls this pure policy module directly. File tools call it
+through the file-tool filesystem adapter below. No caller duplicates blocklist
+logic locally.
+
+Add a small default-policy factory for production callers:
+
+`apps/backend/src/helpers/default-sensitive-path-policy.ts`
+
+This module reads `os.homedir()` and `getDataDir()`, then calls the pure helper.
+
+Add file-tool-specific filesystem wrappers separately:
+
+`apps/backend/src/agent/tools/file/file-access-policy.ts`
+
+This module owns `fs.realpath`, nearest-existing-parent checks for new writes,
+and symlink detection for file tools. It returns the same structured policy
+result and does not format LLM-facing strings.
+
+Add agent file-tool message helpers separately:
+
+`apps/backend/src/agent/tools/file/file-access-policy-messages.ts`
+
+This module owns the LLM-facing denial and skipped-path messages used by
+`read_file`, `write_file`, `edit_file`, `find_files`, and `search_files`.
 
 ## Tool Behavior
 

--- a/docs/superpowers/specs/2026-04-25-agent-file-tool-blocklist-design.md
+++ b/docs/superpowers/specs/2026-04-25-agent-file-tool-blocklist-design.md
@@ -100,9 +100,10 @@ Block pattern matches:
 
 ## Architecture
 
-Add one central backend policy helper for file tools:
+Add one central backend policy helper used by file tools and workspace
+validation:
 
-`apps/backend/src/agent/tools/file/sensitive-path-policy.ts`
+`apps/backend/src/helpers/sensitive-path-policy.ts`
 
 The helper owns:
 
@@ -110,34 +111,29 @@ The helper owns:
 - normalized lexical path checks
 - realpath checks for existing paths
 - nearest-existing-parent resolution for writes to new paths
-- result helpers that format the standard policy failure message
+- result helpers that format the standard policy failure and skipped-path
+  messages
 
 Helper API:
 
 ```ts
-type FileAccessOperation = 'read' | 'write' | 'edit' | 'find' | 'search';
-
 type FileAccessPolicyResult =
   | {allowed: true}
   | {allowed: false; message: string};
 
 async function checkExistingPathAccess(
   absolutePath: string,
-  operation: FileAccessOperation,
 ): Promise<FileAccessPolicyResult>;
 
 async function checkNewPathAccess(
   absolutePath: string,
 ): Promise<FileAccessPolicyResult>;
 
-function checkLexicalPathAccess(
-  absolutePath: string,
-  operation: FileAccessOperation,
-): FileAccessPolicyResult;
+function checkLexicalPathAccess(absolutePath: string): FileAccessPolicyResult;
 ```
 
-Every file tool must call this policy module rather than duplicating blocklist
-logic locally.
+Every file tool and workspace validation path must call this policy module
+rather than duplicating blocklist logic locally.
 
 ## Tool Behavior
 

--- a/docs/superpowers/specs/2026-04-25-agent-file-tool-blocklist-design.md
+++ b/docs/superpowers/specs/2026-04-25-agent-file-tool-blocklist-design.md
@@ -1,0 +1,285 @@
+# Agent File Tool Blocklist Design
+
+## Background
+
+Agent file tools currently resolve paths against the agent working directory and
+then read, write, enumerate, or search directly. Workspace settings validate that
+configured directories exist and are readable/writable, but they do not exclude
+sensitive descendants. If a user configures a broad workspace such as the home
+directory, file tools can reach sensitive paths like `.ssh` or the app's own
+settings directory.
+
+This design adds a default blocklist for agent file tools. It is a guardrail for
+the typed file tools, not a complete local sandbox. Shell commands remain a
+separate boundary.
+
+## Goals
+
+- Prevent file tools from reading, writing, returning, or searching high
+  confidence sensitive paths.
+- Apply the same policy consistently across direct file operations,
+  recursive search tools, and workspace validation.
+- Avoid LLM-facing bypass knobs.
+- Keep legitimate explicit symlink use possible only when the resolved target is
+  allowed.
+- Tell the agent how to respond when a blocked operation is necessary.
+
+## Non-Goals
+
+- No shell-command mediation in this change. `run_command` can still access any
+  path the OS user can access.
+- No user-configurable allow overrides in the initial implementation.
+- No attempt to detect every secret filename. The first blocklist is deliberately
+  high confidence.
+- No automatic disclosure of every skipped sensitive path during broad searches.
+
+## Default Blocklist
+
+The policy blocks both exact roots and sensitive names/patterns. Paths are
+checked after normalization. Direct operations also check real filesystem targets
+where applicable.
+
+### Blocked Roots
+
+Resolve these roots from the current OS user and app environment:
+
+- `~/.ssh`
+- `~/.gnupg`
+- `~/.pki`
+- `~/.aws`
+- `~/.azure`
+- `~/.config/gcloud`
+- `~/.config/gh`
+- `~/.kube`
+- `~/.docker`
+- `~/.terraform.d`
+- `DATA_DIR` if set, otherwise `~/.omni-craft`
+- macOS credential/browser stores:
+  - `~/Library/Keychains`
+  - `~/Library/Application Support/Google/Chrome`
+  - `~/Library/Application Support/Chromium`
+  - `~/Library/Application Support/BraveSoftware`
+  - `~/Library/Application Support/Firefox`
+
+Also block VCS metadata directories by path segment anywhere under a workspace:
+
+- `.git`
+- `.hg`
+- `.svn`
+
+The VCS block does not block useful sibling files like `.gitignore`.
+
+### Blocked Files and Patterns
+
+Block exact basename matches:
+
+- `.netrc`
+- `.git-credentials`
+- `.npmrc`
+- `.pypirc`
+- `.pgpass`
+- `.my.cnf`
+- `.bash_history`
+- `.zsh_history`
+- `.fish_history`
+- `.psql_history`
+- `.mysql_history`
+- `.sqlite_history`
+- `credentials.json`
+
+Block pattern matches:
+
+- `.env` and `.env.*`, except `.env.example`, `.env.sample`, and
+  `.env.template`
+- `*.pem`
+- `*.key`
+- `*.p12`
+- `*.pfx`
+- `id_rsa`, `id_dsa`, `id_ecdsa`, and `id_ed25519`
+- `*service-account*.json`
+
+## Architecture
+
+Add one central backend policy helper for file tools:
+
+`apps/backend/src/agent/tools/file/sensitive-path-policy.ts`
+
+The helper owns:
+
+- default blocked root construction using `os.homedir()` and `getDataDir()`
+- normalized lexical path checks
+- realpath checks for existing paths
+- nearest-existing-parent resolution for writes to new paths
+- result helpers that format the standard policy failure message
+
+Helper API:
+
+```ts
+type FileAccessOperation = 'read' | 'write' | 'edit' | 'find' | 'search';
+
+type FileAccessPolicyResult =
+  | {allowed: true}
+  | {allowed: false; message: string};
+
+async function checkExistingPathAccess(
+  absolutePath: string,
+  operation: FileAccessOperation,
+): Promise<FileAccessPolicyResult>;
+
+async function checkNewPathAccess(
+  absolutePath: string,
+): Promise<FileAccessPolicyResult>;
+
+function checkLexicalPathAccess(
+  absolutePath: string,
+  operation: FileAccessOperation,
+): FileAccessPolicyResult;
+```
+
+Every file tool must call this policy module rather than duplicating blocklist
+logic locally.
+
+## Tool Behavior
+
+### Direct File Tools
+
+`read_file`, `edit_file`, and existing-file `write_file`:
+
+1. Resolve the requested path against `workingDirectory`.
+2. Check the normalized lexical path.
+3. Resolve the real target with `fs.realpath` after confirming the path exists.
+4. Check the real target.
+5. Continue only if both checks pass.
+
+New-file `write_file`:
+
+1. Resolve the requested path against `workingDirectory`.
+2. Check the normalized lexical path.
+3. Resolve the nearest existing parent with `fs.realpath`.
+4. Reconstruct the intended real target by appending the non-existing suffix.
+5. Check that reconstructed target.
+6. Continue only if both checks pass.
+
+This catches paths such as `workspace/link-to-home/.ssh/new-key` when
+`link-to-home` is a symlink to the user's home directory.
+
+### Recursive Search Tools
+
+`find_files` and `search_files` do not follow symbolic links.
+
+- Set `followSymbolicLinks: false` in `fast-glob` options.
+- Policy-check the search root before starting the glob. This check includes
+  realpath, because fast-glob's symlink option does not protect a symlinked base
+  directory.
+- Skip symbolic-link entries entirely. This includes symlinked files and
+  symlinked directories.
+- Filter every returned or searched entry through the lexical policy before
+  returning it from `find_files` or opening it in `search_files`.
+- Skip blocked descendants during broad searches and append a policy note when
+  anything was skipped.
+
+The tool descriptions should mention this behavior:
+
+- `find_files`: `Symlinked directories and files are not traversed or returned. If expected files are missing from results, review whether they are behind a symlink; do not attempt to bypass file access policy.`
+- `search_files`: `Symlinked directories and files are not traversed or searched. If expected matches are missing, review whether the files are behind a symlink; do not attempt to bypass file access policy.`
+
+No LLM-facing option is added to enable symlink following.
+
+## Error Handling
+
+Direct blocked operations fail with this message shape:
+
+```text
+Error: Access denied by file access policy: <path>. This operation would access a blocked sensitive path. Review the file access operation. If this operation is necessary, stop and ask the user to perform it manually.
+```
+
+Broad search tools skip blocked descendants and add a final note when one or
+more entries were skipped:
+
+```text
+Some paths were skipped because they are blocked by file access policy. Do not try to bypass this policy. If accessing those paths is necessary, stop and ask the user to perform the operation manually.
+```
+
+Search tools should not enumerate every skipped blocked path. Direct operations
+may include the requested path because the agent already supplied it.
+
+## Workspace Validation
+
+Workspace settings validation should reject workspaces that are blocked by the
+same policy.
+
+- Add `PathValidationError.BLOCKED`.
+- `normalizeAndValidatePaths` checks the normalized path against the file access
+  policy after absolute-path validation and duplicate detection.
+- A user cannot configure `.ssh`, `~/.omni-craft`, `.git`, or another blocked
+  root as the workspace itself.
+
+This validation does not reject a normal project workspace merely because it
+contains blocked descendants such as `.git` or `.env`; those descendants are
+filtered by the tools at use time.
+
+## Data Flow
+
+Direct read/edit/write:
+
+1. Tool receives path from LLM.
+2. Tool resolves against `context.workingDirectory`.
+3. Policy module checks lexical and real target paths.
+4. Tool either fails with the standard policy message or proceeds with the
+   existing file operation.
+
+Find/search:
+
+1. Tool receives search root and pattern from LLM.
+2. Tool resolves and policy-checks the search root.
+3. Tool runs fast-glob with `followSymbolicLinks: false`.
+4. Tool skips symlink entries and blocked entries.
+5. Tool returns normal results plus the skipped-path policy note if needed.
+
+Workspace save:
+
+1. Settings endpoint receives workspace entries.
+2. Existing normalization/validation runs.
+3. The policy rejects blocked workspace roots with `BLOCKED`.
+4. Valid workspaces are saved unchanged.
+
+## Testing
+
+Add focused tests around the new policy and each affected integration point.
+
+Policy helper tests:
+
+- blocks `~/.ssh` and descendants
+- blocks `DATA_DIR` or `~/.omni-craft`
+- blocks `.git` path segments but not `.gitignore`
+- blocks `.env` and `.env.local` but allows `.env.example`
+- blocks private key extensions and exact secret filenames
+- catches symlinks whose real target is blocked
+- catches new-file writes through a symlinked parent
+
+Tool tests:
+
+- `read_file` fails on blocked direct paths with the standard message
+- `write_file` fails on blocked existing and new paths
+- `edit_file` fails before reading/writing blocked paths
+- `find_files` skips blocked entries and symlink entries, then appends the
+  policy note
+- `search_files` does not search blocked entries or symlink entries, then
+  appends the policy note
+- search root that is itself a symlink to a blocked directory fails
+
+Settings tests:
+
+- workspace save rejects blocked roots with `PathValidationError.BLOCKED`
+- normal workspaces containing blocked descendants remain valid
+
+## Risks and Follow-Ups
+
+- This does not stop `run_command` from accessing sensitive files. Treat shell
+  mediation or a restricted-command mode as a separate follow-up if the threat
+  model requires it.
+- The initial blocklist may need tuning if it blocks legitimate project files.
+  Prefer adding human-controlled settings later over adding tool parameters that
+  the LLM can choose.
+- Browser profile blocking may vary by OS and browser. The first implementation
+  should keep these paths centralized so additions are straightforward.


### PR DESCRIPTION
## Summary
- Add a shared sensitive-path policy with default home/data-dir roots and structured block reasons.
- Enforce policy in direct file tools, recursive search tools, and workspace validation.
- Harden recursive searches against symlink traversal while returning only generic skipped-policy notes.

## Test Plan
- [x] bun run --filter '@omnicraft/backend' test
- [x] bun run --filter '@omnicraft/backend' typecheck
- [x] bun run --filter '@omnicraft/backend' lint
- [x] bun run format:check