### PR TITLE
refactor(backend): align model capacity with provider's three-field shape

### DIFF
--- a/apps/backend/src/agent-core/agent/agent.test.ts
+++ b/apps/backend/src/agent-core/agent/agent.test.ts
@@ -325,7 +325,7 @@ describe('Agent usage reporting', () => {
       if (isSummaryRequest) return summaryCompletionStream();
 
       return usageCompletionStream({
-        inputTokens: 110_000,
+        inputTokens: 120_000,
         outputTokens: 7,
         cacheReadInputTokens: 3,
       });
@@ -347,9 +347,9 @@ describe('Agent usage reporting', () => {
     }
     expect(lastUsageUpdate.usage.currentContextInputTokens).toBeGreaterThan(0);
     expect(lastUsageUpdate.usage.currentContextInputTokens).toBeLessThan(
-      110_000,
+      120_000,
     );
-    expect(lastUsageUpdate.usage.sessionInputTokens).toBe(110_000);
+    expect(lastUsageUpdate.usage.sessionInputTokens).toBe(120_000);
     expect(lastUsageUpdate.usage.sessionOutputTokens).toBe(7);
     expect(lastUsageUpdate.usage.sessionCacheReadInputTokens).toBe(3);
   });

--- a/apps/backend/src/agent-core/agent/agent.ts
+++ b/apps/backend/src/agent-core/agent/agent.ts
@@ -571,7 +571,7 @@ export abstract class Agent {
    */
   private async buildSseUsage(): Promise<SseUsage> {
     const config = await this.getConfig();
-    const contextWindowTokens = await modelCapacity.getMaxInputTokens(config);
+    const contextWindowTokens = await modelCapacity.getMaxPromptTokens(config);
     const usage = this.llmSession.getUsage();
     return {
       model: config.model,

--- a/apps/backend/src/agent-core/llm-session/compaction/compaction-constants.ts
+++ b/apps/backend/src/agent-core/llm-session/compaction/compaction-constants.ts
@@ -1,5 +1,5 @@
-/** Compact when the current prompt reaches this fraction of model input capacity. */
-export const COMPACTION_TRIGGER_INPUT_TOKEN_RATIO = 0.8;
+/** Compact when the current prompt reaches this fraction of the model's prompt-token budget. */
+export const COMPACTION_TRIGGER_PROMPT_TOKEN_RATIO = 0.9;
 
 /** Number of latest messages included in the deterministic recent context. */
 export const RECENT_CONTEXT_SOURCE_MESSAGE_COUNT = 20;

--- a/apps/backend/src/agent-core/llm-session/compaction/llm-compaction-decision-service.test.ts
+++ b/apps/backend/src/agent-core/llm-session/compaction/llm-compaction-decision-service.test.ts
@@ -57,8 +57,8 @@ describe('LlmCompactionDecisionService', () => {
   });
 
   it('returns skip below threshold', async () => {
-    vi.spyOn(modelCapacity, 'getMaxInputTokens').mockResolvedValue(1000);
-    const service = createService(799);
+    vi.spyOn(modelCapacity, 'getMaxPromptTokens').mockResolvedValue(1000);
+    const service = createService(899);
 
     await expect(
       service.decide({
@@ -72,7 +72,7 @@ describe('LlmCompactionDecisionService', () => {
   });
 
   it('returns skip when messages are empty even if token estimate is high', async () => {
-    vi.spyOn(modelCapacity, 'getMaxInputTokens').mockResolvedValue(1000);
+    vi.spyOn(modelCapacity, 'getMaxPromptTokens').mockResolvedValue(1000);
     const service = createService(1000);
 
     await expect(
@@ -87,12 +87,12 @@ describe('LlmCompactionDecisionService', () => {
   });
 
   it('returns compact decision at or above threshold with metadata', async () => {
-    vi.spyOn(modelCapacity, 'getMaxInputTokens').mockResolvedValue(1000);
+    vi.spyOn(modelCapacity, 'getMaxPromptTokens').mockResolvedValue(1000);
     vi.spyOn(crypto, 'randomUUID').mockReturnValue(
       '00000000-0000-4000-8000-000000000000',
     );
     vi.spyOn(Date, 'now').mockReturnValue(12345);
-    const service = createService(800);
+    const service = createService(900);
 
     await expect(
       service.decide({
@@ -106,7 +106,7 @@ describe('LlmCompactionDecisionService', () => {
       type: 'compact',
       compactionId: '00000000-0000-4000-8000-000000000000',
       reason: 'before-llm-call',
-      beforeTokens: 800,
+      beforeTokens: 900,
       coveredMessageCount: 2,
       startedAt: 12345,
     });

--- a/apps/backend/src/agent-core/llm-session/compaction/llm-compaction-decision-service.ts
+++ b/apps/backend/src/agent-core/llm-session/compaction/llm-compaction-decision-service.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 
 import {modelCapacity} from '../../model-capacity/index.js';
-import {COMPACTION_TRIGGER_INPUT_TOKEN_RATIO} from './compaction-constants.js';
+import {COMPACTION_TRIGGER_PROMPT_TOKEN_RATIO} from './compaction-constants.js';
 import {
   LlmCompactionTokenEstimator,
   llmCompactionTokenEstimator,
@@ -19,10 +19,15 @@ export class LlmCompactionDecisionService {
   async decide(
     input: LlmCompactionDecisionInput,
   ): Promise<LlmCompactionDecision> {
-    const maxInputTokens = await modelCapacity.getMaxInputTokens(input.config);
+    const maxPromptTokens = await modelCapacity.getMaxPromptTokens(
+      input.config,
+    );
     const currentTokens = this.tokenEstimator.estimateCurrentTokens(input);
 
-    if (currentTokens < maxInputTokens * COMPACTION_TRIGGER_INPUT_TOKEN_RATIO) {
+    if (
+      currentTokens <
+      maxPromptTokens * COMPACTION_TRIGGER_PROMPT_TOKEN_RATIO
+    ) {
       return {type: 'skip'};
     }
 

--- a/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
+++ b/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
@@ -5,32 +5,113 @@ import {logger} from '@/logger.js';
 import type {LlmConfig} from '../llm-api/types.js';
 
 const DEFAULT_MAX_OUTPUT_TOKENS = 16_384;
-const DEFAULT_MAX_INPUT_TOKENS = 200_000;
+const DEFAULT_MAX_PROMPT_TOKENS = 168_000;
+const DEFAULT_MAX_CONTEXT_WINDOW_TOKENS = 200_000;
 
 /**
  * Known Claude model capacities. Checked before the SDK call so that
  * proxies that don't implement `/v1/models/{id}` still get correct limits.
+ *
+ * Field names mirror the Copilot `/v1/models` capability shape:
+ * - maxContextWindowTokens: total budget (prompt + output)
+ * - maxPromptTokens: max accepted input
+ * - maxOutputTokens: max generation
  */
-const KNOWN_MODELS = new Map([
-  ['claude-opus-4.6-1m', {maxOutputTokens: 64_000, maxInputTokens: 1_000_000}],
-  ['claude-opus-4.6', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
+const KNOWN_MODELS = new Map<string, CachedCapacity>([
+  [
+    'claude-opus-4.6-1m',
+    {
+      maxContextWindowTokens: 1_000_000,
+      maxPromptTokens: 936_000,
+      maxOutputTokens: 64_000,
+    },
+  ],
+  [
+    'claude-opus-4.6',
+    {
+      maxContextWindowTokens: 200_000,
+      maxPromptTokens: 168_000,
+      maxOutputTokens: 32_000,
+    },
+  ],
   [
     'claude-opus-4.7-1m-internal',
-    {maxOutputTokens: 64_000, maxInputTokens: 1_000_000},
+    {
+      maxContextWindowTokens: 1_000_000,
+      maxPromptTokens: 936_000,
+      maxOutputTokens: 64_000,
+    },
   ],
-  ['claude-opus-4.7', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
-  ['claude-opus-4.7-high', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
-  ['claude-opus-4.7-xhigh', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
-  ['claude-sonnet-4.6', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
-  ['claude-sonnet-4', {maxOutputTokens: 16_000, maxInputTokens: 216_000}],
-  ['claude-sonnet-4.5', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
-  ['claude-opus-4.5', {maxOutputTokens: 32_000, maxInputTokens: 200_000}],
-  ['claude-haiku-4.5', {maxOutputTokens: 64_000, maxInputTokens: 200_000}],
+  [
+    'claude-opus-4.7',
+    {
+      maxContextWindowTokens: 200_000,
+      maxPromptTokens: 168_000,
+      maxOutputTokens: 32_000,
+    },
+  ],
+  [
+    'claude-opus-4.7-high',
+    {
+      maxContextWindowTokens: 200_000,
+      maxPromptTokens: 168_000,
+      maxOutputTokens: 32_000,
+    },
+  ],
+  [
+    'claude-opus-4.7-xhigh',
+    {
+      maxContextWindowTokens: 200_000,
+      maxPromptTokens: 168_000,
+      maxOutputTokens: 32_000,
+    },
+  ],
+  [
+    'claude-sonnet-4.6',
+    {
+      maxContextWindowTokens: 200_000,
+      maxPromptTokens: 168_000,
+      maxOutputTokens: 32_000,
+    },
+  ],
+  [
+    'claude-sonnet-4',
+    {
+      maxContextWindowTokens: 216_000,
+      maxPromptTokens: 200_000,
+      maxOutputTokens: 16_000,
+    },
+  ],
+  [
+    'claude-sonnet-4.5',
+    {
+      maxContextWindowTokens: 200_000,
+      maxPromptTokens: 168_000,
+      maxOutputTokens: 32_000,
+    },
+  ],
+  [
+    'claude-opus-4.5',
+    {
+      maxContextWindowTokens: 200_000,
+      maxPromptTokens: 168_000,
+      maxOutputTokens: 32_000,
+    },
+  ],
+  [
+    'claude-haiku-4.5',
+    {
+      maxContextWindowTokens: 200_000,
+      maxPromptTokens: 136_000,
+      maxOutputTokens: 64_000,
+    },
+  ],
 ]);
 
 interface CachedCapacity {
+  maxContextWindowTokens: number;
+  maxPromptTokens: number;
   maxOutputTokens: number;
-  maxInputTokens: number;
 }
 
 /** Module-level cache keyed by `${baseUrl}::${model}`. */
@@ -60,9 +141,14 @@ async function resolve(config: Readonly<LlmConfig>): Promise<CachedCapacity> {
       baseURL: config.baseUrl,
     });
     const model = await client.models.retrieve(config.model);
+    // The Anthropic SDK exposes `max_tokens` (output) and `max_input_tokens`
+    // (prompt budget). Context window is derived: prompt + output.
+    const maxOutputTokens = model.max_tokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
+    const maxPromptTokens = model.max_input_tokens ?? DEFAULT_MAX_PROMPT_TOKENS;
     const capacity: CachedCapacity = {
-      maxOutputTokens: model.max_tokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
-      maxInputTokens: model.max_input_tokens ?? DEFAULT_MAX_INPUT_TOKENS,
+      maxContextWindowTokens: maxPromptTokens + maxOutputTokens,
+      maxPromptTokens,
+      maxOutputTokens,
     };
     cache.set(key, capacity);
     return capacity;
@@ -74,8 +160,9 @@ async function resolve(config: Readonly<LlmConfig>): Promise<CachedCapacity> {
       'Failed to retrieve model capacity, using defaults',
     );
     return {
+      maxContextWindowTokens: DEFAULT_MAX_CONTEXT_WINDOW_TOKENS,
+      maxPromptTokens: DEFAULT_MAX_PROMPT_TOKENS,
       maxOutputTokens: DEFAULT_MAX_OUTPUT_TOKENS,
-      maxInputTokens: DEFAULT_MAX_INPUT_TOKENS,
     };
   }
 }
@@ -88,10 +175,18 @@ export async function getClaudeMaxOutputTokens(
   return capacity.maxOutputTokens;
 }
 
-/** Returns the max input tokens (context window) for a Claude model. */
-export async function getClaudeMaxInputTokens(
+/** Returns the max prompt tokens (input budget, excluding output) for a Claude model. */
+export async function getClaudeMaxPromptTokens(
   config: Readonly<LlmConfig>,
 ): Promise<number> {
   const capacity = await resolve(config);
-  return capacity.maxInputTokens;
+  return capacity.maxPromptTokens;
+}
+
+/** Returns the max context window tokens (prompt + output) for a Claude model. */
+export async function getClaudeMaxContextWindowTokens(
+  config: Readonly<LlmConfig>,
+): Promise<number> {
+  const capacity = await resolve(config);
+  return capacity.maxContextWindowTokens;
 }

--- a/apps/backend/src/agent-core/model-capacity/model-capacity.test.ts
+++ b/apps/backend/src/agent-core/model-capacity/model-capacity.test.ts
@@ -43,7 +43,10 @@ describe('modelCapacity', () => {
         model: 'gpt-5.5',
       });
       expect(await modelCapacity.getMaxOutputTokens(config)).toBe(128_000);
-      expect(await modelCapacity.getMaxInputTokens(config)).toBe(400_000);
+      expect(await modelCapacity.getMaxPromptTokens(config)).toBe(272_000);
+      expect(await modelCapacity.getMaxContextWindowTokens(config)).toBe(
+        400_000,
+      );
     });
 
     it('returns known output limit via openai-responses format', async () => {
@@ -60,7 +63,10 @@ describe('modelCapacity', () => {
         model: 'unknown-model-xyz',
       });
       expect(await modelCapacity.getMaxOutputTokens(config)).toBe(16_384);
-      expect(await modelCapacity.getMaxInputTokens(config)).toBe(128_000);
+      expect(await modelCapacity.getMaxPromptTokens(config)).toBe(128_000);
+      expect(await modelCapacity.getMaxContextWindowTokens(config)).toBe(
+        128_000,
+      );
     });
 
     it('returns known limits for a Gemini model', async () => {
@@ -69,7 +75,10 @@ describe('modelCapacity', () => {
         model: 'gemini-2.5-pro',
       });
       expect(await modelCapacity.getMaxOutputTokens(config)).toBe(64_000);
-      expect(await modelCapacity.getMaxInputTokens(config)).toBe(128_000);
+      expect(await modelCapacity.getMaxPromptTokens(config)).toBe(128_000);
+      expect(await modelCapacity.getMaxContextWindowTokens(config)).toBe(
+        128_000,
+      );
     });
   });
 
@@ -80,7 +89,10 @@ describe('modelCapacity', () => {
         model: 'claude-opus-4.7',
       });
       expect(await modelCapacity.getMaxOutputTokens(config)).toBe(32_000);
-      expect(await modelCapacity.getMaxInputTokens(config)).toBe(200_000);
+      expect(await modelCapacity.getMaxPromptTokens(config)).toBe(168_000);
+      expect(await modelCapacity.getMaxContextWindowTokens(config)).toBe(
+        200_000,
+      );
       expect(mockRetrieve).not.toHaveBeenCalled();
     });
 
@@ -95,7 +107,11 @@ describe('modelCapacity', () => {
       });
 
       expect(await modelCapacity.getMaxOutputTokens(config)).toBe(128_000);
-      expect(await modelCapacity.getMaxInputTokens(config)).toBe(1_000_000);
+      expect(await modelCapacity.getMaxPromptTokens(config)).toBe(1_000_000);
+      // Context window is derived as prompt + output for SDK-returned models.
+      expect(await modelCapacity.getMaxContextWindowTokens(config)).toBe(
+        1_128_000,
+      );
       expect(mockRetrieve).toHaveBeenCalledWith('claude-opus-4-6');
     });
 
@@ -110,7 +126,7 @@ describe('modelCapacity', () => {
       });
 
       await modelCapacity.getMaxOutputTokens(config);
-      await modelCapacity.getMaxInputTokens(config);
+      await modelCapacity.getMaxPromptTokens(config);
 
       // Only one API call despite two queries.
       expect(mockRetrieve).toHaveBeenCalledTimes(1);
@@ -124,7 +140,10 @@ describe('modelCapacity', () => {
       });
 
       expect(await modelCapacity.getMaxOutputTokens(config)).toBe(16_384);
-      expect(await modelCapacity.getMaxInputTokens(config)).toBe(200_000);
+      expect(await modelCapacity.getMaxPromptTokens(config)).toBe(168_000);
+      expect(await modelCapacity.getMaxContextWindowTokens(config)).toBe(
+        200_000,
+      );
     });
 
     it('retries the API call after a transient failure', async () => {

--- a/apps/backend/src/agent-core/model-capacity/model-capacity.ts
+++ b/apps/backend/src/agent-core/model-capacity/model-capacity.ts
@@ -1,11 +1,13 @@
 import type {LlmConfig} from '../llm-api/types.js';
 import {
-  getClaudeMaxInputTokens,
+  getClaudeMaxContextWindowTokens,
   getClaudeMaxOutputTokens,
+  getClaudeMaxPromptTokens,
 } from './claude-capacity.js';
 import {
-  getOpenAIMaxInputTokens,
+  getOpenAIMaxContextWindowTokens,
   getOpenAIMaxOutputTokens,
+  getOpenAIMaxPromptTokens,
 } from './openai-capacity.js';
 
 /** Queries model token limits, dispatching by provider. */
@@ -20,13 +22,25 @@ export const modelCapacity = {
     }
   },
 
-  /** Returns the maximum input tokens (context window) for the configured model. */
-  async getMaxInputTokens(config: Readonly<LlmConfig>): Promise<number> {
+  /** Returns the maximum prompt tokens (input budget, excludes output) for the configured model. */
+  async getMaxPromptTokens(config: Readonly<LlmConfig>): Promise<number> {
     switch (config.apiFormat) {
       case 'claude':
-        return getClaudeMaxInputTokens(config);
+        return getClaudeMaxPromptTokens(config);
       case 'openai-responses':
-        return getOpenAIMaxInputTokens(config);
+        return getOpenAIMaxPromptTokens(config);
+    }
+  },
+
+  /** Returns the maximum context window tokens (prompt + output) for the configured model. */
+  async getMaxContextWindowTokens(
+    config: Readonly<LlmConfig>,
+  ): Promise<number> {
+    switch (config.apiFormat) {
+      case 'claude':
+        return getClaudeMaxContextWindowTokens(config);
+      case 'openai-responses':
+        return getOpenAIMaxContextWindowTokens(config);
     }
   },
 };

--- a/apps/backend/src/agent-core/model-capacity/openai-capacity.ts
+++ b/apps/backend/src/agent-core/model-capacity/openai-capacity.ts
@@ -1,32 +1,129 @@
 import type {LlmConfig} from '../llm-api/types.js';
 
 const DEFAULT_MAX_OUTPUT_TOKENS = 16_384;
-const DEFAULT_MAX_INPUT_TOKENS = 128_000;
+const DEFAULT_MAX_PROMPT_TOKENS = 128_000;
+const DEFAULT_MAX_CONTEXT_WINDOW_TOKENS = 128_000;
+
+interface KnownCapacity {
+  maxContextWindowTokens: number;
+  maxPromptTokens: number;
+  maxOutputTokens: number;
+}
 
 /**
  * Known model capacities from OpenAI-compatible providers (OpenAI, Gemini, etc.).
  * These values must be maintained manually since the OpenAI API does not expose
  * token limits programmatically.
+ *
+ * Field names mirror the Copilot `/v1/models` capability shape:
+ * - maxContextWindowTokens: total budget (prompt + output)
+ * - maxPromptTokens: max accepted input
+ * - maxOutputTokens: max generation
  */
-const KNOWN_MODELS = new Map([
-  ['gpt-4o', {maxOutputTokens: 4_096, maxInputTokens: 128_000}],
-  ['gpt-4.1', {maxOutputTokens: 16_384, maxInputTokens: 128_000}],
-  ['gpt-5-mini', {maxOutputTokens: 64_000, maxInputTokens: 264_000}],
-  ['gpt-5.1', {maxOutputTokens: 64_000, maxInputTokens: 264_000}],
-  ['gpt-5.2', {maxOutputTokens: 128_000, maxInputTokens: 400_000}],
-  ['gpt-5.2-codex', {maxOutputTokens: 128_000, maxInputTokens: 400_000}],
-  ['gpt-5.3-codex', {maxOutputTokens: 128_000, maxInputTokens: 400_000}],
-  ['gpt-5.4-mini', {maxOutputTokens: 128_000, maxInputTokens: 400_000}],
-  ['gpt-5.4', {maxOutputTokens: 128_000, maxInputTokens: 400_000}],
-  ['gpt-5.5', {maxOutputTokens: 128_000, maxInputTokens: 400_000}],
-  ['gemini-2.5-pro', {maxOutputTokens: 64_000, maxInputTokens: 128_000}],
+const KNOWN_MODELS = new Map<string, KnownCapacity>([
+  [
+    'gpt-4o',
+    {
+      maxContextWindowTokens: 128_000,
+      maxPromptTokens: 64_000,
+      maxOutputTokens: 4_096,
+    },
+  ],
+  [
+    'gpt-4.1',
+    {
+      maxContextWindowTokens: 128_000,
+      maxPromptTokens: 128_000,
+      maxOutputTokens: 16_384,
+    },
+  ],
+  [
+    'gpt-5-mini',
+    {
+      maxContextWindowTokens: 264_000,
+      maxPromptTokens: 128_000,
+      maxOutputTokens: 64_000,
+    },
+  ],
+  [
+    'gpt-5.1',
+    {
+      maxContextWindowTokens: 264_000,
+      maxPromptTokens: 128_000,
+      maxOutputTokens: 64_000,
+    },
+  ],
+  [
+    'gpt-5.2',
+    {
+      maxContextWindowTokens: 400_000,
+      maxPromptTokens: 272_000,
+      maxOutputTokens: 128_000,
+    },
+  ],
+  [
+    'gpt-5.2-codex',
+    {
+      maxContextWindowTokens: 400_000,
+      maxPromptTokens: 272_000,
+      maxOutputTokens: 128_000,
+    },
+  ],
+  [
+    'gpt-5.3-codex',
+    {
+      maxContextWindowTokens: 400_000,
+      maxPromptTokens: 272_000,
+      maxOutputTokens: 128_000,
+    },
+  ],
+  [
+    'gpt-5.4-mini',
+    {
+      maxContextWindowTokens: 400_000,
+      maxPromptTokens: 272_000,
+      maxOutputTokens: 128_000,
+    },
+  ],
+  [
+    'gpt-5.4',
+    {
+      maxContextWindowTokens: 400_000,
+      maxPromptTokens: 272_000,
+      maxOutputTokens: 128_000,
+    },
+  ],
+  [
+    'gpt-5.5',
+    {
+      maxContextWindowTokens: 400_000,
+      maxPromptTokens: 272_000,
+      maxOutputTokens: 128_000,
+    },
+  ],
+  [
+    'gemini-2.5-pro',
+    {
+      maxContextWindowTokens: 128_000,
+      maxPromptTokens: 128_000,
+      maxOutputTokens: 64_000,
+    },
+  ],
   [
     'gemini-3-flash-preview',
-    {maxOutputTokens: 64_000, maxInputTokens: 128_000},
+    {
+      maxContextWindowTokens: 128_000,
+      maxPromptTokens: 128_000,
+      maxOutputTokens: 64_000,
+    },
   ],
   [
     'gemini-3.1-pro-preview',
-    {maxOutputTokens: 64_000, maxInputTokens: 200_000},
+    {
+      maxContextWindowTokens: 200_000,
+      maxPromptTokens: 136_000,
+      maxOutputTokens: 64_000,
+    },
   ],
 ]);
 
@@ -37,9 +134,19 @@ export function getOpenAIMaxOutputTokens(config: Readonly<LlmConfig>): number {
   );
 }
 
-/** Returns the max input tokens (context window) for an OpenAI-compatible model. */
-export function getOpenAIMaxInputTokens(config: Readonly<LlmConfig>): number {
+/** Returns the max prompt tokens (input budget, excluding output) for an OpenAI-compatible model. */
+export function getOpenAIMaxPromptTokens(config: Readonly<LlmConfig>): number {
   return (
-    KNOWN_MODELS.get(config.model)?.maxInputTokens ?? DEFAULT_MAX_INPUT_TOKENS
+    KNOWN_MODELS.get(config.model)?.maxPromptTokens ?? DEFAULT_MAX_PROMPT_TOKENS
+  );
+}
+
+/** Returns the max context window tokens (prompt + output) for an OpenAI-compatible model. */
+export function getOpenAIMaxContextWindowTokens(
+  config: Readonly<LlmConfig>,
+): number {
+  return (
+    KNOWN_MODELS.get(config.model)?.maxContextWindowTokens ??
+    DEFAULT_MAX_CONTEXT_WINDOW_TOKENS
   );
 }


### PR DESCRIPTION
## Summary
- Replace single \`maxInputTokens\` per model with three fields mirroring the Copilot \`/v1/models\` shape: \`maxContextWindowTokens\`, \`maxPromptTokens\`, \`maxOutputTokens\`. Anthropic SDK lookups derive the context window as prompt + output (the SDK only returns the other two).
- Switch the compaction trigger from \`maxInputTokens * 0.8\` to \`maxPromptTokens * 0.9\` — anchored to the real input budget (which already excludes output) with a tighter buffer that reflects our mostly-accurate token estimates.
- Use \`maxPromptTokens\` as the denominator for the UI context-usage percentage. The wire field name (\`contextWindowTokens\`) is unchanged so frontend code does not move.

## Notes
- The previous OpenAI-side table was using the context-window value as if it were an input budget (e.g. gpt-5.2 stored 400K, but the provider's actual \`max_prompt_tokens\` is 272K). The new table values come from \`http://copilot-api-server.local:4141/v1/models\`, which silently fixes that.
- UI context% will read higher than before on models where output reserves a meaningful chunk of the window (e.g. 200K/32K-output Claude: denominator drops 200K → 168K). That is the correct number.

## Test plan
- [x] \`bun run lint\` (backend)
- [x] \`bun run typecheck\` (backend)
- [x] \`bun run test\` (backend) — only failure is pre-existing \`sse.test.ts\` ordering issue on main, unrelated
- [x] \`bun run format:check\` (root)
- [x] \`bun run build\` (frontend)
- [x] \`bun run test\` (frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)