### PR TITLE
Generate session title after first user message

### DIFF
--- a/apps/backend/src/agent-core/agent/agent.test.ts
+++ b/apps/backend/src/agent-core/agent/agent.test.ts
@@ -1,0 +1,103 @@
+import type {SseEvent} from '@omnicraft/sse-events';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {llmApi, type LlmConfig, type LlmEventStream} from '../llm-api/index.js';
+import {Agent} from './agent.js';
+
+const MAIN_CONFIG: LlmConfig = {
+  apiFormat: 'openai',
+  apiKey: 'test-key',
+  baseUrl: 'https://example.test',
+  model: 'main-model',
+};
+
+const LIGHT_CONFIG: LlmConfig = {
+  ...MAIN_CONFIG,
+  model: 'light-model',
+};
+
+class TestAgent extends Agent {}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function* mainCompletionStream(): LlmEventStream {
+  yield {type: 'message-start', messageId: 'assistant-message'};
+  await delay(20);
+  yield {type: 'text-delta', content: 'Assistant response'};
+  yield {
+    type: 'message-end',
+    stopReason: 'end_turn',
+    usage: {inputTokens: 1, outputTokens: 1, cacheReadInputTokens: 0},
+  };
+}
+
+async function* titleCompletionStream(): LlmEventStream {
+  yield {type: 'message-start', messageId: 'title-message'};
+  await Promise.resolve();
+  yield {type: 'text-delta', content: 'Short Title'};
+  yield {
+    type: 'message-end',
+    stopReason: 'end_turn',
+    usage: {inputTokens: 1, outputTokens: 1, cacheReadInputTokens: 0},
+  };
+}
+
+async function collectUntilDone(agent: Agent): Promise<SseEvent[]> {
+  const controller = new AbortController();
+  const events: SseEvent[] = [];
+
+  for await (const event of agent.subscribe({signal: controller.signal})) {
+    events.push(event);
+    if (event.type === 'done') {
+      controller.abort();
+      break;
+    }
+  }
+
+  return events;
+}
+
+describe('Agent title generation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('emits the first session title after the first user message starts', async () => {
+    vi.spyOn(llmApi, 'streamCompletion').mockImplementation((options) => {
+      if (options.config.model === LIGHT_CONFIG.model) {
+        return titleCompletionStream();
+      }
+      return mainCompletionStream();
+    });
+
+    const agent = new TestAgent(() => Promise.resolve(MAIN_CONFIG), {
+      toolRegistries: [],
+      skillRegistries: [],
+      baseSystemPrompt: '',
+      getMaxToolRounds: () => 1,
+      getLightConfig: () => Promise.resolve(LIGHT_CONFIG),
+    });
+
+    const eventsPromise = collectUntilDone(agent);
+    agent.handleUserMessage('Please help me rename a component', 'none');
+    const events = await eventsPromise;
+
+    const userStartIndex = events.findIndex(
+      (event) => event.type === 'message-start' && event.role === 'user',
+    );
+    const titleIndex = events.findIndex(
+      (event) => event.type === 'session-title',
+    );
+    const doneIndex = events.findIndex((event) => event.type === 'done');
+
+    expect(userStartIndex).toBeGreaterThanOrEqual(0);
+    expect(titleIndex).toBeGreaterThan(userStartIndex);
+    expect(titleIndex).toBeLessThan(doneIndex);
+    expect(events[titleIndex]).toEqual({
+      type: 'session-title',
+      title: 'Short Title',
+    });
+  });
+});

--- a/apps/backend/src/agent-core/agent/agent.ts
+++ b/apps/backend/src/agent-core/agent/agent.ts
@@ -65,7 +65,7 @@ export abstract class Agent {
 
   static readonly DEFAULT_TITLE = 'New Session';
 
-  /** Short title for this session, generated after the first reply. */
+  /** Short title for this session, generated after the first user message. */
   title = Agent.DEFAULT_TITLE;
 
   /** The LLM session used by this agent. */
@@ -235,13 +235,13 @@ export abstract class Agent {
       );
       await this.pump(stream, (event) => {
         if (
-          event.type === 'done' &&
-          event.reason === 'complete' &&
+          event.type === 'message-start' &&
+          event.role === 'user' &&
           this.title === Agent.DEFAULT_TITLE &&
           !this.isGeneratingTitle
         ) {
           this.isGeneratingTitle = true;
-          void this.generateAndEmitTitle().finally(() => {
+          void this.generateAndEmitTitle(event.content).finally(() => {
             this.isGeneratingTitle = false;
           });
         }
@@ -489,14 +489,13 @@ export abstract class Agent {
   }
 
   /**
-   * Generates a session title from the first user + assistant exchange
-   * using the light LLM, then appends a `session-title` event to sseLog.
+   * Generates a session title from the first user message using the light LLM,
+   * then appends a `session-title` event to sseLog.
    * Fire-and-forget — errors are swallowed and a fallback title is used.
    */
-  private async generateAndEmitTitle(): Promise<void> {
-    const messages = this.llmSession.getMessages();
+  private async generateAndEmitTitle(userMessage: string): Promise<void> {
     const getConfig = this.getLightConfig ?? this.getConfig;
-    this.title = await generateTitle(messages, getConfig);
+    this.title = await generateTitle(userMessage, getConfig);
     if (!this.title) return;
     await this.appendSseEvent({
       type: 'session-title',

--- a/apps/backend/src/agent-core/agent/title/agent-title.ts
+++ b/apps/backend/src/agent-core/agent/title/agent-title.ts
@@ -1,18 +1,14 @@
 import crypto from 'node:crypto';
 
-import type {LlmConfig, LlmMessage} from '../../llm-api/index.js';
+import type {LlmConfig} from '../../llm-api/index.js';
 import {llmApi} from '../../llm-api/index.js';
 
 const TITLE_MAX_LENGTH = 20;
 
 export async function generateTitle(
-  messages: readonly LlmMessage[],
+  userMessage: string,
   getConfig: () => Promise<LlmConfig>,
 ): Promise<string> {
-  const userMsg = messages.find((m) => m.role === 'user');
-  const assistantMsg = messages.find((m) => m.role === 'assistant');
-  if (!userMsg || !assistantMsg) return '';
-
   try {
     const config = await getConfig();
     const stream = llmApi.streamCompletion({
@@ -26,9 +22,7 @@ export async function generateTitle(
             'Generate a short title (under 20 characters) for this conversation.',
             'Reply with ONLY the title, no quotes or extra text.',
             '',
-            `User: ${userMsg.content}`,
-            '',
-            `Assistant: ${assistantMsg.content}`,
+            `User: ${userMessage}`,
           ].join('\n'),
         },
       ],
@@ -44,7 +38,7 @@ export async function generateTitle(
     }
     return title.trim();
   } catch {
-    const trimmed = userMsg.content.trim();
+    const trimmed = userMessage.trim();
     return trimmed.length <= TITLE_MAX_LENGTH
       ? trimmed
       : `${trimmed.slice(0, TITLE_MAX_LENGTH)}…`;


### PR DESCRIPTION
## Summary
- Start session title generation when the first user message is appended instead of waiting for the first completed turn.
- Pass the first user message directly into the title generator.
- Add a regression test covering `session-title` emission before `done`.

## Test Plan
- [x] `bun run --filter '@omnicraft/backend' test`
- [x] `bun run --filter '@omnicraft/backend' typecheck`
- [x] `bun run --filter '@omnicraft/backend' lint`
- [x] `git diff --check`