### PR TITLE
Fix markdown table overflow in chat bubbles

### DIFF
--- a/apps/frontend/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
+++ b/apps/frontend/src/components/MarkdownRenderer/MarkdownRenderer.test.tsx
@@ -1,0 +1,21 @@
+import {render, screen} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+
+import {MarkdownRenderer} from './MarkdownRenderer.js';
+import styles from './styles.module.css';
+
+describe('MarkdownRenderer', () => {
+  it('wraps GFM tables in a horizontal scroll container', () => {
+    render(
+      <MarkdownRenderer
+        content={`| First | Second |
+| --- | --- |
+| Alpha | Beta |`}
+      />,
+    );
+
+    const table = screen.getByRole('table');
+
+    expect(table.parentElement).toHaveClass(styles.tableScroll);
+  });
+});

--- a/apps/frontend/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/frontend/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -16,6 +16,13 @@ const CUSTOM_COMPONENTS: Components = {
   pre({children}) {
     return <CodeBlock>{children}</CodeBlock>;
   },
+  table({node: _node, ...rest}) {
+    return (
+      <div className={styles.tableScroll}>
+        <table {...rest} />
+      </div>
+    );
+  },
   a({href, children, node: _node, ...rest}) {
     const sanitizedHref = sanitizeLinkUrl(href ?? '');
     if (!sanitizedHref) {

--- a/apps/frontend/src/components/MarkdownRenderer/styles.module.css
+++ b/apps/frontend/src/components/MarkdownRenderer/styles.module.css
@@ -86,14 +86,23 @@
 }
 
 /* Tables (GFM) */
-.markdown :global(table) {
+.tableScroll {
+  max-width: 100%;
+  overflow-x: auto;
   margin-top: 0.75em;
   margin-bottom: 0.75em;
-  border-collapse: collapse;
-  width: 100%;
-  font-size: 0.9em;
   border-radius: 8px;
-  overflow: hidden;
+}
+
+.markdown :global(table) {
+  border-collapse: collapse;
+  width: max-content;
+  min-width: 100%;
+  font-size: 0.9em;
+}
+
+.tableScroll :global(table) {
+  margin: 0;
 }
 
 .markdown :global(th),

--- a/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/RenderItem/styles.module.css
+++ b/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/RenderItem/styles.module.css
@@ -12,13 +12,15 @@
 
 .userMessage {
   align-self: flex-end;
-  max-width: 80%;
+  max-width: 100%;
+  min-width: 0;
   animation: fadeInUp 0.2s ease-out;
 }
 
 .assistantMessage {
   align-self: flex-start;
-  max-width: 80%;
+  max-width: 100%;
+  min-width: 0;
   animation: fadeInUp 0.2s ease-out;
 }
 


### PR DESCRIPTION
## Summary
- Wrap rendered Markdown tables in a horizontal scroll container.
- Let chat message bubbles use the full available row width without forcing short messages to stretch.
- Add a regression test for GFM table wrapping.

## Test Plan
- bun run --filter '@omnicraft/frontend' test
- bun run --filter '@omnicraft/frontend' lint
- bun run --filter '@omnicraft/frontend' build