### PR TITLE
[codex] Prevent session item action overlap

### DIFF
--- a/apps/frontend/src/modules/chat-session/components/SessionSidebar/components/SessionItem/SessionItemView.tsx
+++ b/apps/frontend/src/modules/chat-session/components/SessionSidebar/components/SessionItem/SessionItemView.tsx
@@ -29,7 +29,7 @@ export function SessionItemView({
         <span className={styles.title}>{title}</span>
         {workingDirectory !== undefined && (
           <Tooltip delay={0}>
-            <Tooltip.Trigger>
+            <Tooltip.Trigger className={styles.workingDirectoryTrigger}>
               <span className={styles.workingDirectory}>
                 {workingDirectory.split('/').pop()}
               </span>

--- a/apps/frontend/src/modules/chat-session/components/SessionSidebar/components/SessionItem/styles.module.css
+++ b/apps/frontend/src/modules/chat-session/components/SessionSidebar/components/SessionItem/styles.module.css
@@ -3,6 +3,7 @@
   align-items: center;
   gap: 8px;
   width: 100%;
+  min-width: 0;
 }
 
 .icon {
@@ -21,15 +22,26 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .title {
+  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.content .workingDirectoryTrigger {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+}
+
 .workingDirectory {
+  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -38,8 +50,7 @@
 }
 
 .actions {
-  flex-shrink: 0;
-  width: 28px;
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- Constrain the session item text column so long workspace labels ellipsize.
- Let the action area size to its button contents instead of using a brittle fixed width.

## Root Cause
HeroUI Tooltip.Trigger renders as inline-block by default, so long workspace text could exceed the flex content column. The action area also had a smaller fixed width than its icon button needed.

## Validation
- bun run --cwd apps/frontend lint
- bun run --cwd apps/frontend test
- bun run build:frontend