### PR TITLE
Fix subagent replay output

### DIFF
--- a/apps/frontend/src/modules/chat-session/helpers/subagent-event-bus.test.ts
+++ b/apps/frontend/src/modules/chat-session/helpers/subagent-event-bus.test.ts
@@ -1,0 +1,100 @@
+import {describe, expect, it, vi} from 'vitest';
+
+import type {ChatEventMap} from '../components/StreamingMessageDisplay/index.js';
+import {SubagentEventBus} from './subagent-event-bus.js';
+
+function createBus() {
+  return new SubagentEventBus();
+}
+
+function nextMicrotask() {
+  return Promise.resolve();
+}
+
+describe('SubagentEventBus', () => {
+  it('immediately delivers events to listeners already subscribed', () => {
+    const bus = createBus();
+    const listener = vi.fn<(data: ChatEventMap['user-message-sent']) => void>();
+    const event: ChatEventMap['user-message-sent'] = {content: 'hello'};
+
+    bus.on('user-message-sent', listener);
+    bus.emit('user-message-sent', event);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(event);
+  });
+
+  it('replays matching historical events to a late listener on a microtask', async () => {
+    const bus = createBus();
+    const firstEvent: ChatEventMap['user-message-sent'] = {content: 'first'};
+    const secondEvent: ChatEventMap['user-message-sent'] = {content: 'second'};
+    const listener = vi.fn<(data: ChatEventMap['user-message-sent']) => void>();
+
+    bus.emit('user-message-sent', firstEvent);
+    bus.emit('user-message-sent', secondEvent);
+    bus.on('user-message-sent', listener);
+
+    expect(listener).not.toHaveBeenCalled();
+
+    await nextMicrotask();
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenNthCalledWith(1, firstEvent);
+    expect(listener).toHaveBeenNthCalledWith(2, secondEvent);
+  });
+
+  it('does not replay historical events for a different event type', async () => {
+    const bus = createBus();
+    const listener = vi.fn<(data: ChatEventMap['user-message-sent']) => void>();
+
+    bus.emit('stream-error', {message: 'failed'});
+    bus.on('user-message-sent', listener);
+
+    await nextMicrotask();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('does not duplicate history for a listener that already received an event live', async () => {
+    const bus = createBus();
+    const listener = vi.fn<(data: ChatEventMap['user-message-sent']) => void>();
+    const event: ChatEventMap['user-message-sent'] = {content: 'live'};
+
+    bus.on('user-message-sent', listener);
+    bus.emit('user-message-sent', event);
+    bus.on('user-message-sent', listener);
+
+    await nextMicrotask();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(event);
+  });
+
+  it('off prevents a listener from receiving pending replayed history and future events', async () => {
+    const bus = createBus();
+    const listener = vi.fn<(data: ChatEventMap['user-message-sent']) => void>();
+
+    bus.emit('user-message-sent', {content: 'before'});
+    bus.on('user-message-sent', listener);
+    bus.off('user-message-sent', listener);
+
+    await nextMicrotask();
+    bus.emit('user-message-sent', {content: 'after'});
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('does not call the same listener twice when registered twice for the same event', async () => {
+    const bus = createBus();
+    const listener = vi.fn<(data: ChatEventMap['user-message-sent']) => void>();
+    const event: ChatEventMap['user-message-sent'] = {content: 'only once'};
+
+    bus.on('user-message-sent', listener);
+    bus.on('user-message-sent', listener);
+    await nextMicrotask();
+    bus.emit('user-message-sent', event);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(event);
+  });
+});

--- a/apps/frontend/src/modules/chat-session/helpers/subagent-event-bus.ts
+++ b/apps/frontend/src/modules/chat-session/helpers/subagent-event-bus.ts
@@ -1,0 +1,112 @@
+import {EventBus} from '@/helpers/event-bus.js';
+
+import type {ChatEventMap} from '../components/StreamingMessageDisplay/index.js';
+
+type Listener<T> = (data: T) => void;
+
+type ChatEventEntry = {
+  [K in keyof ChatEventMap]: {event: K; data: ChatEventMap[K]};
+}[keyof ChatEventMap];
+
+interface ListenerRecord {
+  event: keyof ChatEventMap;
+  listener: Listener<unknown>;
+  nextReplayIndex: number;
+}
+
+/**
+ * Event bus used only for subagent transcript forwarding.
+ *
+ * During SSE replay, `subagent-output` events can be forwarded before the
+ * nested subagent display has mounted and registered its listeners. A plain
+ * EventBus would drop those early events, leaving the replayed subagent body
+ * blank. This bus keeps a small per-subagent history so late listeners can
+ * receive the already-forwarded transcript while preserving the existing
+ * parent-stream-to-child-bus data flow.
+ */
+export class SubagentEventBus extends EventBus<ChatEventMap> {
+  private readonly history: ChatEventEntry[] = [];
+  private readonly listenerRecords = new Set<ListenerRecord>();
+  private replayScheduled = false;
+
+  override on<K extends keyof ChatEventMap>(
+    event: K,
+    listener: Listener<ChatEventMap[K]>,
+  ): void {
+    const storedListener = listener as Listener<unknown>;
+    for (const record of this.listenerRecords) {
+      if (record.event === event && record.listener === storedListener) return;
+    }
+
+    this.listenerRecords.add({
+      event,
+      listener: storedListener,
+      nextReplayIndex: 0,
+    });
+
+    if (this.history.length > 0) {
+      this.scheduleReplay();
+    }
+  }
+
+  override off<K extends keyof ChatEventMap>(
+    event: K,
+    listener: Listener<ChatEventMap[K]>,
+  ): void {
+    const storedListener = listener as Listener<unknown>;
+    for (const record of this.listenerRecords) {
+      if (record.event === event && record.listener === storedListener) {
+        this.listenerRecords.delete(record);
+      }
+    }
+  }
+
+  override emit<K extends keyof ChatEventMap>(
+    ...args: ChatEventMap[K] extends undefined
+      ? [event: K]
+      : [event: K, data: ChatEventMap[K]]
+  ): void {
+    this.flushReplay();
+
+    const [event, data] = args as [K, ChatEventMap[K]];
+    this.history.push({event, data} as ChatEventEntry);
+
+    const nextReplayIndex = this.history.length;
+    for (const record of this.listenerRecords) {
+      if (record.event !== event) continue;
+      record.listener(data);
+      record.nextReplayIndex = nextReplayIndex;
+    }
+  }
+
+  private scheduleReplay(): void {
+    if (this.replayScheduled) return;
+    this.replayScheduled = true;
+    queueMicrotask(() => {
+      this.replayScheduled = false;
+      this.flushReplay();
+    });
+  }
+
+  private flushReplay(): void {
+    if (!this.hasPendingReplay()) return;
+
+    for (let index = 0; index < this.history.length; index++) {
+      const entry = this.history[index];
+      for (const record of this.listenerRecords) {
+        if (record.nextReplayIndex > index) continue;
+        if (record.event === entry.event) {
+          record.listener(entry.data);
+        }
+        record.nextReplayIndex = index + 1;
+      }
+    }
+  }
+
+  private hasPendingReplay(): boolean {
+    for (const record of this.listenerRecords) {
+      if (record.nextReplayIndex < this.history.length) return true;
+    }
+    return false;
+  }
+}

--- a/apps/frontend/src/modules/chat-session/hooks/useStreamChat.test.tsx
+++ b/apps/frontend/src/modules/chat-session/hooks/useStreamChat.test.tsx
@@ -1,0 +1,190 @@
+import type {SseEvent} from '@omnicraft/sse-events';
+import {act, fireEvent, render, screen} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {
+  ChatEventBusProvider,
+  type ChatSessionApi,
+  ChatSessionApiContext,
+  StreamingMessageDisplay,
+  useChatEventBus,
+  useStreamChat,
+} from '../index.js';
+
+let rafCallbacks: Map<number, FrameRequestCallback>;
+let nextRafId: number;
+
+function mockRaf(cb: FrameRequestCallback): number {
+  const id = nextRafId++;
+  rafCallbacks.set(id, cb);
+  return id;
+}
+
+function mockCancelRaf(id: number): void {
+  rafCallbacks.delete(id);
+}
+
+class ResizeObserverMock implements ResizeObserver {
+  disconnect(): void {
+    return undefined;
+  }
+  observe(): void {
+    return undefined;
+  }
+  unobserve(): void {
+    return undefined;
+  }
+}
+
+function flushRaf(): void {
+  const callbacks = [...rafCallbacks.values()];
+  rafCallbacks.clear();
+  for (const callback of callbacks) {
+    callback(0);
+  }
+}
+
+function usage() {
+  return {
+    model: 'test-model',
+    maxInputTokens: 100,
+    inputTokens: 10,
+    outputTokens: 5,
+    cacheReadInputTokens: 0,
+  };
+}
+
+function createApi(events: readonly SseEvent[]): ChatSessionApi {
+  return {
+    createSession: vi.fn(() => Promise.resolve('session-1')),
+    sendMessage: vi.fn(() => Promise.resolve()),
+    subscribeEvents: vi.fn(async function* () {
+      await Promise.resolve();
+      for (const event of events) {
+        yield event;
+      }
+    }),
+    abortCompletion: vi.fn(() => Promise.resolve()),
+    submitToolResponse: vi.fn(() => Promise.resolve()),
+    listSessions: vi.fn(() => Promise.resolve({sessions: [], total: 0})),
+    deleteSession: vi.fn(() => Promise.resolve()),
+  };
+}
+
+function HarnessContent() {
+  const eventBus = useChatEventBus();
+  useStreamChat({
+    sessionId: 'session-1',
+    createNewSessionId: () => Promise.resolve('session-1'),
+  });
+
+  return <StreamingMessageDisplay eventBus={eventBus} sessionId='session-1' />;
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  rafCallbacks = new Map();
+  nextRafId = 1;
+  vi.stubGlobal('requestAnimationFrame', mockRaf);
+  vi.stubGlobal('cancelAnimationFrame', mockCancelRaf);
+  vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useStreamChat', () => {
+  it('preserves replayed subagent output until the subagent display mounts', async () => {
+    const terminalUsage = usage();
+    const events: SseEvent[] = [
+      {
+        type: 'message-start',
+        role: 'user',
+        messageId: 'user-1',
+        createdAt: 1,
+        content: 'run subagent',
+      },
+      {
+        type: 'message-start',
+        role: 'assistant',
+        messageId: 'assistant-1',
+        createdAt: 2,
+        content: '',
+      },
+      {
+        type: 'subagent-dispatch',
+        agentId: 'subagent-1',
+        task: 'Inspect the replay path',
+        agentType: 'general',
+        thinkingLevel: 'none',
+        workingDirectory: '/tmp/project',
+      },
+      {
+        type: 'subagent-output',
+        agentId: 'subagent-1',
+        event: {
+          type: 'message-start',
+          role: 'user',
+          messageId: 'subagent-user-1',
+          createdAt: 3,
+          content: 'Inspect the replay path',
+        },
+      },
+      {
+        type: 'subagent-output',
+        agentId: 'subagent-1',
+        event: {
+          type: 'message-start',
+          role: 'assistant',
+          messageId: 'subagent-assistant-1',
+          createdAt: 4,
+          content: '',
+        },
+      },
+      {
+        type: 'subagent-output',
+        agentId: 'subagent-1',
+        event: {type: 'text-delta', content: 'Subagent replay content'},
+      },
+      {
+        type: 'subagent-output',
+        agentId: 'subagent-1',
+        event: {type: 'done', reason: 'complete', usage: terminalUsage},
+      },
+      {type: 'subagent-complete', agentId: 'subagent-1', status: 'success'},
+      {type: 'done', reason: 'complete', usage: terminalUsage},
+    ];
+
+    render(
+      <ChatSessionApiContext value={createApi(events)}>
+        <ChatEventBusProvider>
+          <HarnessContent />
+        </ChatEventBusProvider>
+      </ChatSessionApiContext>,
+    );
+
+    await flushAsyncWork();
+    act(flushRaf);
+
+    const trigger = await screen.findByRole('button', {
+      name: /Inspect the replay path/,
+    });
+    if (trigger.getAttribute('aria-expanded') === 'false') {
+      fireEvent.click(trigger);
+    }
+
+    await flushAsyncWork();
+    act(flushRaf);
+    await flushAsyncWork();
+    act(flushRaf);
+
+    expect(screen.getByText('Subagent replay content')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/modules/chat-session/hooks/useStreamChat.ts
+++ b/apps/frontend/src/modules/chat-session/hooks/useStreamChat.ts
@@ -3,10 +3,10 @@ import {useCallback, useEffect, useRef, useState} from 'react';
 
 import {HttpError} from '@/api/helpers/http-error.js';
 import {abortableSleep} from '@/helpers/abortable-sleep.js';
-import {EventBus} from '@/helpers/event-bus.js';
 
-import type {ChatEventMap} from '../components/StreamingMessageDisplay/index.js';
+import type {ChatEventBus} from '../components/StreamingMessageDisplay/index.js';
 import {routeBaseEventToBus} from '../helpers/route-base-event-to-bus.js';
+import {SubagentEventBus} from '../helpers/subagent-event-bus.js';
 import {useChatEventBus} from './useChatEventBus.js';
 import {useChatSessionApi} from './useChatSessionApi.js';
 import type {useSessionId} from './useSessionId.js';
@@ -32,7 +32,7 @@ export function useStreamChat({
   const [isReconnecting, setIsReconnecting] = useState(false);
   const [streamError, setStreamError] = useState<string | null>(null);
   const [maxRoundsReached, setMaxRoundsReached] = useState(false);
-  const subagentBusMapRef = useRef(new Map<string, EventBus<ChatEventMap>>());
+  const subagentBusMapRef = useRef(new Map<string, ChatEventBus>());
   const eventBus = useChatEventBus();
   const {
     sendMessage: apiSendMessage,
@@ -118,7 +118,7 @@ export function useStreamChat({
                 setIsStreaming(false);
                 break;
               case 'subagent-dispatch': {
-                const bus = new EventBus<ChatEventMap>();
+                const bus = new SubagentEventBus();
                 subagentBusMap.set(event.agentId, bus);
                 eventBus.emit('subagent-dispatched', {
                   agentId: event.agentId,


### PR DESCRIPTION
## Summary
- Add a subagent-specific cached event bus so replayed subagent output is preserved for late-mounted displays.
- Use the cached bus only for subagent transcript forwarding in `useStreamChat`.
- Add replay regression coverage and black-box unit tests for subagent event bus behavior.

## Test Plan
- [x] bun run --filter '@omnicraft/frontend' test
- [x] bun run --filter '@omnicraft/frontend' lint
- [x] bun run --filter '@omnicraft/frontend' build
- [x] bun run --filter '@omnicraft/backend' test src/agent-core/agent/agent-sse-log.test.ts
