### PR TITLE
[codex] Make thinking block full width

### DIFF
--- a/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/RenderItem/RenderItem.tsx
+++ b/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/RenderItem/RenderItem.tsx
@@ -101,7 +101,7 @@ export function RenderItem({item}: RenderItemProps) {
     }
     case 'thinking':
       return (
-        <div className={styles.assistantMessage}>
+        <div className={clsx(styles.assistantMessage, styles.fullWidthMessage)}>
           <ThinkingBlock content={item.content} done={item.done} />
         </div>
       );

--- a/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/RenderItem/styles.module.css
+++ b/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/RenderItem/styles.module.css
@@ -24,6 +24,10 @@
   animation: fadeInUp 0.2s ease-out;
 }
 
+.fullWidthMessage {
+  width: 100%;
+}
+
 .timestamp {
   display: block;
   font-size: 0.75rem;

--- a/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/ThinkingBlock/styles.module.css
+++ b/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/ThinkingBlock/styles.module.css
@@ -1,7 +1,7 @@
 .card {
   border-radius: 12px;
   overflow: hidden;
-  width: 400px;
+  width: 100%;
   max-width: 100%;
 }
 


### PR DESCRIPTION
## Summary

- Make chat thinking render items span the full message list width.
- Change the ThinkingBlock card from a fixed 400px width to 100% width.

## Root Cause

The thinking block card had a fixed 400px width, and the thinking render item used the normal assistant message wrapper without a full-width override.

## Validation

- bun run --filter '@omnicraft/frontend' test
- bun run --filter '@omnicraft/frontend' lint
- bun run --filter '@omnicraft/frontend' build
