### PR TITLE
Compress subagent replay deltas

### DIFF
--- a/apps/backend/src/agent-core/agent/agent-sse-log.test.ts
+++ b/apps/backend/src/agent-core/agent/agent-sse-log.test.ts
@@ -2,25 +2,27 @@ import {mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import type {SseEvent} from '@omnicraft/sse-events';
+import type {
+  SseBaseEvent,
+  SseEvent,
+  SseMessageStartEvent,
+  SseTextDeltaEvent,
+  SseThinkingStartEvent,
+} from '@omnicraft/sse-events';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 
 import {AgentSseLog} from './agent-sse-log.js';
 
 /** Helper to create a minimal SseEvent for testing. */
-function textDelta(content: string): SseEvent {
+function textDelta(content: string): SseTextDeltaEvent {
   return {type: 'text-delta', content};
 }
 
-function thinkingDelta(content: string): SseEvent {
-  return {type: 'thinking-delta', content};
+function subagentOutput(agentId: string, event: SseBaseEvent): SseEvent {
+  return {type: 'subagent-output', agentId, event};
 }
 
-function toolExecuteDelta(callId: string, content: string): SseEvent {
-  return {type: 'tool-execute-delta', callId, content};
-}
-
-function messageStart(messageId = 'msg-1'): SseEvent {
+function messageStart(messageId = 'msg-1'): SseMessageStartEvent {
   return {
     type: 'message-start',
     role: 'assistant',
@@ -30,7 +32,7 @@ function messageStart(messageId = 'msg-1'): SseEvent {
   };
 }
 
-function thinkingStart(): SseEvent {
+function thinkingStart(): SseThinkingStartEvent {
   return {type: 'thinking-start'};
 }
 
@@ -470,8 +472,8 @@ describe('AgentSseLog', () => {
     });
   });
 
-  describe('delta merging during replay', () => {
-    it('merges consecutive text-delta events into one', async () => {
+  describe('replay compression integration', () => {
+    it('compresses top-level replay delta events', async () => {
       const log = new AgentSseLog();
       await log.append(textDelta('a'));
       await log.append(textDelta('b'));
@@ -485,87 +487,7 @@ describe('AgentSseLog', () => {
       expect(await collected).toEqual([textDelta('abc')]);
     });
 
-    it('merges consecutive thinking-delta events into one', async () => {
-      const log = new AgentSseLog();
-      await log.append(thinkingDelta('x'));
-      await log.append(thinkingDelta('y'));
-
-      const controller = new AbortController();
-      const collected = collect(log.createReader({signal: controller.signal}));
-      await new Promise((r) => setTimeout(r, 10));
-      controller.abort();
-
-      expect(await collected).toEqual([thinkingDelta('xy')]);
-    });
-
-    it('merges consecutive tool-execute-delta events with same callId', async () => {
-      const log = new AgentSseLog();
-      await log.append(toolExecuteDelta('call-1', 'a'));
-      await log.append(toolExecuteDelta('call-1', 'b'));
-
-      const controller = new AbortController();
-      const collected = collect(log.createReader({signal: controller.signal}));
-      await new Promise((r) => setTimeout(r, 10));
-      controller.abort();
-
-      expect(await collected).toEqual([toolExecuteDelta('call-1', 'ab')]);
-    });
-
-    it('does not merge tool-execute-delta events with different callIds', async () => {
-      const log = new AgentSseLog();
-      await log.append(toolExecuteDelta('call-1', 'a'));
-      await log.append(toolExecuteDelta('call-2', 'b'));
-
-      const controller = new AbortController();
-      const collected = collect(log.createReader({signal: controller.signal}));
-      await new Promise((r) => setTimeout(r, 10));
-      controller.abort();
-
-      expect(await collected).toEqual([
-        toolExecuteDelta('call-1', 'a'),
-        toolExecuteDelta('call-2', 'b'),
-      ]);
-    });
-
-    it('non-delta events break merge sequences', async () => {
-      const log = new AgentSseLog();
-      await log.append(textDelta('a'));
-      await log.append(textDelta('b'));
-      await log.append(messageStart());
-      await log.append(textDelta('c'));
-      await log.append(textDelta('d'));
-
-      const controller = new AbortController();
-      const collected = collect(log.createReader({signal: controller.signal}));
-      await new Promise((r) => setTimeout(r, 10));
-      controller.abort();
-
-      expect(await collected).toEqual([
-        textDelta('ab'),
-        messageStart(),
-        textDelta('cd'),
-      ]);
-    });
-
-    it('does not merge across different delta types', async () => {
-      const log = new AgentSseLog();
-      await log.append(textDelta('a'));
-      await log.append(thinkingDelta('b'));
-      await log.append(textDelta('c'));
-
-      const controller = new AbortController();
-      const collected = collect(log.createReader({signal: controller.signal}));
-      await new Promise((r) => setTimeout(r, 10));
-      controller.abort();
-
-      expect(await collected).toEqual([
-        textDelta('a'),
-        thinkingDelta('b'),
-        textDelta('c'),
-      ]);
-    });
-
-    it('does not merge live events arriving after replay', async () => {
+    it('does not compress top-level live delta events after replay', async () => {
       const log = new AgentSseLog();
       await log.append(textDelta('replay'));
 
@@ -585,6 +507,44 @@ describe('AgentSseLog', () => {
         textDelta('replay'),
         textDelta('live-1'),
         textDelta('live-2'),
+      ]);
+    });
+
+    it('compresses nested subagent replay delta events', async () => {
+      const log = new AgentSseLog();
+      await log.append(subagentOutput('subagent-1', textDelta('a')));
+      await log.append(subagentOutput('subagent-1', textDelta('b')));
+
+      const controller = new AbortController();
+      const collected = collect(log.createReader({signal: controller.signal}));
+      await new Promise((r) => setTimeout(r, 10));
+      controller.abort();
+
+      expect(await collected).toEqual([
+        subagentOutput('subagent-1', textDelta('ab')),
+      ]);
+    });
+
+    it('does not compress nested subagent live delta events after replay', async () => {
+      const log = new AgentSseLog();
+      await log.append(subagentOutput('subagent-1', textDelta('replay')));
+
+      const controller = new AbortController();
+      const collected = collect(log.createReader({signal: controller.signal}));
+
+      // Let the reader drain replay and enter live mode.
+      await new Promise((r) => setTimeout(r, 10));
+
+      await log.append(subagentOutput('subagent-1', textDelta('live-1')));
+      await log.append(subagentOutput('subagent-1', textDelta('live-2')));
+
+      await new Promise((r) => setTimeout(r, 10));
+      controller.abort();
+
+      expect(await collected).toEqual([
+        subagentOutput('subagent-1', textDelta('replay')),
+        subagentOutput('subagent-1', textDelta('live-1')),
+        subagentOutput('subagent-1', textDelta('live-2')),
       ]);
     });
   });

--- a/apps/backend/src/agent-core/agent/agent-sse-log.ts
+++ b/apps/backend/src/agent-core/agent/agent-sse-log.ts
@@ -2,43 +2,12 @@ import assert from 'node:assert';
 import {appendFile, mkdir, readFile, writeFile} from 'node:fs/promises';
 import path from 'node:path';
 
-import {
-  type SseEvent,
-  sseEventSchema,
-  type SseTextDeltaEvent,
-  type SseThinkingDeltaEvent,
-  type SseToolExecuteDeltaEvent,
-} from '@omnicraft/sse-events';
+import {type SseEvent, sseEventSchema} from '@omnicraft/sse-events';
 
 import {isFileNotFoundError} from '@/helpers/fs.js';
 import {Mutex} from '@/helpers/mutex.js';
 
-type DeltaEvent =
-  | SseTextDeltaEvent
-  | SseThinkingDeltaEvent
-  | SseToolExecuteDeltaEvent;
-
-function isDeltaEvent(event: SseEvent): event is DeltaEvent {
-  return (
-    event.type === 'text-delta' ||
-    event.type === 'thinking-delta' ||
-    event.type === 'tool-execute-delta'
-  );
-}
-
-function canMergeWithNext(
-  current: DeltaEvent,
-  next: SseEvent,
-): next is DeltaEvent {
-  if (current.type !== next.type) return false;
-  if (
-    current.type === 'tool-execute-delta' &&
-    next.type === 'tool-execute-delta'
-  ) {
-    return next.callId === current.callId;
-  }
-  return true;
-}
+import {sseReplayCompressor} from './sse-replay-compressor.js';
 
 export interface AgentSseLogReaderOptions {
   /** Index to start reading from (inclusive). Defaults to 0. */
@@ -137,21 +106,17 @@ export class AgentSseLog {
     try {
       // Phase 1: Replay — merge consecutive delta events.
       while (cursor < this.events.length) {
-        const event = this.events[cursor];
+        let event = this.events[cursor];
         cursor++;
 
-        if (isDeltaEvent(event)) {
-          let content = event.content;
-          while (cursor < this.events.length) {
-            const next = this.events[cursor];
-            if (!canMergeWithNext(event, next)) break;
-            content += next.content;
-            cursor++;
-          }
-          yield {...event, content};
-        } else {
-          yield event;
+        while (cursor < this.events.length) {
+          const next = this.events[cursor];
+          if (!sseReplayCompressor.canMerge(event, next)) break;
+          event = sseReplayCompressor.merge(event, next);
+          cursor++;
         }
+
+        yield event;
 
         if (signal?.aborted) return;
       }

--- a/apps/backend/src/agent-core/agent/sse-replay-compressor.test.ts
+++ b/apps/backend/src/agent-core/agent/sse-replay-compressor.test.ts
@@ -1,0 +1,151 @@
+import type {
+  SseBaseEvent,
+  SseEvent,
+  SseMessageStartEvent,
+  SseTextDeltaEvent,
+  SseThinkingDeltaEvent,
+  SseToolExecuteDeltaEvent,
+} from '@omnicraft/sse-events';
+import {describe, expect, it} from 'vitest';
+
+import {sseReplayCompressor} from './sse-replay-compressor.js';
+
+function textDelta(content: string): SseTextDeltaEvent {
+  return {type: 'text-delta', content};
+}
+
+function thinkingDelta(content: string): SseThinkingDeltaEvent {
+  return {type: 'thinking-delta', content};
+}
+
+function toolExecuteDelta(
+  callId: string,
+  content: string,
+): SseToolExecuteDeltaEvent {
+  return {type: 'tool-execute-delta', callId, content};
+}
+
+function messageStart(messageId = 'msg-1'): SseMessageStartEvent {
+  return {
+    type: 'message-start',
+    role: 'assistant',
+    messageId,
+    createdAt: 0,
+    content: '',
+  };
+}
+
+function subagentOutput(agentId: string, event: SseBaseEvent): SseEvent {
+  return {type: 'subagent-output', agentId, event};
+}
+
+function expectMerge(
+  current: SseEvent,
+  next: SseEvent,
+  expected: SseEvent,
+): void {
+  expect(sseReplayCompressor.canMerge(current, next)).toBe(true);
+  expect(sseReplayCompressor.merge(current, next)).toEqual(expected);
+}
+
+describe('sseReplayCompressor', () => {
+  it('merges consecutive top-level text deltas', () => {
+    expectMerge(textDelta('a'), textDelta('b'), textDelta('ab'));
+  });
+
+  it('merges consecutive top-level thinking deltas', () => {
+    expectMerge(thinkingDelta('x'), thinkingDelta('y'), thinkingDelta('xy'));
+  });
+
+  it('merges consecutive top-level tool deltas for the same callId', () => {
+    expectMerge(
+      toolExecuteDelta('call-1', 'a'),
+      toolExecuteDelta('call-1', 'b'),
+      toolExecuteDelta('call-1', 'ab'),
+    );
+  });
+
+  it('does not merge top-level tool deltas for different callIds', () => {
+    expect(
+      sseReplayCompressor.canMerge(
+        toolExecuteDelta('call-1', 'a'),
+        toolExecuteDelta('call-2', 'b'),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not merge top-level events across delta types or boundaries', () => {
+    expect(
+      sseReplayCompressor.canMerge(textDelta('a'), thinkingDelta('b')),
+    ).toBe(false);
+    expect(sseReplayCompressor.canMerge(textDelta('a'), messageStart())).toBe(
+      false,
+    );
+  });
+
+  it('merges nested subagent text deltas for the same agent', () => {
+    expectMerge(
+      subagentOutput('subagent-1', textDelta('a')),
+      subagentOutput('subagent-1', textDelta('b')),
+      subagentOutput('subagent-1', textDelta('ab')),
+    );
+  });
+
+  it('merges nested subagent thinking deltas for the same agent', () => {
+    expectMerge(
+      subagentOutput('subagent-1', thinkingDelta('x')),
+      subagentOutput('subagent-1', thinkingDelta('y')),
+      subagentOutput('subagent-1', thinkingDelta('xy')),
+    );
+  });
+
+  it('merges nested subagent tool deltas for the same agent and callId', () => {
+    expectMerge(
+      subagentOutput('subagent-1', toolExecuteDelta('call-1', 'a')),
+      subagentOutput('subagent-1', toolExecuteDelta('call-1', 'b')),
+      subagentOutput('subagent-1', toolExecuteDelta('call-1', 'ab')),
+    );
+  });
+
+  it('does not merge nested subagent deltas across different agents', () => {
+    expect(
+      sseReplayCompressor.canMerge(
+        subagentOutput('subagent-1', textDelta('a')),
+        subagentOutput('subagent-2', textDelta('b')),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not merge nested subagent tool deltas across different callIds', () => {
+    expect(
+      sseReplayCompressor.canMerge(
+        subagentOutput('subagent-1', toolExecuteDelta('call-1', 'a')),
+        subagentOutput('subagent-1', toolExecuteDelta('call-2', 'b')),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not merge nested subagent events across inner delta types or boundaries', () => {
+    expect(
+      sseReplayCompressor.canMerge(
+        subagentOutput('subagent-1', textDelta('a')),
+        subagentOutput('subagent-1', thinkingDelta('b')),
+      ),
+    ).toBe(false);
+    expect(
+      sseReplayCompressor.canMerge(
+        subagentOutput('subagent-1', textDelta('a')),
+        subagentOutput('subagent-1', messageStart()),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not merge top-level deltas with nested subagent deltas', () => {
+    expect(
+      sseReplayCompressor.canMerge(
+        textDelta('a'),
+        subagentOutput('subagent-1', textDelta('b')),
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/backend/src/agent-core/agent/sse-replay-compressor.ts
+++ b/apps/backend/src/agent-core/agent/sse-replay-compressor.ts
@@ -1,0 +1,123 @@
+import assert from 'node:assert';
+
+import type {
+  SseBaseEvent,
+  SseEvent,
+  SseSubagentOutputEvent,
+  SseTextDeltaEvent,
+  SseThinkingDeltaEvent,
+  SseToolExecuteDeltaEvent,
+} from '@omnicraft/sse-events';
+
+type DeltaEvent =
+  | SseTextDeltaEvent
+  | SseThinkingDeltaEvent
+  | SseToolExecuteDeltaEvent;
+
+type ReplayMergeTarget =
+  | {
+      scope: 'top-level';
+      event: DeltaEvent;
+    }
+  | {
+      scope: 'subagent';
+      agentId: string;
+      event: DeltaEvent;
+    };
+
+function canMerge(current: SseEvent, next: SseEvent): boolean {
+  const currentTarget = toMergeTarget(current);
+  if (!currentTarget) return false;
+
+  const nextTarget = toMergeTarget(next);
+  if (!nextTarget) return false;
+
+  return areTargetsCompatible(currentTarget, nextTarget);
+}
+
+function merge(current: SseEvent, next: SseEvent): SseEvent {
+  const currentTarget = toMergeTarget(current);
+  const nextTarget = toMergeTarget(next);
+  assert(currentTarget, 'Current replay event is not mergeable');
+  assert(nextTarget, 'Next replay event is not mergeable');
+  assert(
+    areTargetsCompatible(currentTarget, nextTarget),
+    'Replay events are not compatible for merging',
+  );
+
+  const mergedEvent = mergeDeltaEvent(currentTarget.event, nextTarget.event);
+  if (currentTarget.scope === 'top-level') return mergedEvent;
+
+  assert(current.type === 'subagent-output');
+  return {
+    ...current,
+    event: mergedEvent,
+  } satisfies SseSubagentOutputEvent;
+}
+
+function toMergeTarget(event: SseEvent): ReplayMergeTarget | null {
+  if (isDeltaEvent(event)) {
+    return {scope: 'top-level', event};
+  }
+
+  if (event.type !== 'subagent-output') return null;
+  if (!isDeltaEvent(event.event)) return null;
+
+  return {
+    scope: 'subagent',
+    agentId: event.agentId,
+    event: event.event,
+  };
+}
+
+function isDeltaEvent(event: SseEvent | SseBaseEvent): event is DeltaEvent {
+  return (
+    event.type === 'text-delta' ||
+    event.type === 'thinking-delta' ||
+    event.type === 'tool-execute-delta'
+  );
+}
+
+function areTargetsCompatible(
+  current: ReplayMergeTarget,
+  next: ReplayMergeTarget,
+): boolean {
+  if (current.scope !== next.scope) return false;
+  if (
+    current.scope === 'subagent' &&
+    next.scope === 'subagent' &&
+    current.agentId !== next.agentId
+  ) {
+    return false;
+  }
+
+  if (current.event.type !== next.event.type) return false;
+  if (
+    current.event.type === 'tool-execute-delta' &&
+    next.event.type === 'tool-execute-delta'
+  ) {
+    return current.event.callId === next.event.callId;
+  }
+
+  return true;
+}
+
+function mergeDeltaEvent(current: DeltaEvent, next: DeltaEvent): DeltaEvent {
+  switch (current.type) {
+    case 'text-delta':
+      assert(next.type === 'text-delta');
+      return {...current, content: current.content + next.content};
+    case 'thinking-delta':
+      assert(next.type === 'thinking-delta');
+      return {...current, content: current.content + next.content};
+    case 'tool-execute-delta':
+      assert(next.type === 'tool-execute-delta');
+      assert(current.callId === next.callId);
+      return {...current, content: current.content + next.content};
+  }
+}
+
+export const sseReplayCompressor = {
+  canMerge,
+  merge,
+};


### PR DESCRIPTION
## Summary
- Add a dedicated SSE replay compressor for top-level and nested subagent delta events.
- Compress compatible `subagent-output` replay deltas by `agentId`, delta type, and tool `callId` where applicable.
- Keep `AgentSseLog` focused on log lifecycle and replay/live iteration, with compression rules covered by a dedicated test suite.

## Test Plan
- [x] `bun run --filter '@omnicraft/backend' test`
- [x] `bun run --filter '@omnicraft/backend' test src/agent-core/agent/agent-sse-log.test.ts src/agent-core/agent/sse-replay-compressor.test.ts`
- [x] `bun run --filter '@omnicraft/backend' typecheck`
- [x] `bun run --filter '@omnicraft/backend' lint`

## Notes
- This addresses nested subagent replay compression only.
- Reconnect cursor correctness is tracked separately in #208.

Fixes #207
