### PR TITLE
[codex] Use usage baseline for compaction checks

### DIFF
--- a/apps/backend/src/agent-core/agent/agent.test.ts
+++ b/apps/backend/src/agent-core/agent/agent.test.ts
@@ -21,6 +21,7 @@ const LIGHT_CONFIG: LlmConfig = {
 function emptyUsage() {
   return {
     currentContextInputTokens: 0,
+    latestCallOutputTokens: 0,
     sessionInputTokens: 0,
     sessionOutputTokens: 0,
     sessionCacheReadInputTokens: 0,
@@ -259,7 +260,6 @@ describe('Agent compaction lifecycle', () => {
   });
 
   it('emits a clear error when pre-call compaction fails', async () => {
-    vi.spyOn(llmApi, 'countToken').mockResolvedValue(200_000);
     vi.spyOn(llmApi, 'streamCompletion').mockReturnValue(failingStream());
     const agent = new TestAgent(
       () => Promise.resolve(MAIN_CONFIG),
@@ -271,11 +271,12 @@ describe('Agent compaction lifecycle', () => {
         llmSession: {
           id: 'llm-session-1',
           compactions: [],
+          usageBaselineMessageCount: null,
           messages: Array.from({length: 12}, (_, index) => ({
             id: `old-${index.toString()}`,
             createdAt: index,
             role: 'user' as const,
-            content: `old message ${index.toString()}`,
+            content: `old message ${index.toString()} ${'x'.repeat(30_000)}`,
           })),
           usage: emptyUsage(),
         },
@@ -308,6 +309,7 @@ describe('Agent snapshot restore', () => {
         id: 'llm-session-id',
         messages: [],
         compactions: [],
+        usageBaselineMessageCount: null,
         usage: emptyUsage(),
       },
       options: {

--- a/apps/backend/src/agent-core/agent/persistence/agent-persistence.test.ts
+++ b/apps/backend/src/agent-core/agent/persistence/agent-persistence.test.ts
@@ -11,6 +11,7 @@ import {agentPersistence} from './agent-persistence.js';
 function emptyUsage() {
   return {
     currentContextInputTokens: 0,
+    latestCallOutputTokens: 0,
     sessionInputTokens: 0,
     sessionOutputTokens: 0,
     sessionCacheReadInputTokens: 0,
@@ -26,6 +27,7 @@ function createTestSnapshot(id: string): AgentSnapshot {
       id: 'llm-session-id',
       messages: [],
       compactions: [],
+      usageBaselineMessageCount: null,
       usage: emptyUsage(),
     },
     options: {
@@ -124,6 +126,7 @@ describe('agentPersistence', () => {
             id: 'llm-session-id',
             messages: [],
             compactions: [],
+            usageBaselineMessageCount: null,
             usage: emptyUsage(),
           },
           options: {workingDirectory: '/tmp/test-working-dir'},

--- a/apps/backend/src/agent-core/llm-session/helpers.ts
+++ b/apps/backend/src/agent-core/llm-session/helpers.ts
@@ -3,6 +3,7 @@ import type {LlmSessionUsage} from './types.js';
 export function createEmptyLlmSessionUsage(): LlmSessionUsage {
   return {
     currentContextInputTokens: 0,
+    latestCallOutputTokens: 0,
     sessionInputTokens: 0,
     sessionOutputTokens: 0,
     sessionCacheReadInputTokens: 0,

--- a/apps/backend/src/agent-core/llm-session/llm-session.test.ts
+++ b/apps/backend/src/agent-core/llm-session/llm-session.test.ts
@@ -18,18 +18,19 @@ const CONFIG: LlmConfig = {
 function emptyUsage() {
   return {
     currentContextInputTokens: 0,
+    latestCallOutputTokens: 0,
     sessionInputTokens: 0,
     sessionOutputTokens: 0,
     sessionCacheReadInputTokens: 0,
   };
 }
 
-function oldMessages(count: number): LlmMessage[] {
+function largeOldMessages(count: number): LlmMessage[] {
   return Array.from({length: count}, (_, index) => ({
     id: `old-${index.toString()}`,
     createdAt: index,
     role: 'user' as const,
-    content: `old message ${index.toString()}`,
+    content: `old message ${index.toString()} ${'x'.repeat(30_000)}`,
   }));
 }
 
@@ -96,6 +97,17 @@ async function* failingStream(): LlmEventStream {
   throw new Error('provider failed');
 }
 
+async function* failingAfterUsageStream(): LlmEventStream {
+  yield {type: 'message-start', messageId: 'assistant'};
+  await Promise.resolve();
+  yield {
+    type: 'message-end',
+    stopReason: 'end_turn',
+    usage: {inputTokens: 100, outputTokens: 10, cacheReadInputTokens: 5},
+  };
+  throw new Error('provider failed after usage');
+}
+
 async function drain(stream: AsyncIterable<unknown>): Promise<void> {
   for await (const _event of stream) {
     // Drain stream.
@@ -113,8 +125,103 @@ describe('LlmSession compaction', () => {
     expect(session.toSnapshot().compactions).toEqual([]);
   });
 
-  it('compacts before model call when countToken reaches threshold', async () => {
-    const countSpy = vi.spyOn(llmApi, 'countToken').mockResolvedValue(200_000);
+  it('uses latest call usage and pending input estimate to trigger pre-call compaction', async () => {
+    const countSpy = vi.spyOn(llmApi, 'countToken').mockResolvedValue(1);
+    let mainCallCount = 0;
+    const streamSpy = vi
+      .spyOn(llmApi, 'streamCompletion')
+      .mockImplementation((options) => {
+        const isSummaryRequest =
+          options.tools.length === 0 &&
+          options.messages.length === 1 &&
+          options.messages[0]?.role === 'user' &&
+          options.messages[0].content.includes('<history_to_summarize>');
+
+        if (isSummaryRequest) return summaryStream();
+
+        mainCallCount++;
+        if (mainCallCount === 1) {
+          return usageStream({
+            inputTokens: 102_399,
+            outputTokens: 100,
+            cacheReadInputTokens: 0,
+          });
+        }
+
+        const hasSummaryMessage = options.messages.some(
+          (message) =>
+            message.role === 'user' &&
+            message.content.includes('<conversation_summary>'),
+        );
+        expect(hasSummaryMessage).toBe(true);
+        return normalStream();
+      });
+
+    const session = new LlmSession(() => Promise.resolve(CONFIG));
+
+    await drain(session.sendUserMessage('first', [], '', 'none').stream);
+    await drain(session.sendUserMessage('second', [], '', 'none').stream);
+
+    expect(countSpy).not.toHaveBeenCalled();
+    expect(streamSpy).toHaveBeenCalledTimes(3);
+    expect(session.toSnapshot().compactions).toHaveLength(1);
+  });
+
+  it('restores usage baseline message count for compaction estimates', async () => {
+    let mainCallCount = 0;
+    const streamSpy = vi
+      .spyOn(llmApi, 'streamCompletion')
+      .mockImplementation((options) => {
+        const isSummaryRequest =
+          options.tools.length === 0 &&
+          options.messages.length === 1 &&
+          options.messages[0]?.role === 'user' &&
+          options.messages[0].content.includes('<history_to_summarize>');
+
+        if (isSummaryRequest) return summaryStream();
+
+        mainCallCount++;
+        const hasSummaryMessage = options.messages.some(
+          (message) =>
+            message.role === 'user' &&
+            message.content.includes('<conversation_summary>'),
+        );
+        expect(hasSummaryMessage).toBe(true);
+        return normalStream();
+      });
+
+    const session = new LlmSession(() => Promise.resolve(CONFIG), {
+      id: 'session-1',
+      messages: [
+        {id: 'user-1', createdAt: 1, role: 'user', content: 'first'},
+        {
+          id: 'assistant-1',
+          createdAt: 2,
+          role: 'assistant',
+          content: 'reply',
+          toolCalls: [],
+          thinking: [],
+        },
+      ],
+      compactions: [],
+      usageBaselineMessageCount: 1,
+      usage: {
+        currentContextInputTokens: 102_399,
+        latestCallOutputTokens: 100,
+        sessionInputTokens: 102_399,
+        sessionOutputTokens: 100,
+        sessionCacheReadInputTokens: 0,
+      },
+    });
+
+    await drain(session.sendUserMessage('second', [], '', 'none').stream);
+
+    expect(mainCallCount).toBe(1);
+    expect(streamSpy).toHaveBeenCalledTimes(2);
+    expect(session.toSnapshot().compactions).toHaveLength(1);
+  });
+
+  it('compacts before model call when local prompt estimate reaches threshold', async () => {
     const streamSpy = vi
       .spyOn(llmApi, 'streamCompletion')
       .mockImplementation((options) => {
@@ -138,7 +245,8 @@ describe('LlmSession compaction', () => {
     const session = new LlmSession(() => Promise.resolve(CONFIG), {
       id: 'session-1',
       compactions: [],
-      messages: oldMessages(12),
+      usageBaselineMessageCount: null,
+      messages: largeOldMessages(12),
       usage: emptyUsage(),
     });
 
@@ -146,7 +254,6 @@ describe('LlmSession compaction', () => {
 
     const snapshot = session.toSnapshot();
 
-    expect(countSpy).toHaveBeenCalled();
     expect(streamSpy).toHaveBeenCalledTimes(2);
     expect(snapshot.messages[0]?.role).toBe('user');
     expect(snapshot.messages[0]?.content).toContain('<conversation_summary>');
@@ -164,14 +271,14 @@ describe('LlmSession compaction', () => {
   });
 
   it('replaces compacted history with a single synthetic message before the next assistant reply', async () => {
-    vi.spyOn(llmApi, 'countToken').mockResolvedValue(200_000);
     vi.spyOn(llmApi, 'streamCompletion')
       .mockReturnValueOnce(summaryStream())
       .mockReturnValueOnce(normalStream());
     const session = new LlmSession(() => Promise.resolve(CONFIG), {
       id: 'session-1',
       compactions: [],
-      messages: oldMessages(12),
+      usageBaselineMessageCount: null,
+      messages: largeOldMessages(12),
       usage: emptyUsage(),
     });
 
@@ -185,14 +292,14 @@ describe('LlmSession compaction', () => {
   });
 
   it('rolls back compaction when the provider stream fails after compaction', async () => {
-    vi.spyOn(llmApi, 'countToken').mockResolvedValue(200_000);
     vi.spyOn(llmApi, 'streamCompletion')
       .mockReturnValueOnce(summaryStream())
       .mockReturnValueOnce(failingStream());
-    const messages = oldMessages(12);
+    const messages = largeOldMessages(12);
     const session = new LlmSession(() => Promise.resolve(CONFIG), {
       id: 'session-1',
       compactions: [],
+      usageBaselineMessageCount: null,
       messages,
       usage: emptyUsage(),
     });
@@ -204,18 +311,19 @@ describe('LlmSession compaction', () => {
     expect(session.toSnapshot()).toEqual({
       id: 'session-1',
       compactions: [],
+      usageBaselineMessageCount: null,
       messages,
       usage: emptyUsage(),
     });
   });
 
   it('surfaces a clear error when pre-call compaction fails', async () => {
-    vi.spyOn(llmApi, 'countToken').mockResolvedValue(200_000);
     vi.spyOn(llmApi, 'streamCompletion').mockReturnValue(failingStream());
-    const messages = oldMessages(12);
+    const messages = largeOldMessages(12);
     const session = new LlmSession(() => Promise.resolve(CONFIG), {
       id: 'session-1',
       compactions: [],
+      usageBaselineMessageCount: null,
       messages,
       usage: emptyUsage(),
     });
@@ -227,6 +335,7 @@ describe('LlmSession compaction', () => {
     expect(session.toSnapshot()).toEqual({
       id: 'session-1',
       compactions: [],
+      usageBaselineMessageCount: null,
       messages,
       usage: emptyUsage(),
     });
@@ -234,14 +343,14 @@ describe('LlmSession compaction', () => {
 
   it('does not start the provider call when aborted during pre-call compaction', async () => {
     const controller = new AbortController();
-    vi.spyOn(llmApi, 'countToken').mockResolvedValue(200_000);
     const streamSpy = vi
       .spyOn(llmApi, 'streamCompletion')
       .mockReturnValue(abortingSummaryStream(controller));
-    const messages = oldMessages(12);
+    const messages = largeOldMessages(12);
     const session = new LlmSession(() => Promise.resolve(CONFIG), {
       id: 'session-1',
       compactions: [],
+      usageBaselineMessageCount: null,
       messages,
       usage: emptyUsage(),
     });
@@ -263,18 +372,19 @@ describe('LlmSession compaction', () => {
     expect(session.toSnapshot()).toEqual({
       id: 'session-1',
       compactions: [],
+      usageBaselineMessageCount: null,
       messages,
       usage: emptyUsage(),
     });
   });
 
   it('fails compaction when the generated summary is empty', async () => {
-    vi.spyOn(llmApi, 'countToken').mockResolvedValue(200_000);
     vi.spyOn(llmApi, 'streamCompletion').mockReturnValue(emptySummaryStream());
-    const messages = oldMessages(12);
+    const messages = largeOldMessages(12);
     const session = new LlmSession(() => Promise.resolve(CONFIG), {
       id: 'session-1',
       compactions: [],
+      usageBaselineMessageCount: null,
       messages,
       usage: emptyUsage(),
     });
@@ -291,18 +401,19 @@ describe('LlmSession compaction', () => {
     expect(session.toSnapshot()).toEqual({
       id: 'session-1',
       compactions: [],
+      usageBaselineMessageCount: null,
       messages,
       usage: emptyUsage(),
     });
   });
 
   it('keeps history unchanged when turn-end compaction fails', async () => {
-    vi.spyOn(llmApi, 'countToken').mockResolvedValue(200_000);
     vi.spyOn(llmApi, 'streamCompletion').mockReturnValue(failingStream());
-    const messages = oldMessages(12);
+    const messages = largeOldMessages(12);
     const session = new LlmSession(() => Promise.resolve(CONFIG), {
       id: 'session-1',
       compactions: [],
+      usageBaselineMessageCount: null,
       messages,
       usage: emptyUsage(),
     });
@@ -319,6 +430,7 @@ describe('LlmSession compaction', () => {
     expect(session.toSnapshot()).toEqual({
       id: 'session-1',
       compactions: [],
+      usageBaselineMessageCount: null,
       messages,
       usage: emptyUsage(),
     });
@@ -331,7 +443,6 @@ describe('LlmSession usage', () => {
   });
 
   it('tracks latest context input separately from cumulative session totals', async () => {
-    vi.spyOn(llmApi, 'countToken').mockResolvedValue(1);
     vi.spyOn(llmApi, 'streamCompletion')
       .mockReturnValueOnce(
         usageStream({
@@ -354,9 +465,23 @@ describe('LlmSession usage', () => {
 
     expect(session.getUsage()).toEqual({
       currentContextInputTokens: 40,
+      latestCallOutputTokens: 8,
       sessionInputTokens: 140,
       sessionOutputTokens: 18,
       sessionCacheReadInputTokens: 25,
     });
+  });
+
+  it('rolls back usage when the provider stream fails after reporting usage', async () => {
+    vi.spyOn(llmApi, 'streamCompletion').mockReturnValue(
+      failingAfterUsageStream(),
+    );
+    const session = new LlmSession(() => Promise.resolve(CONFIG));
+
+    await expect(
+      drain(session.sendUserMessage('hello', [], '', 'none').stream),
+    ).rejects.toThrow('provider failed after usage');
+
+    expect(session.getUsage()).toEqual(emptyUsage());
   });
 });

--- a/apps/backend/src/agent-core/llm-session/llm-session.ts
+++ b/apps/backend/src/agent-core/llm-session/llm-session.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import crypto from 'node:crypto';
 
 import type {ThinkingLevel} from '@omnicraft/api-schema';
+import {z} from 'zod';
 
 import {Mutex} from '@/helpers/mutex.js';
 
@@ -13,6 +14,7 @@ import type {
   LlmToolCall,
 } from '../llm-api/index.js';
 import {llmApi} from '../llm-api/index.js';
+import {estimatePromptTokens} from '../llm-api/token-estimator.js';
 import {modelCapacity} from '../model-capacity/index.js';
 import type {ToolDefinition} from '../tool/types.js';
 import {COMPACTION_TRIGGER_INPUT_TOKEN_RATIO} from './compaction/constants.js';
@@ -52,6 +54,8 @@ export class LlmSession {
   private readonly messages: LlmMessage[] = [];
   private readonly compactions: LlmCompactionMetadata[] = [];
   private usage: LlmSessionUsage = createEmptyLlmSessionUsage();
+  /** Number of messages covered by the latest provider input-token usage. */
+  private usageBaselineMessageCount: number | null = null;
   private readonly getConfig: () => Promise<LlmConfig>;
   private readonly mutex = new Mutex();
 
@@ -66,6 +70,7 @@ export class LlmSession {
       this.messages.push(...snapshot.messages);
       this.compactions.push(...snapshot.compactions);
       this.usage = {...snapshot.usage};
+      this.usageBaselineMessageCount = snapshot.usageBaselineMessageCount;
     } else {
       this.id = crypto.randomUUID();
     }
@@ -77,6 +82,7 @@ export class LlmSession {
       id: this.id,
       messages: [...this.messages],
       compactions: [...this.compactions],
+      usageBaselineMessageCount: this.usageBaselineMessageCount,
       usage: {...this.usage},
     };
   }
@@ -171,6 +177,7 @@ export class LlmSession {
     this.messages.length = 0;
     this.compactions.length = 0;
     this.usage = createEmptyLlmSessionUsage();
+    this.usageBaselineMessageCount = null;
   }
 
   /**
@@ -187,6 +194,8 @@ export class LlmSession {
     const release = await this.mutex.acquire();
     const rollbackMessages = [...this.messages];
     const rollbackCompactions = [...this.compactions];
+    const rollbackUsage = {...this.usage};
+    const rollbackUsageBaselineMessageCount = this.usageBaselineMessageCount;
     this.messages.push(...messages);
     let completed = false;
     try {
@@ -205,6 +214,8 @@ export class LlmSession {
         this.messages.push(...rollbackMessages);
         this.compactions.length = 0;
         this.compactions.push(...rollbackCompactions);
+        this.usage = rollbackUsage;
+        this.usageBaselineMessageCount = rollbackUsageBaselineMessageCount;
       }
       release();
     }
@@ -243,13 +254,7 @@ export class LlmSession {
   ): Promise<boolean> {
     const config = await this.getConfig();
     const maxInputTokens = await modelCapacity.getMaxInputTokens(config);
-    const currentTokens = await llmApi.countToken({
-      config,
-      messages: this.messages,
-      systemPrompt: options.systemPrompt || undefined,
-      tools: options.tools,
-      thinkingLevel: options.thinkingLevel,
-    });
+    const currentTokens = this.estimatePromptTokensForCompaction(options);
 
     if (currentTokens < maxInputTokens * COMPACTION_TRIGGER_INPUT_TOKEN_RATIO) {
       return false;
@@ -283,6 +288,7 @@ export class LlmSession {
 
     this.messages.length = 0;
     this.messages.push(summaryMessage);
+    this.usageBaselineMessageCount = null;
     this.compactions.push({
       id: crypto.randomUUID(),
       compactedAt: Date.now(),
@@ -293,6 +299,42 @@ export class LlmSession {
     });
 
     return true;
+  }
+
+  private estimatePromptTokensForCompaction(
+    options: LlmCompactionOptions,
+  ): number {
+    const latestUsageEstimate = this.estimatePromptTokensFromLatestUsage();
+    if (latestUsageEstimate !== null) return latestUsageEstimate;
+
+    return estimatePromptTokens({
+      messages: this.messages,
+      ...(options.systemPrompt ? {systemPrompt: options.systemPrompt} : {}),
+      tools: options.tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        parameters: z.toJSONSchema(tool.parameters),
+      })),
+      thinkingLevel: options.thinkingLevel,
+    });
+  }
+
+  private estimatePromptTokensFromLatestUsage(): number | null {
+    if (this.usageBaselineMessageCount === null) return null;
+    if (this.usage.currentContextInputTokens <= 0) return null;
+
+    const pendingStart = this.usageBaselineMessageCount + 1;
+    if (pendingStart > this.messages.length) return null;
+
+    const pendingMessages = this.messages.slice(pendingStart);
+    const pendingInputTokens =
+      pendingMessages.length > 0 ? estimatePromptTokens(pendingMessages) : 0;
+
+    return (
+      this.usage.currentContextInputTokens +
+      this.usage.latestCallOutputTokens +
+      pendingInputTokens
+    );
   }
 
   /**
@@ -307,6 +349,7 @@ export class LlmSession {
     signal?: AbortSignal,
   ): LlmSessionEventStream {
     const llmConfig = await this.getConfig();
+    const inputMessageCount = this.messages.length;
     const eventStream = llmApi.streamCompletion({
       config: llmConfig,
       messages: this.messages,
@@ -369,6 +412,7 @@ export class LlmSession {
         case 'message-end':
           this.usage = {
             currentContextInputTokens: event.usage.inputTokens,
+            latestCallOutputTokens: event.usage.outputTokens,
             sessionInputTokens:
               this.usage.sessionInputTokens + event.usage.inputTokens,
             sessionOutputTokens:
@@ -377,6 +421,7 @@ export class LlmSession {
               this.usage.sessionCacheReadInputTokens +
               event.usage.cacheReadInputTokens,
           };
+          this.usageBaselineMessageCount = inputMessageCount;
           break;
         case 'message-start':
           assistantCreatedAt = Date.now();

--- a/apps/backend/src/agent-core/llm-session/types.test.ts
+++ b/apps/backend/src/agent-core/llm-session/types.test.ts
@@ -14,6 +14,7 @@ const TEST_CONFIG: LlmConfig = {
 function emptyUsage() {
   return {
     currentContextInputTokens: 0,
+    latestCallOutputTokens: 0,
     sessionInputTokens: 0,
     sessionOutputTokens: 0,
     sessionCacheReadInputTokens: 0,
@@ -55,10 +56,22 @@ describe('llmSessionSnapshotSchema', () => {
       id: 'session-1',
       messages: [],
       compactions: [],
+      usageBaselineMessageCount: null,
       usage: emptyUsage(),
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it('requires usage baseline message count', () => {
+    const result = llmSessionSnapshotSchema.safeParse({
+      id: 'session-1',
+      messages: [],
+      compactions: [],
+      usage: emptyUsage(),
+    });
+
+    expect(result.success).toBe(false);
   });
 
   it('requires usage metadata', () => {
@@ -66,6 +79,7 @@ describe('llmSessionSnapshotSchema', () => {
       id: 'session-1',
       messages: [],
       compactions: [],
+      usageBaselineMessageCount: null,
     });
 
     expect(result.success).toBe(false);
@@ -75,6 +89,7 @@ describe('llmSessionSnapshotSchema', () => {
     const result = llmSessionSnapshotSchema.safeParse({
       id: 'session-1',
       compactions: [],
+      usageBaselineMessageCount: null,
       usage: emptyUsage(),
       messages: [
         {
@@ -94,6 +109,7 @@ describe('llmSessionSnapshotSchema', () => {
     const result = llmSessionSnapshotSchema.safeParse({
       id: 'session-1',
       compactions: [],
+      usageBaselineMessageCount: null,
       usage: emptyUsage(),
       messages: [
         {
@@ -126,8 +142,10 @@ describe('LlmSession snapshot metadata', () => {
           afterCharCount: 200,
         },
       ],
+      usageBaselineMessageCount: 1,
       usage: {
         currentContextInputTokens: 40,
+        latestCallOutputTokens: 8,
         sessionInputTokens: 140,
         sessionOutputTokens: 18,
         sessionCacheReadInputTokens: 25,
@@ -157,6 +175,7 @@ describe('LlmSession snapshot metadata', () => {
           afterCharCount: 200,
         },
       ],
+      usageBaselineMessageCount: null,
       usage: emptyUsage(),
     });
 
@@ -174,6 +193,7 @@ describe('LlmSession snapshot metadata', () => {
       id: 'session-1',
       messages: [],
       compactions: [],
+      usageBaselineMessageCount: null,
       usage: emptyUsage(),
     });
 

--- a/apps/backend/src/agent-core/llm-session/types.ts
+++ b/apps/backend/src/agent-core/llm-session/types.ts
@@ -17,6 +17,7 @@ export type LlmCompactionMetadata = z.infer<typeof llmCompactionMetadataSchema>;
 
 export const llmSessionUsageSchema = z.object({
   currentContextInputTokens: z.number(),
+  latestCallOutputTokens: z.number(),
   sessionInputTokens: z.number(),
   sessionOutputTokens: z.number(),
   sessionCacheReadInputTokens: z.number(),
@@ -30,6 +31,7 @@ export const llmSessionSnapshotSchema = z.object({
   id: z.string(),
   messages: z.array(llmMessageSchema),
   compactions: z.array(llmCompactionMetadataSchema),
+  usageBaselineMessageCount: z.number().nullable(),
   usage: llmSessionUsageSchema,
 });
 

--- a/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts
+++ b/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts
@@ -41,6 +41,7 @@ function initAgentRegistries(): void {
 function emptyUsage() {
   return {
     currentContextInputTokens: 0,
+    latestCallOutputTokens: 0,
     sessionInputTokens: 0,
     sessionOutputTokens: 0,
     sessionCacheReadInputTokens: 0,
@@ -190,7 +191,12 @@ describe('dispatchAgentTool', () => {
         id: subagent.id,
         title: 'New Session',
         sseEventCount: 0,
-        llmSession: {messages: [], compactions: [], usage: emptyUsage()},
+        llmSession: {
+          messages: [],
+          compactions: [],
+          usageBaselineMessageCount: null,
+          usage: emptyUsage(),
+        },
         options: {workingDirectory: tmpDir, thinkingLevel: 'none'},
       });
       expect(metadata).toEqual({
@@ -231,7 +237,12 @@ describe('dispatchAgentTool', () => {
         id: subagent.id,
         title: 'New Session',
         sseEventCount: 0,
-        llmSession: {messages: [], compactions: [], usage: emptyUsage()},
+        llmSession: {
+          messages: [],
+          compactions: [],
+          usageBaselineMessageCount: null,
+          usage: emptyUsage(),
+        },
         options: {workingDirectory: tmpDir, thinkingLevel: 'none'},
       });
       expect(metadata).toEqual({


### PR DESCRIPTION
## Summary

- Add `latestCallOutputTokens` to backend `LlmSessionUsage` so compaction can account for the latest assistant output without a token-count API call.
- Replace compact trigger token counting with a single `LlmSession` estimate based on latest provider input usage, latest output usage, and locally estimated pending user/tool messages.
- Roll back usage/tracker state when a provider stream fails after reporting usage.

## Impact

This avoids relying on unsupported provider token-count endpoints for normal compact checks while preserving a bounded fallback estimate when no provider usage baseline exists.

## Validation

- `bun run test` in `apps/backend`: 47 files / 558 tests passed
- `bun run typecheck` in `apps/backend`: passed
- `bun run lint` in `apps/backend`: passed
