### PR TITLE
[codex] Move turn compaction before done

### DIFF
--- a/apps/backend/src/agent-core/agent/agent.test.ts
+++ b/apps/backend/src/agent-core/agent/agent.test.ts
@@ -84,6 +84,17 @@ async function* titleCompletionStream(): LlmEventStream {
   };
 }
 
+async function* summaryCompletionStream(): LlmEventStream {
+  yield {type: 'message-start', messageId: 'summary-message'};
+  await Promise.resolve();
+  yield {type: 'text-delta', content: 'Compacted summary'};
+  yield {
+    type: 'message-end',
+    stopReason: 'end_turn',
+    usage: {inputTokens: 1, outputTokens: 1, cacheReadInputTokens: 0},
+  };
+}
+
 async function* failingStream(): LlmEventStream {
   yield {type: 'message-start', messageId: 'failed-message'};
   await Promise.resolve();
@@ -130,14 +141,6 @@ async function collectAll(
     events.push(event);
   }
   return events;
-}
-
-async function waitFor(predicate: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt++) {
-    if (predicate()) return;
-    await delay(5);
-  }
-  expect(predicate()).toBe(true);
 }
 
 describe('Agent title generation', () => {
@@ -224,6 +227,41 @@ describe('Agent usage reporting', () => {
       },
     });
   });
+
+  it('emits done usage with compacted context after turn-end compaction', async () => {
+    vi.spyOn(llmApi, 'streamCompletion').mockImplementation((options) => {
+      const isSummaryRequest =
+        options.tools.length === 0 &&
+        options.messages.length === 1 &&
+        options.messages[0]?.role === 'user' &&
+        options.messages[0].content.includes('<history_to_summarize>');
+
+      if (isSummaryRequest) return summaryCompletionStream();
+
+      return usageCompletionStream({
+        inputTokens: 110_000,
+        outputTokens: 7,
+        cacheReadInputTokens: 3,
+      });
+    });
+    const agent = new UsageTestAgent(
+      () => Promise.resolve(MAIN_CONFIG),
+      testAgentOptions(),
+    );
+
+    const events = await collectAll(agent.streamForTest('compact this turn'));
+    const doneEvent = events.at(-1);
+
+    expect(doneEvent?.type).toBe('done');
+    if (doneEvent?.type !== 'done') {
+      throw new Error('Expected final event to be done');
+    }
+    expect(doneEvent.usage.currentContextInputTokens).toBeGreaterThan(0);
+    expect(doneEvent.usage.currentContextInputTokens).toBeLessThan(110_000);
+    expect(doneEvent.usage.sessionInputTokens).toBe(110_000);
+    expect(doneEvent.usage.sessionOutputTokens).toBe(7);
+    expect(doneEvent.usage.sessionCacheReadInputTokens).toBe(3);
+  });
 });
 
 describe('Agent compaction lifecycle', () => {
@@ -231,27 +269,30 @@ describe('Agent compaction lifecycle', () => {
     vi.restoreAllMocks();
   });
 
-  it('requests turn-end compaction after emitting done', async () => {
+  it('requests turn-end compaction before emitting done', async () => {
     vi.spyOn(llmApi, 'countToken').mockResolvedValue(1);
-    vi.spyOn(llmApi, 'streamCompletion').mockImplementation((options) => {
-      if (options.config.model === LIGHT_CONFIG.model) {
-        return titleCompletionStream();
-      }
-      return mainCompletionStream();
-    });
+    vi.spyOn(llmApi, 'streamCompletion').mockImplementation(() =>
+      mainCompletionStream(),
+    );
+    const order: string[] = [];
     const compactSpy = vi
       .spyOn(LlmSession.prototype, 'compactIfNeeded')
-      .mockResolvedValue(false);
-    const agent = new TestAgent(() => Promise.resolve(MAIN_CONFIG), {
-      ...testAgentOptions(),
-    });
+      .mockImplementation(() => {
+        order.push('compact');
+        return Promise.resolve(false);
+      });
+    const agent = new UsageTestAgent(
+      () => Promise.resolve(MAIN_CONFIG),
+      testAgentOptions(),
+    );
 
-    const eventsPromise = collectUntilDone(agent);
-    agent.handleUserMessage('Finish the task');
-    const events = await eventsPromise;
+    for await (const event of agent.streamForTest('Finish the task')) {
+      if (event.type === 'done') {
+        order.push('done');
+      }
+    }
 
-    expect(events.at(-1)).toMatchObject({type: 'done', reason: 'complete'});
-    await waitFor(() => compactSpy.mock.calls.length > 0);
+    expect(order).toEqual(['compact', 'done']);
     const [compactionOptions] = compactSpy.mock.calls[0];
     expect(compactionOptions.reason).toBe('after-turn');
     expect(compactionOptions.tools).toEqual([]);

--- a/apps/backend/src/agent-core/agent/agent.ts
+++ b/apps/backend/src/agent-core/agent/agent.ts
@@ -291,6 +291,9 @@ export abstract class Agent {
 
   private async *emitAbortCompletion(
     inFlightToolCalls: Set<string>,
+    tools: readonly ToolDefinition[],
+    systemPrompt: string,
+    thinkingLevel: ThinkingLevel,
   ): AgentEventStream {
     for (const callId of inFlightToolCalls) {
       yield {
@@ -301,9 +304,24 @@ export abstract class Agent {
         data: {message: 'Aborted'},
       } satisfies SseToolExecuteEndEvent;
     }
+    yield* this.emitDoneAfterTurn(
+      'aborted',
+      tools,
+      systemPrompt,
+      thinkingLevel,
+    );
+  }
+
+  private async *emitDoneAfterTurn(
+    reason: SseDoneEvent['reason'],
+    tools: readonly ToolDefinition[],
+    systemPrompt: string,
+    thinkingLevel: ThinkingLevel,
+  ): AgentEventStream {
+    await this.compactAfterTurn(tools, systemPrompt, thinkingLevel);
     yield {
       type: 'done',
-      reason: 'aborted',
+      reason,
       usage: await this.buildSseUsage(),
     } satisfies SseDoneEvent;
   }
@@ -372,19 +390,23 @@ export abstract class Agent {
     let round = 0;
     while (toolCalls.length > 0) {
       if (signal.aborted) {
-        yield* this.emitAbortCompletion(inFlightToolCalls);
-        await this.compactAfterTurn(toolDefs, systemPrompt, thinkingLevel);
+        yield* this.emitAbortCompletion(
+          inFlightToolCalls,
+          toolDefs,
+          systemPrompt,
+          thinkingLevel,
+        );
         return;
       }
 
       round++;
       if (round > maxRounds) {
-        yield {
-          type: 'done',
-          reason: 'max_rounds_reached',
-          usage: await this.buildSseUsage(),
-        } satisfies SseDoneEvent;
-        await this.compactAfterTurn(toolDefs, systemPrompt, thinkingLevel);
+        yield* this.emitDoneAfterTurn(
+          'max_rounds_reached',
+          toolDefs,
+          systemPrompt,
+          thinkingLevel,
+        );
         return;
       }
 
@@ -478,8 +500,12 @@ export abstract class Agent {
       // signal.aborted may have changed during async tool execution
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (signal.aborted) {
-        yield* this.emitAbortCompletion(inFlightToolCalls);
-        await this.compactAfterTurn(toolDefs, systemPrompt, thinkingLevel);
+        yield* this.emitAbortCompletion(
+          inFlightToolCalls,
+          toolDefs,
+          systemPrompt,
+          thinkingLevel,
+        );
         return;
       }
 
@@ -499,12 +525,12 @@ export abstract class Agent {
       );
     }
 
-    yield {
-      type: 'done',
-      reason: 'complete',
-      usage: await this.buildSseUsage(),
-    } satisfies SseDoneEvent;
-    await this.compactAfterTurn(toolDefs, systemPrompt, thinkingLevel);
+    yield* this.emitDoneAfterTurn(
+      'complete',
+      toolDefs,
+      systemPrompt,
+      thinkingLevel,
+    );
   }
 
   /**

--- a/apps/backend/src/agent-core/llm-session/llm-session.ts
+++ b/apps/backend/src/agent-core/llm-session/llm-session.ts
@@ -289,6 +289,11 @@ export class LlmSession {
     this.messages.length = 0;
     this.messages.push(summaryMessage);
     this.usageBaselineMessageCount = null;
+    this.usage = {
+      ...this.usage,
+      currentContextInputTokens: this.estimatePromptTokensFromMessages(options),
+      latestCallOutputTokens: 0,
+    };
     this.compactions.push({
       id: crypto.randomUUID(),
       compactedAt: Date.now(),
@@ -307,6 +312,12 @@ export class LlmSession {
     const latestUsageEstimate = this.estimatePromptTokensFromLatestUsage();
     if (latestUsageEstimate !== null) return latestUsageEstimate;
 
+    return this.estimatePromptTokensFromMessages(options);
+  }
+
+  private estimatePromptTokensFromMessages(
+    options: LlmCompactionOptions,
+  ): number {
     return estimatePromptTokens({
       messages: this.messages,
       ...(options.systemPrompt ? {systemPrompt: options.systemPrompt} : {}),


### PR DESCRIPTION
## Summary
- Move turn-end compaction before terminal `done` events for complete, max-rounds, and abort paths.
- Update compacted session usage so `done.usage.currentContextInputTokens` reflects the compacted prompt estimate.
- Add regression coverage for terminal event ordering and compacted usage reporting.

## Why
This prepares the lifecycle for a future compact progress indicator: `done` should mean the turn is fully finished, including post-turn context cleanup.

## Validation
- `bun run --filter '@omnicraft/backend' test`\n- `bun run --filter '@omnicraft/backend' typecheck`\n- `bun run --filter '@omnicraft/backend' lint`