### PR TITLE
Fix frontend lint and build warnings

### DIFF
--- a/apps/frontend/src/hooks/useInfiniteList.ts
+++ b/apps/frontend/src/hooks/useInfiniteList.ts
@@ -43,7 +43,7 @@ export function useInfiniteList<T>({
   // Incremented on each refresh. loadMore captures this value before fetching
   // and discards results if it has changed, preventing stale pages from being
   // appended after a refresh has already replaced the list.
-  const refreshGenerationId = useRef(0);
+  const refreshGenerationIdRef = useRef(0);
 
   // Controls whether the next refresh shows a loading indicator.
   // true for the initial load and explicit refresh(), false for backgroundRefresh().
@@ -51,13 +51,13 @@ export function useInfiniteList<T>({
 
   const refresh = useCallback(() => {
     showLoadingRef.current = true;
-    refreshGenerationId.current += 1;
+    refreshGenerationIdRef.current += 1;
     setRefreshKey((prev) => prev + 1);
   }, []);
 
   const backgroundRefresh = useCallback(() => {
     showLoadingRef.current = false;
-    refreshGenerationId.current += 1;
+    refreshGenerationIdRef.current += 1;
     setRefreshKey((prev) => prev + 1);
   }, []);
 
@@ -102,24 +102,24 @@ export function useInfiniteList<T>({
     }
 
     setIsLoadingMore(true);
-    const currentRefreshGenerationId = refreshGenerationId.current;
+    const currentRefreshGenerationId = refreshGenerationIdRef.current;
     const offset = items.length;
 
     async function fetchNextPage() {
       try {
         const page = await fetcher(offset, pageSize);
-        if (currentRefreshGenerationId !== refreshGenerationId.current) {
+        if (currentRefreshGenerationId !== refreshGenerationIdRef.current) {
           return;
         }
         setItems((prev) => [...prev, ...page.items]);
         setTotal(page.total);
       } catch (e: unknown) {
-        if (currentRefreshGenerationId !== refreshGenerationId.current) {
+        if (currentRefreshGenerationId !== refreshGenerationIdRef.current) {
           return;
         }
         setError(e instanceof Error ? e.message : 'Failed to load more');
       } finally {
-        if (currentRefreshGenerationId === refreshGenerationId.current) {
+        if (currentRefreshGenerationId === refreshGenerationIdRef.current) {
           setIsLoadingMore(false);
         }
       }

--- a/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/SubagentDisclosure/SubagentDisclosureView.tsx
+++ b/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/SubagentDisclosure/SubagentDisclosureView.tsx
@@ -2,16 +2,12 @@ import {Disclosure, ScrollShadow, Spinner} from '@heroui/react';
 import type {ThinkingLevel} from '@omnicraft/api-schema';
 import clsx from 'clsx';
 import {Bot, CircleCheck, CircleX} from 'lucide-react';
-import {lazy, type RefObject, Suspense} from 'react';
+import type {RefObject} from 'react';
 
 import {UsageInfo} from '../../../../../UsageInfo/index.js';
+import {StreamingMessageDisplay} from '../../../../StreamingMessageDisplay.js';
 import type {ChatEventBus} from '../../../../types.js';
 import styles from './styles.module.css';
-
-const StreamingMessageDisplay = lazy(async () => {
-  const {StreamingMessageDisplay} = await import('../../../../index.js');
-  return {default: StreamingMessageDisplay};
-});
 
 interface SubagentDisclosureViewProps {
   task: string;
@@ -70,12 +66,7 @@ export function SubagentDisclosureView({
                 <span className={styles.workingDir}>{workingDirectory}</span>
               </div>
               <ScrollShadow className={styles.content} ref={scrollRef}>
-                <Suspense>
-                  <StreamingMessageDisplay
-                    eventBus={eventBus}
-                    sessionId={null}
-                  />
-                </Suspense>
+                <StreamingMessageDisplay eventBus={eventBus} sessionId={null} />
               </ScrollShadow>
             </Disclosure.Body>
             <div className={styles.footer}>


### PR DESCRIPTION
## Summary
- Rename the infinite-list refresh generation ref to satisfy the frontend ref naming lint rule while preserving the generation-id meaning.
- Replace the ineffective lazy subagent message display import with the static import already used by the bundle.

## Test Plan
- [x] cd apps/frontend && bun run lint
- [x] cd apps/frontend && bun run build
- [x] cd apps/frontend && bun run test