### PR TITLE
fix(backend): isolate default agent working directory per agent id

### DIFF
--- a/apps/backend/src/agent-core/agent/agent.test.ts
+++ b/apps/backend/src/agent-core/agent/agent.test.ts
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto';
-import {realpathSync, statSync} from 'node:fs';
+import {mkdtempSync, realpathSync, rmSync, statSync} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -55,6 +55,11 @@ class TestToolRegistry extends ToolRegistry {
 }
 
 function testAgentOptions() {
+  // Provide a per-call tmp workingDirectory so the Agent constructor's
+  // default path (which would mkdir under os.tmpdir() and leak a directory)
+  // doesn't run. The dir is registered for cleanup by the afterEach below.
+  const workingDirectory = mkdtempSync(path.join(os.tmpdir(), 'agent-test-'));
+  tmpDirsToCleanup.add(workingDirectory);
   return {
     toolRegistries: [],
     skillRegistries: [],
@@ -62,8 +67,22 @@ function testAgentOptions() {
     getMaxToolRounds: () => 1,
     getLightConfig: () => Promise.resolve(LIGHT_CONFIG),
     thinkingLevel: 'high' as const,
+    workingDirectory,
   };
 }
+
+const tmpDirsToCleanup = new Set<string>();
+
+afterEach(() => {
+  for (const dir of tmpDirsToCleanup) {
+    try {
+      rmSync(dir, {recursive: true, force: true});
+    } catch {
+      // ignore — best-effort cleanup
+    }
+  }
+  tmpDirsToCleanup.clear();
+});
 
 async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
@@ -823,13 +842,27 @@ describe('Agent snapshot restore', () => {
 });
 
 describe('Agent default working directory', () => {
+  // Helpers: these tests intentionally exercise the constructor's default
+  // path (no workingDirectory passed), which creates `<tmpdir>/<agent-id>`.
+  // We register that path for cleanup ourselves since testAgentOptions()'s
+  // default workingDirectory is what we're trying to bypass here.
+  function defaultedOptions() {
+    const {workingDirectory: _omit, ...rest} = testAgentOptions();
+    return rest;
+  }
+  function registerAgentTmpDir(id: string): string {
+    const dir = path.join(realpathSync(os.tmpdir()), id);
+    tmpDirsToCleanup.add(dir);
+    return dir;
+  }
+
   it('creates a per-id tmp directory for a fresh agent', () => {
     const agent = new TestAgent(
       () => Promise.resolve(MAIN_CONFIG),
-      testAgentOptions(),
+      defaultedOptions(),
     );
 
-    const expected = path.join(realpathSync(os.tmpdir()), agent.id);
+    const expected = registerAgentTmpDir(agent.id);
     const {workingDirectory} = agent.toSnapshot().options;
     expect(workingDirectory).toBe(expected);
     expect(statSync(expected).isDirectory()).toBe(true);
@@ -858,11 +891,11 @@ describe('Agent default working directory', () => {
 
     const agent = new TestAgent(
       () => Promise.resolve(MAIN_CONFIG),
-      testAgentOptions(),
+      defaultedOptions(),
       snapshot,
     );
 
-    const expected = path.join(realpathSync(os.tmpdir()), id);
+    const expected = registerAgentTmpDir(id);
     expect(agent.toSnapshot().options.workingDirectory).toBe(expected);
     expect(statSync(expected).isDirectory()).toBe(true);
   });
@@ -888,7 +921,7 @@ describe('Agent default working directory', () => {
       () =>
         new TestAgent(
           () => Promise.resolve(MAIN_CONFIG),
-          testAgentOptions(),
+          defaultedOptions(),
           snapshot,
         ),
     ).toThrow();
@@ -897,7 +930,7 @@ describe('Agent default working directory', () => {
   it('respects an explicit workingDirectory and skips tmp dir creation', () => {
     const explicit = realpathSync(os.tmpdir());
     const agent = new TestAgent(() => Promise.resolve(MAIN_CONFIG), {
-      ...testAgentOptions(),
+      ...defaultedOptions(),
       workingDirectory: explicit,
     });
     expect(agent.toSnapshot().options.workingDirectory).toBe(explicit);

--- a/apps/backend/src/agent-core/agent/agent.test.ts
+++ b/apps/backend/src/agent-core/agent/agent.test.ts
@@ -1,3 +1,8 @@
+import crypto from 'node:crypto';
+import {realpathSync, statSync} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
 import type {SseEvent} from '@omnicraft/sse-events';
 import {afterEach, describe, expect, it, vi} from 'vitest';
 
@@ -480,7 +485,7 @@ describe('Agent compaction lifecycle', () => {
       () => Promise.resolve(MAIN_CONFIG),
       testAgentOptions(),
       {
-        id: 'agent-1',
+        id: crypto.randomUUID(),
         title: 'Existing Title',
         sseEventCount: 0,
         llmSession: {
@@ -690,7 +695,7 @@ describe('Agent abort flow', () => {
       () => Promise.resolve(MAIN_CONFIG),
       testAgentOptions(),
       {
-        id: 'agent-compaction-abort',
+        id: crypto.randomUUID(),
         title: 'Existing Title',
         sseEventCount: 0,
         llmSession: {
@@ -814,5 +819,87 @@ describe('Agent snapshot restore', () => {
           snapshot,
         ),
     ).toThrow('Snapshot is missing thinkingLevel');
+  });
+});
+
+describe('Agent default working directory', () => {
+  it('creates a per-id tmp directory for a fresh agent', () => {
+    const agent = new TestAgent(
+      () => Promise.resolve(MAIN_CONFIG),
+      testAgentOptions(),
+    );
+
+    const expected = path.join(realpathSync(os.tmpdir()), agent.id);
+    const {workingDirectory} = agent.toSnapshot().options;
+    expect(workingDirectory).toBe(expected);
+    expect(statSync(expected).isDirectory()).toBe(true);
+    // Owner-only access. On macOS the parent tmp dir is already 0o700, but
+    // we still assert the per-agent dir landed on the mode we asked for.
+    expect(statSync(expected).mode & 0o777).toBe(0o700);
+  });
+
+  it('creates a per-id tmp directory when restoring a snapshot without workingDirectory', () => {
+    const id = crypto.randomUUID();
+    const snapshot: AgentSnapshot = {
+      id,
+      title: 'Restored Session',
+      sseEventCount: 0,
+      llmSession: {
+        id: 'llm-session-id',
+        messages: [],
+        compactions: [],
+        latestUsageInputMessageCount: null,
+        usage: emptyUsage(),
+      },
+      options: {
+        thinkingLevel: 'high',
+      },
+    };
+
+    const agent = new TestAgent(
+      () => Promise.resolve(MAIN_CONFIG),
+      testAgentOptions(),
+      snapshot,
+    );
+
+    const expected = path.join(realpathSync(os.tmpdir()), id);
+    expect(agent.toSnapshot().options.workingDirectory).toBe(expected);
+    expect(statSync(expected).isDirectory()).toBe(true);
+  });
+
+  it('rejects snapshots whose id is not a UUID', () => {
+    const snapshot = {
+      id: '../escape',
+      title: 'Restored Session',
+      sseEventCount: 0,
+      llmSession: {
+        id: 'llm-session-id',
+        messages: [],
+        compactions: [],
+        latestUsageInputMessageCount: null,
+        usage: emptyUsage(),
+      },
+      options: {
+        thinkingLevel: 'high',
+      },
+    } as unknown as AgentSnapshot;
+
+    expect(
+      () =>
+        new TestAgent(
+          () => Promise.resolve(MAIN_CONFIG),
+          testAgentOptions(),
+          snapshot,
+        ),
+    ).toThrow();
+  });
+
+  it('respects an explicit workingDirectory and skips tmp dir creation', () => {
+    const explicit = realpathSync(os.tmpdir());
+    const agent = new TestAgent(() => Promise.resolve(MAIN_CONFIG), {
+      ...testAgentOptions(),
+      workingDirectory: explicit,
+    });
+    expect(agent.toSnapshot().options.workingDirectory).toBe(explicit);
   });
 });

--- a/apps/backend/src/agent-core/agent/agent.ts
+++ b/apps/backend/src/agent-core/agent/agent.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import crypto from 'node:crypto';
-import {chmodSync, mkdirSync, realpathSync} from 'node:fs';
+import {chmodSync, lstatSync, mkdirSync, realpathSync} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -67,6 +67,11 @@ function createAgentTmpDir(agentId: string): string {
   agentSnapshotSchema.shape.id.parse(agentId);
   const dir = path.join(os.tmpdir(), agentId);
   mkdirSync(dir, {recursive: true, mode: 0o700});
+  // lstat (not stat) so a pre-planted symlink at `dir` is rejected before
+  // chmod/realpath would follow it to a target we don't own.
+  if (!lstatSync(dir).isDirectory()) {
+    throw new Error(`Agent tmp path is not a real directory: ${dir}`);
+  }
   // mkdir's `mode` is only applied on creation (and is masked by umask), so
   // re-assert 0o700 to cover the "directory already exists" case.
   chmodSync(dir, 0o700);

--- a/apps/backend/src/agent-core/agent/agent.ts
+++ b/apps/backend/src/agent-core/agent/agent.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert';
 import crypto from 'node:crypto';
+import {mkdirSync, realpathSync} from 'node:fs';
 import os from 'node:os';
+import path from 'node:path';
 
 import type {ThinkingLevel} from '@omnicraft/api-schema';
 import type {
@@ -53,6 +55,12 @@ import {FileStatTracker} from './state/file-stat-tracker.js';
 import {TodoStore} from './state/todo-store.js';
 import {generateTitle} from './title/agent-title.js';
 import type {AgentEventStream, AgentOptions, AgentSnapshot} from './types.js';
+
+function createAgentTmpDir(agentId: string): string {
+  const dir = path.join(os.tmpdir(), agentId);
+  mkdirSync(dir, {recursive: true, mode: 0o700});
+  return realpathSync(dir);
+}
 
 /**
  * Base class for all agents.
@@ -141,12 +149,14 @@ export abstract class Agent {
       this.id = snapshot.id;
       this.title = snapshot.title;
       this.sseEventCount = snapshot.sseEventCount;
-      this.workingDirectory = snapshot.options.workingDirectory ?? os.tmpdir();
+      this.workingDirectory =
+        snapshot.options.workingDirectory ?? createAgentTmpDir(this.id);
       this.llmSession = new LlmSession(getConfig, snapshot.llmSession);
     } else {
       this.thinkingLevel = options.thinkingLevel;
       this.id = crypto.randomUUID();
-      this.workingDirectory = options.workingDirectory ?? os.tmpdir();
+      this.workingDirectory =
+        options.workingDirectory ?? createAgentTmpDir(this.id);
       this.llmSession = new LlmSession(getConfig);
     }
 

--- a/apps/backend/src/agent-core/agent/agent.ts
+++ b/apps/backend/src/agent-core/agent/agent.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import crypto from 'node:crypto';
-import {mkdirSync, realpathSync} from 'node:fs';
+import {chmodSync, mkdirSync, realpathSync} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -54,11 +54,22 @@ import {FileContentCache} from './state/file-content-cache.js';
 import {FileStatTracker} from './state/file-stat-tracker.js';
 import {TodoStore} from './state/todo-store.js';
 import {generateTitle} from './title/agent-title.js';
-import type {AgentEventStream, AgentOptions, AgentSnapshot} from './types.js';
+import {
+  type AgentEventStream,
+  type AgentOptions,
+  type AgentSnapshot,
+  agentSnapshotSchema,
+} from './types.js';
 
 function createAgentTmpDir(agentId: string): string {
+  // Defense in depth: agentId reaches here from snapshots on disk. Reject
+  // anything that isn't a UUID so path.join can't escape os.tmpdir().
+  agentSnapshotSchema.shape.id.parse(agentId);
   const dir = path.join(os.tmpdir(), agentId);
   mkdirSync(dir, {recursive: true, mode: 0o700});
+  // mkdir's `mode` is only applied on creation (and is masked by umask), so
+  // re-assert 0o700 to cover the "directory already exists" case.
+  chmodSync(dir, 0o700);
   return realpathSync(dir);
 }
 

--- a/apps/backend/src/agent-core/agent/persistence/agent-persistence.test.ts
+++ b/apps/backend/src/agent-core/agent/persistence/agent-persistence.test.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import {mkdir, mkdtemp, readFile, rm, writeFile} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -43,7 +44,7 @@ function sseTextDelta(content: string): SseEvent {
 
 describe('agentPersistence', () => {
   let tmpDir: string;
-  const agentId = 'test-agent-id';
+  const agentId = crypto.randomUUID();
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(path.join(os.tmpdir(), 'agent-persistence-test-'));

--- a/apps/backend/src/agent-core/agent/types.ts
+++ b/apps/backend/src/agent-core/agent/types.ts
@@ -27,7 +27,7 @@ const agentSnapshotOptionsSchema = z.object({
 });
 
 export const agentSnapshotSchema = z.object({
-  id: z.string(),
+  id: z.uuid(),
   title: z.string(),
   sseEventCount: z.number(),
   llmSession: llmSessionSnapshotSchema,

--- a/apps/backend/src/models/agent-store/main-agent-store.test.ts
+++ b/apps/backend/src/models/agent-store/main-agent-store.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import crypto from 'node:crypto';
 import {mkdir, mkdtemp, rm, utimes, writeFile} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -245,26 +246,29 @@ describe('MainAgentStore', () => {
 
     it('returns metadata from valid snapshots', async () => {
       const store = MainAgentStore.create(sessionsDir);
-      await writeSnapshot(sessionsDir, 'session-a', {
-        id: 'session-a',
+      const id = crypto.randomUUID();
+      await writeSnapshot(sessionsDir, id, {
+        id,
         title: 'Title A',
       });
       const result = await store.listSessionMetadata(0, 100);
       expect(result).toEqual({
-        sessions: [{id: 'session-a', title: 'Title A'}],
+        sessions: [{id, title: 'Title A'}],
         total: 1,
       });
     });
 
     it('sorts by file mtime descending (most recent first)', async () => {
       const store = MainAgentStore.create(sessionsDir);
+      const olderId = crypto.randomUUID();
+      const newerId = crypto.randomUUID();
 
-      await writeSnapshot(sessionsDir, 'older', {
-        id: 'older',
+      await writeSnapshot(sessionsDir, olderId, {
+        id: olderId,
         title: 'Older',
       });
-      await writeSnapshot(sessionsDir, 'newer', {
-        id: 'newer',
+      await writeSnapshot(sessionsDir, newerId, {
+        id: newerId,
         title: 'Newer',
       });
 
@@ -272,30 +276,31 @@ describe('MainAgentStore', () => {
       const past = new Date(Date.now() - 60_000);
       const now = new Date();
       await utimes(
-        path.join(sessionsDir, 'older', 'snapshot.json'),
+        path.join(sessionsDir, olderId, 'snapshot.json'),
         past,
         past,
       );
-      await utimes(path.join(sessionsDir, 'newer', 'snapshot.json'), now, now);
+      await utimes(path.join(sessionsDir, newerId, 'snapshot.json'), now, now);
 
       const result = await store.listSessionMetadata(0, 100);
       expect(result.sessions).toEqual([
-        {id: 'newer', title: 'Newer'},
-        {id: 'older', title: 'Older'},
+        {id: newerId, title: 'Newer'},
+        {id: olderId, title: 'Older'},
       ]);
     });
 
     it('skips directories with missing snapshot.json', async () => {
       const store = MainAgentStore.create(sessionsDir);
+      const validId = crypto.randomUUID();
       await mkdir(path.join(sessionsDir, 'no-snapshot'));
-      await writeSnapshot(sessionsDir, 'valid', {
-        id: 'valid',
+      await writeSnapshot(sessionsDir, validId, {
+        id: validId,
         title: 'Valid',
       });
 
       const result = await store.listSessionMetadata(0, 100);
       expect(result).toEqual({
-        sessions: [{id: 'valid', title: 'Valid'}],
+        sessions: [{id: validId, title: 'Valid'}],
         total: 1,
       });
     });
@@ -306,85 +311,91 @@ describe('MainAgentStore', () => {
       await mkdir(dir);
       await writeFile(path.join(dir, 'snapshot.json'), 'not valid json{{{');
 
-      await writeSnapshot(sessionsDir, 'good', {id: 'good', title: 'Good'});
+      const goodId = crypto.randomUUID();
+      await writeSnapshot(sessionsDir, goodId, {id: goodId, title: 'Good'});
 
       const result = await store.listSessionMetadata(0, 100);
-      expect(result.sessions).toEqual([{id: 'good', title: 'Good'}]);
+      expect(result.sessions).toEqual([{id: goodId, title: 'Good'}]);
     });
 
     it('skips snapshots missing required fields', async () => {
       const store = MainAgentStore.create(sessionsDir);
-      await writeSnapshot(sessionsDir, 'no-title', {id: 'no-title'});
-      await writeSnapshot(sessionsDir, 'complete', {
-        id: 'complete',
+      const noTitleId = crypto.randomUUID();
+      const completeId = crypto.randomUUID();
+      await writeSnapshot(sessionsDir, noTitleId, {id: noTitleId});
+      await writeSnapshot(sessionsDir, completeId, {
+        id: completeId,
         title: 'Complete',
       });
 
       const result = await store.listSessionMetadata(0, 100);
-      expect(result.sessions).toEqual([{id: 'complete', title: 'Complete'}]);
+      expect(result.sessions).toEqual([{id: completeId, title: 'Complete'}]);
     });
 
     it('paginates with offset and limit', async () => {
       const store = MainAgentStore.create(sessionsDir);
 
-      for (let i = 0; i < 5; i++) {
-        await writeSnapshot(sessionsDir, `s${i}`, {
-          id: `s${i}`,
+      const ids = Array.from({length: 5}, () => crypto.randomUUID());
+      for (let i = 0; i < ids.length; i++) {
+        await writeSnapshot(sessionsDir, ids[i], {
+          id: ids[i],
           title: `T${i}`,
         });
         const mtime = new Date(Date.now() - (4 - i) * 60_000);
         await utimes(
-          path.join(sessionsDir, `s${i}`, 'snapshot.json'),
+          path.join(sessionsDir, ids[i], 'snapshot.json'),
           mtime,
           mtime,
         );
       }
 
-      // Sorted order by mtime desc: s4, s3, s2, s1, s0
+      // Sorted order by mtime desc: ids[4], ids[3], ids[2], ids[1], ids[0]
       const page1 = await store.listSessionMetadata(0, 2);
       expect(page1.total).toBe(5);
       expect(page1.sessions).toEqual([
-        {id: 's4', title: 'T4'},
-        {id: 's3', title: 'T3'},
+        {id: ids[4], title: 'T4'},
+        {id: ids[3], title: 'T3'},
       ]);
 
       const page2 = await store.listSessionMetadata(2, 2);
       expect(page2.total).toBe(5);
       expect(page2.sessions).toEqual([
-        {id: 's2', title: 'T2'},
-        {id: 's1', title: 'T1'},
+        {id: ids[2], title: 'T2'},
+        {id: ids[1], title: 'T1'},
       ]);
 
       const page3 = await store.listSessionMetadata(4, 2);
       expect(page3.total).toBe(5);
-      expect(page3.sessions).toEqual([{id: 's0', title: 'T0'}]);
+      expect(page3.sessions).toEqual([{id: ids[0], title: 'T0'}]);
     });
 
     it('reads from metadata.json when present', async () => {
       const store = MainAgentStore.create(sessionsDir);
-      await writeSnapshot(sessionsDir, 'sess-1', {
-        id: 'sess-1',
+      const id = crypto.randomUUID();
+      await writeSnapshot(sessionsDir, id, {
+        id,
         title: 'Snapshot Title',
         sseEventCount: 0,
         llmSession: {id: 'llm-1', messages: [{large: 'data'}]},
         options: {workingDirectory: '/tmp'},
       });
-      await writeMetadata(sessionsDir, 'sess-1', {
-        id: 'sess-1',
+      await writeMetadata(sessionsDir, id, {
+        id,
         title: 'Metadata Title',
         workingDirectory: '/tmp',
       });
 
       const result = await store.listSessionMetadata(0, 100);
       expect(result.sessions).toEqual([
-        {id: 'sess-1', title: 'Metadata Title', workingDirectory: '/tmp'},
+        {id, title: 'Metadata Title', workingDirectory: '/tmp'},
       ]);
     });
 
     it('falls back to snapshot.json when metadata.json is missing', async () => {
       const store = MainAgentStore.create(sessionsDir);
-      await writeSnapshot(sessionsDir, 'legacy', {
-        id: 'legacy',
+      const id = crypto.randomUUID();
+      await writeSnapshot(sessionsDir, id, {
+        id,
         title: 'Legacy Title',
         sseEventCount: 0,
         llmSession: {id: 'llm-1', messages: []},
@@ -392,7 +403,7 @@ describe('MainAgentStore', () => {
       });
 
       const result = await store.listSessionMetadata(0, 100);
-      expect(result.sessions).toEqual([{id: 'legacy', title: 'Legacy Title'}]);
+      expect(result.sessions).toEqual([{id, title: 'Legacy Title'}]);
     });
   });
 

--- a/packages/api-schema/src/chat/schema.ts
+++ b/packages/api-schema/src/chat/schema.ts
@@ -30,7 +30,7 @@ export type CreateCodingSessionRequest = z.infer<
 
 /** Schema for the POST /chat/session response body. */
 export const createSessionResponseSchema = z.object({
-  sessionId: z.string(),
+  sessionId: z.uuid(),
 });
 
 export type CreateSessionResponse = z.infer<typeof createSessionResponseSchema>;
@@ -62,7 +62,7 @@ export type SubmitToolResponseRequest = z.infer<
 
 /** Schema for a single session entry in the list response. */
 export const sessionMetadataSchema = z.object({
-  id: z.string(),
+  id: z.uuid(),
   title: z.string(),
   workingDirectory: z.string().optional(),
 });


### PR DESCRIPTION
## Summary
- Replace shared `os.tmpdir()` default with a per-agent `os.tmpdir()/<agent-id>` directory so concurrent agents can't read or overwrite each other's files
- Apply to both fresh agents and snapshots that lack a stored `workingDirectory`
- Create with mode `0o700` and resolve via `realpath` to match the bash tool's macOS cwd comparisons (`/var` → `/private/var`)
- No cleanup on agent deletion for now; OS reaps stale tmp dirs

## Test plan
- [x] `bun run test src/agent-core/agent/` — 107 tests pass
- [x] `bunx tsc --noEmit` — clean