### PR TITLE
[codex] Keep thinking blocks expanded

### DIFF
--- a/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/ThinkingBlock/ThinkingBlock.test.tsx
+++ b/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/ThinkingBlock/ThinkingBlock.test.tsx
@@ -1,0 +1,74 @@
+import {cleanup, fireEvent, render, screen} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {ThinkingBlock} from './ThinkingBlock.js';
+
+class ResizeObserverMock implements ResizeObserver {
+  disconnect(): void {
+    return undefined;
+  }
+  observe(): void {
+    return undefined;
+  }
+  unobserve(): void {
+    return undefined;
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    return window.setTimeout(() => {
+      callback(0);
+    }, 0);
+  });
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+    window.clearTimeout(id);
+  });
+  vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('ThinkingBlock', () => {
+  it('stays expanded when thinking finishes', () => {
+    const {rerender} = render(
+      <ThinkingBlock content='Inspect the replay path.' done={false} />,
+    );
+
+    expect(screen.getByRole('button', {name: /Thinking/})).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+
+    rerender(<ThinkingBlock content='Inspect the replay path.' done />);
+
+    expect(screen.getByRole('button', {name: /Thought/})).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    expect(screen.getByText('Inspect the replay path.')).toBeInTheDocument();
+  });
+
+  it('does not reopen user-collapsed thinking when thinking finishes', () => {
+    const {rerender} = render(
+      <ThinkingBlock content='Inspect the replay path.' done={false} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', {name: /Thinking/}));
+
+    expect(screen.getByRole('button', {name: /Thinking/})).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+
+    rerender(<ThinkingBlock content='Inspect the replay path.' done />);
+
+    expect(screen.getByRole('button', {name: /Thought/})).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+});

--- a/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/ThinkingBlock/ThinkingBlock.tsx
+++ b/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/ThinkingBlock/ThinkingBlock.tsx
@@ -11,7 +11,7 @@ interface ThinkingBlockProps {
 }
 
 export function ThinkingBlock({content, done}: ThinkingBlockProps) {
-  const {isExpanded, onExpandedChange} = useThinkingBlock({done});
+  const {isExpanded, onExpandedChange} = useThinkingBlock();
   const {displayedContent} = useStreamingText(content);
   const deferredContent = useDeferredValue(displayedContent);
 

--- a/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/ThinkingBlock/hooks/useThinkingBlock.test.ts
+++ b/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/ThinkingBlock/hooks/useThinkingBlock.test.ts
@@ -1,0 +1,40 @@
+import {act, renderHook} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+
+import {useThinkingBlock} from './useThinkingBlock.js';
+
+describe('useThinkingBlock', () => {
+  it('starts expanded while thinking is streaming', () => {
+    const {result} = renderHook(() => useThinkingBlock());
+
+    expect(result.current.isExpanded).toBe(true);
+  });
+
+  it('keeps the current expansion state after rerendering', () => {
+    const {result, rerender} = renderHook(() => useThinkingBlock());
+
+    expect(result.current.isExpanded).toBe(true);
+
+    rerender();
+
+    expect(result.current.isExpanded).toBe(true);
+  });
+
+  it('keeps user-collapsed thinking collapsed after rerendering', () => {
+    const {result, rerender} = renderHook(() => useThinkingBlock());
+
+    act(() => {
+      result.current.onExpandedChange(false);
+    });
+
+    rerender();
+
+    expect(result.current.isExpanded).toBe(false);
+  });
+
+  it('starts expanded for already completed thinking', () => {
+    const {result} = renderHook(() => useThinkingBlock());
+
+    expect(result.current.isExpanded).toBe(true);
+  });
+});

--- a/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/ThinkingBlock/hooks/useThinkingBlock.test.ts
+++ b/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/ThinkingBlock/hooks/useThinkingBlock.test.ts
@@ -31,10 +31,4 @@ describe('useThinkingBlock', () => {
 
     expect(result.current.isExpanded).toBe(false);
   });
-
-  it('starts expanded for already completed thinking', () => {
-    const {result} = renderHook(() => useThinkingBlock());
-
-    expect(result.current.isExpanded).toBe(true);
-  });
 });

--- a/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/ThinkingBlock/hooks/useThinkingBlock.ts
+++ b/apps/frontend/src/modules/chat-session/components/StreamingMessageDisplay/components/MessageList/components/ThinkingBlock/hooks/useThinkingBlock.ts
@@ -1,15 +1,7 @@
-import {useEffect, useState} from 'react';
+import {useState} from 'react';
 
-interface UseThinkingBlockOptions {
-  done: boolean;
-}
-
-export function useThinkingBlock({done}: UseThinkingBlockOptions) {
-  const [isExpanded, setIsExpanded] = useState(!done);
-
-  useEffect(() => {
-    if (done) setIsExpanded(false);
-  }, [done]);
+export function useThinkingBlock() {
+  const [isExpanded, setIsExpanded] = useState(true);
 
   return {isExpanded, onExpandedChange: setIsExpanded};
 }


### PR DESCRIPTION
## Summary

- keep thinking content expanded by default regardless of completion state
- preserve manual collapse state across rerenders
- add regression coverage for the thinking block expansion hook

## Root Cause

`useThinkingBlock` initialized expansion from `done` and previously forced the disclosure closed when thinking completed, so completed thinking content could collapse without user action.

## Validation

- `bun run --filter '@omnicraft/frontend' lint`\n- `bun run --filter '@omnicraft/frontend' test`\n- `bun run --filter '@omnicraft/frontend' build`