### PR TITLE
chore(backend): add Claude opus 4.7 variants to model capacity table

### DIFF
--- a/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
+++ b/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
@@ -14,7 +14,13 @@ const DEFAULT_MAX_INPUT_TOKENS = 200_000;
 const KNOWN_MODELS = new Map([
   ['claude-opus-4.6-1m', {maxOutputTokens: 64_000, maxInputTokens: 1_000_000}],
   ['claude-opus-4.6', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
+  [
+    'claude-opus-4.7-1m-internal',
+    {maxOutputTokens: 64_000, maxInputTokens: 1_000_000},
+  ],
   ['claude-opus-4.7', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
+  ['claude-opus-4.7-high', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
+  ['claude-opus-4.7-xhigh', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
   ['claude-sonnet-4.6', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
   ['claude-sonnet-4', {maxOutputTokens: 16_000, maxInputTokens: 216_000}],
   ['claude-sonnet-4.5', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],


### PR DESCRIPTION
## Summary
- Add capacity entries for the three Claude opus 4.7 variants exposed by the Copilot proxy that were missing from the static table: \`claude-opus-4.7-1m-internal\` (64K out / 1M in), \`claude-opus-4.7-high\`, and \`claude-opus-4.7-xhigh\` (both 32K out / 200K in).

## Test plan
- [x] \`bun run lint\`
- [x] \`bun run typecheck\`
- [x] \`bun test src/agent-core/model-capacity/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)