### PR TITLE
[codex] Track persisted subagents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@ Before starting any task, you must first confirm:
 
 - When adding a new npm package, always install it via the package manager (e.g., `bun add <package>`). Never manually write a version number in package.json.
 
+## Verification
+
+- After a pre-commit hook runs, do not repeat compilation or test verification solely because the hook formatted files or ran lint. Formatting and lint do not affect compilation or test results.
+
 ## Runtime APIs
 
 - Bun is used only as the package manager and runtime. In code, always use Node.js APIs (e.g., `node:fs/promises`, `node:path`). Do not use Bun-specific APIs (e.g., `Bun.file()`, `Bun.write()`).

--- a/apps/backend/src/agent-core/agent/agent-runtime-state.test.ts
+++ b/apps/backend/src/agent-core/agent/agent-runtime-state.test.ts
@@ -21,14 +21,14 @@ describe('AgentRuntimeState', () => {
   it('keeps shell and todo state isolated per agent instance', () => {
     const first = new AgentRuntimeState('/workspace/one');
     const second = new AgentRuntimeState('/workspace/two');
-    const firstSubagents = new SubagentRegistry();
-    const secondSubagents = new SubagentRegistry();
+    const firstSubagentRegistry = new SubagentRegistry();
+    const secondSubagentRegistry = new SubagentRegistry();
 
     const firstContext = first.buildToolExecutionContext({
       callId: 'call-1',
       agentId: 'agent-1',
       sessionsDir: null,
-      subagents: firstSubagents,
+      subagentRegistry: firstSubagentRegistry,
       availableSkills: new Map(),
       workingDirectory: '/workspace/one',
       signal: new AbortController().signal,
@@ -40,7 +40,7 @@ describe('AgentRuntimeState', () => {
       callId: 'call-2',
       agentId: 'agent-2',
       sessionsDir: null,
-      subagents: secondSubagents,
+      subagentRegistry: secondSubagentRegistry,
       availableSkills: new Map(),
       workingDirectory: '/workspace/two',
       signal: new AbortController().signal,
@@ -73,13 +73,13 @@ describe('AgentRuntimeState', () => {
     const state = new AgentRuntimeState('/workspace/project');
     const signal = new AbortController().signal;
     const subAgentEvents: SseSubAgentEvent[] = [];
-    const subagents = new SubagentRegistry();
+    const subagentRegistry = new SubagentRegistry();
 
     const context = state.buildToolExecutionContext({
       callId: 'call-123',
       agentId: 'agent-123',
       sessionsDir: '/sessions',
-      subagents,
+      subagentRegistry,
       availableSkills: new Map(),
       workingDirectory: '/workspace/project',
       signal,
@@ -99,7 +99,7 @@ describe('AgentRuntimeState', () => {
     expect(context.callId).toBe('call-123');
     expect(context.agentId).toBe('agent-123');
     expect(context.sessionsDir).toBe('/sessions');
-    expect(context.subagents).toBe(subagents);
+    expect(context.subagentRegistry).toBe(subagentRegistry);
     expect(context.workingDirectory).toBe('/workspace/project');
     expect(context.signal).toBe(signal);
     expect(subAgentEvents).toEqual([
@@ -113,7 +113,7 @@ describe('AgentRuntimeState', () => {
       callId: 'call-1',
       agentId: 'agent-1',
       sessionsDir: null,
-      subagents: new SubagentRegistry(),
+      subagentRegistry: new SubagentRegistry(),
       availableSkills: new Map(),
       workingDirectory: '/workspace/project',
       signal: new AbortController().signal,

--- a/apps/backend/src/agent-core/agent/agent-runtime-state.test.ts
+++ b/apps/backend/src/agent-core/agent/agent-runtime-state.test.ts
@@ -3,6 +3,7 @@ import {describe, expect, it} from 'vitest';
 
 import type {LlmConfig} from '../llm-api/index.js';
 import {AgentRuntimeState} from './agent-runtime-state.js';
+import {SubagentRegistry} from './state/subagent-registry.js';
 
 const MAIN_CONFIG: LlmConfig = {
   apiFormat: 'openai-responses',
@@ -20,11 +21,14 @@ describe('AgentRuntimeState', () => {
   it('keeps shell and todo state isolated per agent instance', () => {
     const first = new AgentRuntimeState('/workspace/one');
     const second = new AgentRuntimeState('/workspace/two');
+    const firstSubagents = new SubagentRegistry();
+    const secondSubagents = new SubagentRegistry();
 
     const firstContext = first.buildToolExecutionContext({
       callId: 'call-1',
       agentId: 'agent-1',
       sessionsDir: null,
+      subagents: firstSubagents,
       availableSkills: new Map(),
       workingDirectory: '/workspace/one',
       signal: new AbortController().signal,
@@ -36,6 +40,7 @@ describe('AgentRuntimeState', () => {
       callId: 'call-2',
       agentId: 'agent-2',
       sessionsDir: null,
+      subagents: secondSubagents,
       availableSkills: new Map(),
       workingDirectory: '/workspace/two',
       signal: new AbortController().signal,
@@ -68,11 +73,13 @@ describe('AgentRuntimeState', () => {
     const state = new AgentRuntimeState('/workspace/project');
     const signal = new AbortController().signal;
     const subAgentEvents: SseSubAgentEvent[] = [];
+    const subagents = new SubagentRegistry();
 
     const context = state.buildToolExecutionContext({
       callId: 'call-123',
       agentId: 'agent-123',
       sessionsDir: '/sessions',
+      subagents,
       availableSkills: new Map(),
       workingDirectory: '/workspace/project',
       signal,
@@ -92,6 +99,7 @@ describe('AgentRuntimeState', () => {
     expect(context.callId).toBe('call-123');
     expect(context.agentId).toBe('agent-123');
     expect(context.sessionsDir).toBe('/sessions');
+    expect(context.subagents).toBe(subagents);
     expect(context.workingDirectory).toBe('/workspace/project');
     expect(context.signal).toBe(signal);
     expect(subAgentEvents).toEqual([
@@ -105,6 +113,7 @@ describe('AgentRuntimeState', () => {
       callId: 'call-1',
       agentId: 'agent-1',
       sessionsDir: null,
+      subagents: new SubagentRegistry(),
       availableSkills: new Map(),
       workingDirectory: '/workspace/project',
       signal: new AbortController().signal,

--- a/apps/backend/src/agent-core/agent/agent-runtime-state.ts
+++ b/apps/backend/src/agent-core/agent/agent-runtime-state.ts
@@ -10,12 +10,14 @@ import type {
 import {UserInteractionBridge} from '../user-interaction/index.js';
 import {FileContentCache} from './state/file-content-cache.js';
 import {FileStatTracker} from './state/file-stat-tracker.js';
+import type {SubagentRegistry} from './state/subagent-registry.js';
 import {type TodoItem, TodoStore} from './state/todo-store.js';
 
 export interface BuildToolExecutionContextInput {
   readonly callId: string;
   readonly agentId: string;
   readonly sessionsDir: string | null;
+  readonly subagents: SubagentRegistry;
   readonly availableSkills: ReadonlyMap<string, SkillDefinition>;
   readonly workingDirectory: string;
   readonly signal: AbortSignal;
@@ -55,6 +57,7 @@ export class AgentRuntimeState {
       callId: input.callId,
       agentId: input.agentId,
       sessionsDir: input.sessionsDir,
+      subagents: input.subagents,
       availableSkills: input.availableSkills,
       workingDirectory: input.workingDirectory,
       fileCache: this.fileCache,

--- a/apps/backend/src/agent-core/agent/agent-runtime-state.ts
+++ b/apps/backend/src/agent-core/agent/agent-runtime-state.ts
@@ -17,7 +17,7 @@ export interface BuildToolExecutionContextInput {
   readonly callId: string;
   readonly agentId: string;
   readonly sessionsDir: string | null;
-  readonly subagents: SubagentRegistry;
+  readonly subagentRegistry: SubagentRegistry;
   readonly availableSkills: ReadonlyMap<string, SkillDefinition>;
   readonly workingDirectory: string;
   readonly signal: AbortSignal;
@@ -57,7 +57,7 @@ export class AgentRuntimeState {
       callId: input.callId,
       agentId: input.agentId,
       sessionsDir: input.sessionsDir,
-      subagents: input.subagents,
+      subagentRegistry: input.subagentRegistry,
       availableSkills: input.availableSkills,
       workingDirectory: input.workingDirectory,
       fileCache: this.fileCache,

--- a/apps/backend/src/agent-core/agent/agent-tool-executor.test.ts
+++ b/apps/backend/src/agent-core/agent/agent-tool-executor.test.ts
@@ -61,7 +61,7 @@ function executeInput(overrides: {
     runtimeState: new AgentRuntimeState('/workspace/project'),
     agentId: 'agent-1',
     sessionsDir: '/sessions',
-    subagents: new SubagentRegistry(),
+    subagentRegistry: new SubagentRegistry(),
     availableSkills: new Map<string, SkillDefinition>(),
     workingDirectory: '/workspace/project',
     signal: new AbortController().signal,
@@ -113,7 +113,7 @@ describe('AgentToolExecutor', () => {
       throw new Error('Tool did not receive execution context');
     }
     const context = receivedContext.current;
-    expect(context.subagents).toBe(input.subagents);
+    expect(context.subagentRegistry).toBe(input.subagentRegistry);
     expect(context).toMatchObject({
       callId: 'call-1',
       agentId: 'agent-1',

--- a/apps/backend/src/agent-core/agent/agent-tool-executor.test.ts
+++ b/apps/backend/src/agent-core/agent/agent-tool-executor.test.ts
@@ -12,6 +12,7 @@ import {
   agentToolExecutor,
   type AgentToolSseEvent,
 } from './agent-tool-executor.js';
+import {SubagentRegistry} from './state/subagent-registry.js';
 
 const MAIN_CONFIG: LlmConfig = {
   apiFormat: 'openai-responses',
@@ -60,6 +61,7 @@ function executeInput(overrides: {
     runtimeState: new AgentRuntimeState('/workspace/project'),
     agentId: 'agent-1',
     sessionsDir: '/sessions',
+    subagents: new SubagentRegistry(),
     availableSkills: new Map<string, SkillDefinition>(),
     workingDirectory: '/workspace/project',
     signal: new AbortController().signal,
@@ -71,7 +73,7 @@ function executeInput(overrides: {
 
 describe('AgentToolExecutor', () => {
   it('executes a visible tool and forwards output and subagent events', async () => {
-    let receivedContext: ToolExecutionContext | null = null;
+    const receivedContext: {current?: ToolExecutionContext} = {};
     const subAgentEvent: SseSubAgentEvent = {
       type: 'subagent-complete',
       agentId: 'child-agent',
@@ -85,7 +87,7 @@ describe('AgentToolExecutor', () => {
       parameters,
       suppressToolEvents: false,
       execute: (args, context, onOutput) => {
-        receivedContext = context;
+        receivedContext.current = context;
         onOutput?.(`value:${args.value}`);
         context.onSubAgentEvent(subAgentEvent);
         return {
@@ -107,7 +109,12 @@ describe('AgentToolExecutor', () => {
       content: 'result:ok',
       data: {message: 'ok'},
     });
-    expect(receivedContext).toMatchObject({
+    if (!receivedContext.current) {
+      throw new Error('Tool did not receive execution context');
+    }
+    const context = receivedContext.current;
+    expect(context.subagents).toBe(input.subagents);
+    expect(context).toMatchObject({
       callId: 'call-1',
       agentId: 'agent-1',
       sessionsDir: '/sessions',

--- a/apps/backend/src/agent-core/agent/agent-tool-executor.ts
+++ b/apps/backend/src/agent-core/agent/agent-tool-executor.ts
@@ -14,6 +14,7 @@ import type {LlmConfig, LlmToolCall} from '../llm-api/index.js';
 import type {SkillDefinition} from '../skill/index.js';
 import type {ToolDefinition} from '../tool/index.js';
 import type {AgentRuntimeState} from './agent-runtime-state.js';
+import type {SubagentRegistry} from './state/subagent-registry.js';
 
 export type AgentToolSseEvent =
   | SseToolExecuteEndEvent
@@ -28,6 +29,7 @@ export interface ExecuteAgentToolInput {
   readonly runtimeState: AgentRuntimeState;
   readonly agentId: string;
   readonly sessionsDir: string | null;
+  readonly subagents: SubagentRegistry;
   readonly availableSkills: ReadonlyMap<string, SkillDefinition>;
   readonly workingDirectory: string;
   readonly signal: AbortSignal;
@@ -63,6 +65,7 @@ export class AgentToolExecutor {
       callId: input.toolCall.callId,
       agentId: input.agentId,
       sessionsDir: input.sessionsDir,
+      subagents: input.subagents,
       availableSkills: input.availableSkills,
       workingDirectory: input.workingDirectory,
       signal: input.signal,

--- a/apps/backend/src/agent-core/agent/agent-tool-executor.ts
+++ b/apps/backend/src/agent-core/agent/agent-tool-executor.ts
@@ -29,7 +29,7 @@ export interface ExecuteAgentToolInput {
   readonly runtimeState: AgentRuntimeState;
   readonly agentId: string;
   readonly sessionsDir: string | null;
-  readonly subagents: SubagentRegistry;
+  readonly subagentRegistry: SubagentRegistry;
   readonly availableSkills: ReadonlyMap<string, SkillDefinition>;
   readonly workingDirectory: string;
   readonly signal: AbortSignal;
@@ -65,7 +65,7 @@ export class AgentToolExecutor {
       callId: input.toolCall.callId,
       agentId: input.agentId,
       sessionsDir: input.sessionsDir,
-      subagents: input.subagents,
+      subagentRegistry: input.subagentRegistry,
       availableSkills: input.availableSkills,
       workingDirectory: input.workingDirectory,
       signal: input.signal,

--- a/apps/backend/src/agent-core/agent/agent-turn-runner.test.ts
+++ b/apps/backend/src/agent-core/agent/agent-turn-runner.test.ts
@@ -8,6 +8,7 @@ import type {ToolDefinition} from '../tool/index.js';
 import {ToolRegistry} from '../tool/tool-registry.js';
 import {AgentRuntimeState} from './agent-runtime-state.js';
 import {agentTurnRunner, type RunAgentTurnInput} from './agent-turn-runner.js';
+import {SubagentRegistry} from './state/subagent-registry.js';
 
 const MAIN_CONFIG: LlmConfig = {
   apiFormat: 'openai-responses',
@@ -127,10 +128,12 @@ function createInput(
   const llmSession =
     overrides.llmSession ?? new LlmSession(() => Promise.resolve(MAIN_CONFIG));
   const workingDirectory = overrides.workingDirectory ?? '/workspace/project';
-  return {
+  const subagents = overrides.subagents ?? new SubagentRegistry();
+  const defaults: RunAgentTurnInput = {
     userMessage: 'user request',
     agentId: 'agent-1',
     sessionsDir: null,
+    subagents,
     workingDirectory,
     thinkingLevel: 'high',
     signal: new AbortController().signal,
@@ -143,7 +146,14 @@ function createInput(
     getLightConfig: () => Promise.resolve(MAIN_CONFIG),
     getMaxToolRounds: () => 5,
     compactAfterTurn: () => Promise.resolve(),
+  };
+
+  return {
+    ...defaults,
     ...overrides,
+    llmSession,
+    workingDirectory,
+    subagents,
   };
 }
 

--- a/apps/backend/src/agent-core/agent/agent-turn-runner.test.ts
+++ b/apps/backend/src/agent-core/agent/agent-turn-runner.test.ts
@@ -128,12 +128,12 @@ function createInput(
   const llmSession =
     overrides.llmSession ?? new LlmSession(() => Promise.resolve(MAIN_CONFIG));
   const workingDirectory = overrides.workingDirectory ?? '/workspace/project';
-  const subagents = overrides.subagents ?? new SubagentRegistry();
+  const subagentRegistry = overrides.subagentRegistry ?? new SubagentRegistry();
   const defaults: RunAgentTurnInput = {
     userMessage: 'user request',
     agentId: 'agent-1',
     sessionsDir: null,
-    subagents,
+    subagentRegistry,
     workingDirectory,
     thinkingLevel: 'high',
     signal: new AbortController().signal,
@@ -153,7 +153,7 @@ function createInput(
     ...overrides,
     llmSession,
     workingDirectory,
-    subagents,
+    subagentRegistry,
   };
 }
 

--- a/apps/backend/src/agent-core/agent/agent-turn-runner.ts
+++ b/apps/backend/src/agent-core/agent/agent-turn-runner.ts
@@ -26,12 +26,14 @@ import {
   buildAvailableTools,
   buildSystemPrompt,
 } from './catalog/agent-catalog.js';
+import type {SubagentRegistry} from './state/subagent-registry.js';
 import type {AgentEventStream} from './types.js';
 
 export interface RunAgentTurnInput {
   readonly userMessage: string;
   readonly agentId: string;
   readonly sessionsDir: string | null;
+  readonly subagents: SubagentRegistry;
   readonly workingDirectory: string;
   readonly thinkingLevel: ThinkingLevel;
   readonly signal: AbortSignal;
@@ -165,6 +167,7 @@ export class AgentTurnRunner {
             runtimeState: input.runtimeState,
             agentId: input.agentId,
             sessionsDir: input.sessionsDir,
+            subagents: input.subagents,
             availableSkills,
             workingDirectory: input.workingDirectory,
             signal: input.signal,

--- a/apps/backend/src/agent-core/agent/agent-turn-runner.ts
+++ b/apps/backend/src/agent-core/agent/agent-turn-runner.ts
@@ -33,7 +33,7 @@ export interface RunAgentTurnInput {
   readonly userMessage: string;
   readonly agentId: string;
   readonly sessionsDir: string | null;
-  readonly subagents: SubagentRegistry;
+  readonly subagentRegistry: SubagentRegistry;
   readonly workingDirectory: string;
   readonly thinkingLevel: ThinkingLevel;
   readonly signal: AbortSignal;
@@ -167,7 +167,7 @@ export class AgentTurnRunner {
             runtimeState: input.runtimeState,
             agentId: input.agentId,
             sessionsDir: input.sessionsDir,
-            subagents: input.subagents,
+            subagentRegistry: input.subagentRegistry,
             availableSkills,
             workingDirectory: input.workingDirectory,
             signal: input.signal,

--- a/apps/backend/src/agent-core/agent/agent.test.ts
+++ b/apps/backend/src/agent-core/agent/agent.test.ts
@@ -520,6 +520,7 @@ describe('Agent compaction lifecycle', () => {
           usage: emptyUsage(),
         },
         options: {thinkingLevel: 'high'},
+        subagents: [],
       },
     );
 
@@ -730,6 +731,7 @@ describe('Agent abort flow', () => {
           usage: emptyUsage(),
         },
         options: {thinkingLevel: 'high'},
+        subagents: [],
       },
     );
 
@@ -813,6 +815,49 @@ describe('Agent abort flow', () => {
 });
 
 describe('Agent snapshot restore', () => {
+  it('includes subagent records in snapshots', () => {
+    const agent = new TestAgent(() => Promise.resolve(MAIN_CONFIG), {
+      ...testAgentOptions(),
+    });
+    const childId = crypto.randomUUID();
+
+    agent.subagents.register({id: childId, agentType: 'general'});
+
+    expect(agent.toSnapshot().subagents).toEqual([
+      {id: childId, agentType: 'general'},
+    ]);
+  });
+
+  it('restores subagent records from snapshots', () => {
+    const childId = crypto.randomUUID();
+    const snapshot: AgentSnapshot = {
+      id: crypto.randomUUID(),
+      title: 'Restored Session',
+      sseEventCount: 0,
+      llmSession: {
+        id: 'llm-session-id',
+        messages: [],
+        compactions: [],
+        latestUsageInputMessageCount: null,
+        usage: emptyUsage(),
+      },
+      options: {
+        thinkingLevel: 'high',
+      },
+      subagents: [{id: childId, agentType: 'explore'}],
+    };
+
+    const agent = new TestAgent(
+      () => Promise.resolve(MAIN_CONFIG),
+      testAgentOptions(),
+      snapshot,
+    );
+
+    expect(agent.subagents.list()).toEqual([
+      {id: childId, agentType: 'explore'},
+    ]);
+  });
+
   it('throws when a snapshot reaches the constructor without thinkingLevel', () => {
     const snapshot = {
       id: 'agent-with-missing-thinking-level',
@@ -887,6 +932,7 @@ describe('Agent default working directory', () => {
       options: {
         thinkingLevel: 'high',
       },
+      subagents: [],
     };
 
     const agent = new TestAgent(

--- a/apps/backend/src/agent-core/agent/agent.test.ts
+++ b/apps/backend/src/agent-core/agent/agent.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 import type {SseEvent} from '@omnicraft/sse-events';
 import {afterEach, describe, expect, it, vi} from 'vitest';
+import {z} from 'zod';
 
 import {llmApi, type LlmConfig, type LlmEventStream} from '../llm-api/index.js';
 import {LlmSession} from '../llm-session/index.js';
@@ -124,6 +125,24 @@ async function* toolCallCompletionStream(
   yield {type: 'tool-call-delta', callId: 'call-1', argumentsDelta: '{}'};
   yield {type: 'tool-call-end', callId: 'call-1'};
   yield {type: 'message-end', stopReason: 'tool_use', usage};
+}
+
+function createSubagentRegisteringTool(childId: string): ToolDefinition {
+  return {
+    name: 'register_subagent',
+    displayName: 'Register Subagent',
+    description: 'Registers a subagent record for Agent snapshot tests',
+    parameters: z.object({}),
+    suppressToolEvents: false,
+    execute: (_args, context) => {
+      context.subagentRegistry.register({id: childId, agentType: 'general'});
+      return {
+        status: 'success',
+        content: 'registered',
+        data: {message: 'registered'},
+      };
+    },
+  };
 }
 
 async function* titleCompletionStream(): LlmEventStream {
@@ -815,13 +834,37 @@ describe('Agent abort flow', () => {
 });
 
 describe('Agent snapshot restore', () => {
-  it('includes subagent records in snapshots', () => {
-    const agent = new TestAgent(() => Promise.resolve(MAIN_CONFIG), {
-      ...testAgentOptions(),
-    });
-    const childId = crypto.randomUUID();
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
-    agent.subagentRegistry.register({id: childId, agentType: 'general'});
+  it('includes subagent records in snapshots', async () => {
+    vi.spyOn(llmApi, 'countToken').mockResolvedValue(1);
+    vi.spyOn(llmApi, 'streamCompletion')
+      .mockReturnValueOnce(
+        toolCallCompletionStream('register_subagent', {
+          inputTokens: 10,
+          outputTokens: 1,
+          cacheReadInputTokens: 0,
+        }),
+      )
+      .mockReturnValueOnce(
+        usageCompletionStream({
+          inputTokens: 10,
+          outputTokens: 1,
+          cacheReadInputTokens: 0,
+        }),
+      );
+    const childId = crypto.randomUUID();
+    const registry = TestToolRegistry.createForTest();
+    registry.register(createSubagentRegisteringTool(childId));
+    const agent = new UsageTestAgent(() => Promise.resolve(MAIN_CONFIG), {
+      ...testAgentOptions(),
+      toolRegistries: [registry],
+      getMaxToolRounds: () => 5,
+    });
+
+    await collectAll(agent.streamForTest('register a child'));
 
     expect(agent.toSnapshot().subagents).toEqual([
       {id: childId, agentType: 'general'},
@@ -853,7 +896,7 @@ describe('Agent snapshot restore', () => {
       snapshot,
     );
 
-    expect(agent.subagentRegistry.list()).toEqual([
+    expect(agent.toSnapshot().subagents).toEqual([
       {id: childId, agentType: 'explore'},
     ]);
   });

--- a/apps/backend/src/agent-core/agent/agent.test.ts
+++ b/apps/backend/src/agent-core/agent/agent.test.ts
@@ -821,7 +821,7 @@ describe('Agent snapshot restore', () => {
     });
     const childId = crypto.randomUUID();
 
-    agent.subagents.register({id: childId, agentType: 'general'});
+    agent.subagentRegistry.register({id: childId, agentType: 'general'});
 
     expect(agent.toSnapshot().subagents).toEqual([
       {id: childId, agentType: 'general'},
@@ -853,7 +853,7 @@ describe('Agent snapshot restore', () => {
       snapshot,
     );
 
-    expect(agent.subagents.list()).toEqual([
+    expect(agent.subagentRegistry.list()).toEqual([
       {id: childId, agentType: 'explore'},
     ]);
   });

--- a/apps/backend/src/agent-core/agent/agent.ts
+++ b/apps/backend/src/agent-core/agent/agent.ts
@@ -21,6 +21,7 @@ import {agentWorkingDirectoryService} from './agent-working-directory-service.js
 import type {AgentSseLogReaderOptions} from './events/agent-sse-log.js';
 import {AgentSseLog} from './events/agent-sse-log.js';
 import {agentPersistence} from './persistence/agent-persistence.js';
+import {SubagentRegistry} from './state/subagent-registry.js';
 import {generateTitle} from './title/agent-title.js';
 import {
   type AgentEventStream,
@@ -55,6 +56,8 @@ export abstract class Agent {
   private readonly getConfig: () => Promise<LlmConfig>;
   private readonly getLightConfig: (() => Promise<LlmConfig>) | null;
   private readonly thinkingLevel: ThinkingLevel;
+
+  readonly subagents: SubagentRegistry;
 
   private readonly workingDirectory: string;
 
@@ -103,6 +106,7 @@ export abstract class Agent {
         snapshot.options.workingDirectory ??
         agentWorkingDirectoryService.createDefaultWorkingDirectory(this.id);
       this.llmSession = new LlmSession(getConfig, snapshot.llmSession);
+      this.subagents = new SubagentRegistry(snapshot.subagents);
     } else {
       this.thinkingLevel = options.thinkingLevel;
       this.id = crypto.randomUUID();
@@ -110,6 +114,7 @@ export abstract class Agent {
         options.workingDirectory ??
         agentWorkingDirectoryService.createDefaultWorkingDirectory(this.id);
       this.llmSession = new LlmSession(getConfig);
+      this.subagents = new SubagentRegistry();
     }
 
     this.sseLog = this.sessionsDir
@@ -151,6 +156,7 @@ export abstract class Agent {
         workingDirectory: this.workingDirectory,
         thinkingLevel: this.thinkingLevel,
       },
+      subagents: this.subagents.list(),
     };
   }
 
@@ -283,6 +289,7 @@ export abstract class Agent {
       userMessage,
       agentId: this.id,
       sessionsDir: this.sessionsDir,
+      subagents: this.subagents,
       workingDirectory: this.workingDirectory,
       thinkingLevel,
       signal,

--- a/apps/backend/src/agent-core/agent/agent.ts
+++ b/apps/backend/src/agent-core/agent/agent.ts
@@ -57,7 +57,7 @@ export abstract class Agent {
   private readonly getLightConfig: (() => Promise<LlmConfig>) | null;
   private readonly thinkingLevel: ThinkingLevel;
 
-  readonly subagentRegistry: SubagentRegistry;
+  private readonly subagentRegistry: SubagentRegistry;
 
   private readonly workingDirectory: string;
 

--- a/apps/backend/src/agent-core/agent/agent.ts
+++ b/apps/backend/src/agent-core/agent/agent.ts
@@ -57,7 +57,7 @@ export abstract class Agent {
   private readonly getLightConfig: (() => Promise<LlmConfig>) | null;
   private readonly thinkingLevel: ThinkingLevel;
 
-  readonly subagents: SubagentRegistry;
+  readonly subagentRegistry: SubagentRegistry;
 
   private readonly workingDirectory: string;
 
@@ -106,7 +106,7 @@ export abstract class Agent {
         snapshot.options.workingDirectory ??
         agentWorkingDirectoryService.createDefaultWorkingDirectory(this.id);
       this.llmSession = new LlmSession(getConfig, snapshot.llmSession);
-      this.subagents = new SubagentRegistry(snapshot.subagents);
+      this.subagentRegistry = new SubagentRegistry(snapshot.subagents);
     } else {
       this.thinkingLevel = options.thinkingLevel;
       this.id = crypto.randomUUID();
@@ -114,7 +114,7 @@ export abstract class Agent {
         options.workingDirectory ??
         agentWorkingDirectoryService.createDefaultWorkingDirectory(this.id);
       this.llmSession = new LlmSession(getConfig);
-      this.subagents = new SubagentRegistry();
+      this.subagentRegistry = new SubagentRegistry();
     }
 
     this.sseLog = this.sessionsDir
@@ -156,7 +156,7 @@ export abstract class Agent {
         workingDirectory: this.workingDirectory,
         thinkingLevel: this.thinkingLevel,
       },
-      subagents: this.subagents.list(),
+      subagents: this.subagentRegistry.list(),
     };
   }
 
@@ -289,7 +289,7 @@ export abstract class Agent {
       userMessage,
       agentId: this.id,
       sessionsDir: this.sessionsDir,
-      subagents: this.subagents,
+      subagentRegistry: this.subagentRegistry,
       workingDirectory: this.workingDirectory,
       thinkingLevel,
       signal,

--- a/apps/backend/src/agent-core/agent/persistence/agent-persistence.test.ts
+++ b/apps/backend/src/agent-core/agent/persistence/agent-persistence.test.ts
@@ -35,6 +35,7 @@ function createTestSnapshot(id: string): AgentSnapshot {
       workingDirectory: '/tmp/test-working-dir',
       thinkingLevel: 'medium',
     },
+    subagents: [],
   };
 }
 
@@ -131,6 +132,7 @@ describe('agentPersistence', () => {
             usage: emptyUsage(),
           },
           options: {workingDirectory: '/tmp/test-working-dir'},
+          subagents: [],
         }),
       );
 

--- a/apps/backend/src/agent-core/agent/persistence/agent-persistence.test.ts
+++ b/apps/backend/src/agent-core/agent/persistence/agent-persistence.test.ts
@@ -92,6 +92,16 @@ describe('agentPersistence', () => {
       expect(loaded).toEqual(snapshot);
     });
 
+    it('defaults missing subagents to an empty list', async () => {
+      const {subagents: _subagents, ...snapshot} = createTestSnapshot(agentId);
+      const filePath = path.join(tmpDir, agentId, 'snapshot.json');
+      await writeFile(filePath, JSON.stringify(snapshot, null, 2) + '\n');
+
+      const loaded = await agentPersistence.loadSnapshot(tmpDir, agentId);
+
+      expect(loaded.subagents).toEqual([]);
+    });
+
     it('throws when snapshot.json does not exist', async () => {
       await expect(
         agentPersistence.loadSnapshot(tmpDir, 'nonexistent-id'),

--- a/apps/backend/src/agent-core/agent/state/subagent-registry.test.ts
+++ b/apps/backend/src/agent-core/agent/state/subagent-registry.test.ts
@@ -46,4 +46,10 @@ describe('SubagentRegistry', () => {
 
     expect(registry.list()).toEqual([{id: agent1, agentType: 'general'}]);
   });
+
+  it('rejects non-UUID ids during lookup', () => {
+    const registry = new SubagentRegistry();
+
+    expect(() => registry.get('not-a-uuid')).toThrow();
+  });
 });

--- a/apps/backend/src/agent-core/agent/state/subagent-registry.test.ts
+++ b/apps/backend/src/agent-core/agent/state/subagent-registry.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, it} from 'vitest';
+
+import {SubagentRegistry} from './subagent-registry.js';
+
+describe('SubagentRegistry', () => {
+  const agent1 = '11111111-1111-4111-8111-111111111111';
+  const agent2 = '22222222-2222-4222-8222-222222222222';
+
+  it('starts empty by default', () => {
+    const registry = new SubagentRegistry();
+
+    expect(registry.list()).toEqual([]);
+  });
+
+  it('registers subagents in insertion order', () => {
+    const registry = new SubagentRegistry();
+
+    registry.register({id: agent1, agentType: 'general'});
+    registry.register({id: agent2, agentType: 'explore'});
+
+    expect(registry.list()).toEqual([
+      {id: agent1, agentType: 'general'},
+      {id: agent2, agentType: 'explore'},
+    ]);
+  });
+
+  it('updates an existing record without changing its position', () => {
+    const registry = new SubagentRegistry([
+      {id: agent1, agentType: 'general'},
+      {id: agent2, agentType: 'explore'},
+    ]);
+
+    registry.register({id: agent1, agentType: 'explore'});
+
+    expect(registry.list()).toEqual([
+      {id: agent1, agentType: 'explore'},
+      {id: agent2, agentType: 'explore'},
+    ]);
+  });
+
+  it('returns immutable snapshots of records', () => {
+    const registry = new SubagentRegistry([{id: agent1, agentType: 'general'}]);
+
+    const listed = registry.list();
+    listed.push({id: agent2, agentType: 'explore'});
+
+    expect(registry.list()).toEqual([{id: agent1, agentType: 'general'}]);
+  });
+});

--- a/apps/backend/src/agent-core/agent/state/subagent-registry.ts
+++ b/apps/backend/src/agent-core/agent/state/subagent-registry.ts
@@ -6,6 +6,8 @@ export const subagentRecordSchema = z.object({
   agentType: subAgentTypeSchema,
 });
 
+const subagentIdSchema = subagentRecordSchema.shape.id;
+
 export type SubagentRecord = z.infer<typeof subagentRecordSchema>;
 
 export class SubagentRegistry {
@@ -23,7 +25,8 @@ export class SubagentRegistry {
   }
 
   get(id: string): SubagentRecord | undefined {
-    const record = this.records.get(id);
+    const parsedId = subagentIdSchema.parse(id);
+    const record = this.records.get(parsedId);
     return record ? {...record} : undefined;
   }
 

--- a/apps/backend/src/agent-core/agent/state/subagent-registry.ts
+++ b/apps/backend/src/agent-core/agent/state/subagent-registry.ts
@@ -1,0 +1,33 @@
+import {subAgentTypeSchema} from '@omnicraft/api-schema';
+import {z} from 'zod';
+
+export const subagentRecordSchema = z.object({
+  id: z.uuid(),
+  agentType: subAgentTypeSchema,
+});
+
+export type SubagentRecord = z.infer<typeof subagentRecordSchema>;
+
+export class SubagentRegistry {
+  private readonly records = new Map<string, SubagentRecord>();
+
+  constructor(records: readonly SubagentRecord[] = []) {
+    for (const record of records) {
+      this.register(record);
+    }
+  }
+
+  register(record: SubagentRecord): void {
+    const parsed = subagentRecordSchema.parse(record);
+    this.records.set(parsed.id, parsed);
+  }
+
+  get(id: string): SubagentRecord | undefined {
+    const record = this.records.get(id);
+    return record ? {...record} : undefined;
+  }
+
+  list(): SubagentRecord[] {
+    return [...this.records.values()].map((record) => ({...record}));
+  }
+}

--- a/apps/backend/src/agent-core/agent/types.ts
+++ b/apps/backend/src/agent-core/agent/types.ts
@@ -33,7 +33,7 @@ export const agentSnapshotSchema = z.object({
   sseEventCount: z.number(),
   llmSession: llmSessionSnapshotSchema,
   options: agentSnapshotOptionsSchema,
-  subagents: z.array(subagentRecordSchema),
+  subagents: z.array(subagentRecordSchema).default([]),
 });
 
 /** Serializable agent configuration persisted in snapshots. */

--- a/apps/backend/src/agent-core/agent/types.ts
+++ b/apps/backend/src/agent-core/agent/types.ts
@@ -6,6 +6,7 @@ import type {LlmConfig} from '../llm-api/index.js';
 import {llmSessionSnapshotSchema} from '../llm-session/index.js';
 import type {SkillRegistry} from '../skill/index.js';
 import type {ToolRegistry} from '../tool/index.js';
+import {subagentRecordSchema} from './state/subagent-registry.js';
 
 // ---------------------------------------------------------------------------
 // Agent Event Types
@@ -32,6 +33,7 @@ export const agentSnapshotSchema = z.object({
   sseEventCount: z.number(),
   llmSession: llmSessionSnapshotSchema,
   options: agentSnapshotOptionsSchema,
+  subagents: z.array(subagentRecordSchema),
 });
 
 /** Serializable agent configuration persisted in snapshots. */

--- a/apps/backend/src/agent-core/tool/testing.ts
+++ b/apps/backend/src/agent-core/tool/testing.ts
@@ -39,7 +39,7 @@ export function createMockContext(
     callId: 'mock-call-id',
     agentId: 'mock-agent-id',
     sessionsDir: null,
-    subagents: new SubagentRegistry(),
+    subagentRegistry: new SubagentRegistry(),
     availableSkills: new Map(),
     workingDirectory,
     fileCache: new FileContentCache(),

--- a/apps/backend/src/agent-core/tool/testing.ts
+++ b/apps/backend/src/agent-core/tool/testing.ts
@@ -8,6 +8,7 @@ import {z} from 'zod';
 
 import {FileContentCache} from '../agent/state/file-content-cache.js';
 import {FileStatTracker} from '../agent/state/file-stat-tracker.js';
+import {SubagentRegistry} from '../agent/state/subagent-registry.js';
 import {TodoStore} from '../agent/state/todo-store.js';
 import {UserInteractionBridge} from '../user-interaction/index.js';
 import type {ToolDefinition, ToolExecutionContext} from './types.js';
@@ -38,6 +39,7 @@ export function createMockContext(
     callId: 'mock-call-id',
     agentId: 'mock-agent-id',
     sessionsDir: null,
+    subagents: new SubagentRegistry(),
     availableSkills: new Map(),
     workingDirectory,
     fileCache: new FileContentCache(),

--- a/apps/backend/src/agent-core/tool/types.ts
+++ b/apps/backend/src/agent-core/tool/types.ts
@@ -4,6 +4,7 @@ import type {z} from 'zod';
 
 import type {FileContentCache} from '../agent/state/file-content-cache.js';
 import type {FileStatTracker} from '../agent/state/file-stat-tracker.js';
+import type {SubagentRegistry} from '../agent/state/subagent-registry.js';
 import type {TodoStore} from '../agent/state/todo-store.js';
 import type {
   LlmConfig,
@@ -35,6 +36,9 @@ export interface ToolExecutionContext {
 
   /** Directory where the parent Agent persists sessions, or null for in-memory agents. */
   readonly sessionsDir: string | null;
+
+  /** Registry of subagents owned by the current Agent session. */
+  readonly subagents: SubagentRegistry;
 
   /** All skills available to the current Agent, merged and deduplicated. */
   readonly availableSkills: ReadonlyMap<string, SkillDefinition>;

--- a/apps/backend/src/agent-core/tool/types.ts
+++ b/apps/backend/src/agent-core/tool/types.ts
@@ -38,7 +38,7 @@ export interface ToolExecutionContext {
   readonly sessionsDir: string | null;
 
   /** Registry of subagents owned by the current Agent session. */
-  readonly subagents: SubagentRegistry;
+  readonly subagentRegistry: SubagentRegistry;
 
   /** All skills available to the current Agent, merged and deduplicated. */
   readonly availableSkills: ReadonlyMap<string, SkillDefinition>;

--- a/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts
+++ b/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+import {SubAgentType} from '@omnicraft/api-schema';
 import {afterEach, beforeEach, describe, expect, it} from 'vitest';
 
 import {ExploreSubAgent, GeneralSubAgent} from '@/agent/agents/index.js';
@@ -12,6 +13,7 @@ import {
   FileToolRegistry,
   WebToolRegistry,
 } from '@/agent/tools/index.js';
+import type {Agent} from '@/agent-core/agent/index.js';
 import {createMockContext} from '@/agent-core/tool/testing.js';
 import type {ToolExecutionContext} from '@/agent-core/tool/types.js';
 
@@ -19,7 +21,7 @@ import {
   createSubAgent,
   dispatchAgentTool,
   getSubagentSessionsDir,
-  SUB_AGENT_TYPE,
+  registerSubAgent,
 } from './dispatch-agent-tool.js';
 
 function resetAgentRegistries(): void {
@@ -68,7 +70,7 @@ describe('dispatchAgentTool', () => {
   it('accepts the explore agent type', () => {
     const result = dispatchAgentTool.parameters.safeParse({
       task: 'Map the backend agent architecture',
-      agentType: SUB_AGENT_TYPE.EXPLORE,
+      agentType: SubAgentType.EXPLORE,
     });
 
     expect(result.success).toBe(true);
@@ -76,10 +78,10 @@ describe('dispatchAgentTool', () => {
 
   it('documents general and explore agent types', () => {
     expect(dispatchAgentTool.description).toContain(
-      `- ${SUB_AGENT_TYPE.GENERAL} (General):`,
+      `- ${SubAgentType.GENERAL} (General):`,
     );
     expect(dispatchAgentTool.description).toContain(
-      `- ${SUB_AGENT_TYPE.EXPLORE} (Explore):`,
+      `- ${SubAgentType.EXPLORE} (Explore):`,
     );
   });
 
@@ -97,7 +99,7 @@ describe('dispatchAgentTool', () => {
 
   it('documents explore-specific research use cases', () => {
     expect(dispatchAgentTool.description).toContain(
-      `- ${SUB_AGENT_TYPE.EXPLORE} (Explore):`,
+      `- ${SubAgentType.EXPLORE} (Explore):`,
     );
     expect(dispatchAgentTool.description).toContain('architecture');
     expect(dispatchAgentTool.description).toContain('data flow');
@@ -112,7 +114,7 @@ describe('dispatchAgentTool', () => {
     initAgentRegistries();
     try {
       const subagent = createSubAgent(
-        SUB_AGENT_TYPE.GENERAL,
+        SubAgentType.GENERAL,
         context.getConfig,
         tmpDir,
         'none',
@@ -129,7 +131,7 @@ describe('dispatchAgentTool', () => {
     initAgentRegistries();
     try {
       const subagent = createSubAgent(
-        SUB_AGENT_TYPE.EXPLORE,
+        SubAgentType.EXPLORE,
         context.getConfig,
         tmpDir,
         'none',
@@ -169,7 +171,7 @@ describe('dispatchAgentTool', () => {
     try {
       const sessionsDir = path.join(tmpDir, 'subagents');
       const subagent = createSubAgent(
-        SUB_AGENT_TYPE.GENERAL,
+        SubAgentType.GENERAL,
         context.getConfig,
         tmpDir,
         'none',
@@ -215,7 +217,7 @@ describe('dispatchAgentTool', () => {
     try {
       const sessionsDir = path.join(tmpDir, 'subagents');
       const subagent = createSubAgent(
-        SUB_AGENT_TYPE.EXPLORE,
+        SubAgentType.EXPLORE,
         context.getConfig,
         tmpDir,
         'none',
@@ -253,6 +255,18 @@ describe('dispatchAgentTool', () => {
     } finally {
       resetAgentRegistries();
     }
+  });
+
+  it('registers the dispatched subagent in the parent context registry', () => {
+    const subagent = {
+      id: '11111111-1111-4111-8111-111111111111',
+    } as Agent;
+
+    registerSubAgent(context, subagent, SubAgentType.EXPLORE);
+
+    expect(context.subagents.list()).toEqual([
+      {id: subagent.id, agentType: SubAgentType.EXPLORE},
+    ]);
   });
 
   describe('workingDirectory boundary check', () => {

--- a/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts
+++ b/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts
@@ -264,7 +264,7 @@ describe('dispatchAgentTool', () => {
 
     registerSubAgent(context, subagent, SubAgentType.EXPLORE);
 
-    expect(context.subagents.list()).toEqual([
+    expect(context.subagentRegistry.list()).toEqual([
       {id: subagent.id, agentType: SubAgentType.EXPLORE},
     ]);
   });

--- a/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
+++ b/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
@@ -95,7 +95,7 @@ export function registerSubAgent(
   subagent: Agent,
   agentType: SubAgentType,
 ): void {
-  context.subagents.register({id: subagent.id, agentType});
+  context.subagentRegistry.register({id: subagent.id, agentType});
 }
 
 const parameters = z.object({

--- a/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
+++ b/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
@@ -1,6 +1,11 @@
 import path from 'node:path';
 
-import {thinkingLevelSchema} from '@omnicraft/api-schema';
+import {
+  SubAgentType,
+  subAgentTypeSchema,
+  type ThinkingLevel,
+  thinkingLevelSchema,
+} from '@omnicraft/api-schema';
 import type {SseBaseEvent} from '@omnicraft/sse-events';
 import {z} from 'zod';
 
@@ -19,21 +24,14 @@ interface SubAgentInfo {
   description: string;
 }
 
-export const SUB_AGENT_TYPE = {
-  GENERAL: 'general',
-  EXPLORE: 'explore',
-} as const;
-
-export type SubAgentType = (typeof SUB_AGENT_TYPE)[keyof typeof SUB_AGENT_TYPE];
-
 const subAgentInfos = {
-  [SUB_AGENT_TYPE.GENERAL]: {
+  [SubAgentType.GENERAL]: {
     name: 'General',
     description:
       'General-purpose agent for autonomous multi-step tasks. ' +
       'Use for delegated work that no specialized subagent type covers.',
   },
-  [SUB_AGENT_TYPE.EXPLORE]: {
+  [SubAgentType.EXPLORE]: {
     name: 'Explore',
     description:
       'Research-focused agent for repository research, architecture, module design, ' +
@@ -42,11 +40,6 @@ const subAgentInfos = {
       'Do not specify a report format unless the user asked for one.',
   },
 } as const satisfies Record<SubAgentType, SubAgentInfo>;
-
-const agentTypeSchema = z.enum([
-  SUB_AGENT_TYPE.GENERAL,
-  SUB_AGENT_TYPE.EXPLORE,
-]);
 
 function buildToolDescription(): string {
   const header =
@@ -69,18 +62,18 @@ export function createSubAgent(
   agentType: SubAgentType,
   getConfig: () => Promise<LlmConfig>,
   workingDirectory: string,
-  thinkingLevel: z.infer<typeof thinkingLevelSchema>,
+  thinkingLevel: ThinkingLevel,
   sessionsDir?: string,
 ): Agent {
   switch (agentType) {
-    case SUB_AGENT_TYPE.GENERAL:
+    case SubAgentType.GENERAL:
       return new GeneralSubAgent(
         getConfig,
         workingDirectory,
         thinkingLevel,
         sessionsDir,
       );
-    case SUB_AGENT_TYPE.EXPLORE:
+    case SubAgentType.EXPLORE:
       return new ExploreSubAgent(
         getConfig,
         workingDirectory,
@@ -97,12 +90,20 @@ export function getSubagentSessionsDir(
   return path.join(context.sessionsDir, context.agentId, 'subagents');
 }
 
+export function registerSubAgent(
+  context: ToolExecutionContext,
+  subagent: Agent,
+  agentType: SubAgentType,
+): void {
+  context.subagents.register({id: subagent.id, agentType});
+}
+
 const parameters = z.object({
   task: z.string().min(1).describe('The task description for the subagent'),
-  agentType: agentTypeSchema
+  agentType: subAgentTypeSchema
     .optional()
     .describe(
-      `Type of subagent to dispatch. Defaults to '${SUB_AGENT_TYPE.GENERAL}'.`,
+      `Type of subagent to dispatch. Defaults to '${SubAgentType.GENERAL}'.`,
     ),
   model: z
     .enum(['default', 'light'])
@@ -154,7 +155,7 @@ export const dispatchAgentTool: ToolDefinition<
   ): Promise<ToolExecuteResult<DispatchAgentResult>> {
     const {
       task,
-      agentType = SUB_AGENT_TYPE.GENERAL,
+      agentType = SubAgentType.GENERAL,
       model = 'default',
       thinkingLevel = 'none',
     } = args;
@@ -191,6 +192,7 @@ export const dispatchAgentTool: ToolDefinition<
       thinkingLevel,
       subagentSessionsDir,
     );
+    registerSubAgent(context, subagent, agentType);
 
     // Link parent abort signal to subagent
     const onAbort = () => {

--- a/packages/api-schema/src/index.ts
+++ b/packages/api-schema/src/index.ts
@@ -45,6 +45,7 @@ export {
   type SettingValue,
   settingValueSchema,
 } from './settings/schema.js';
+export * from './sub-agent/schema.js';
 export {
   type GetVscodeStatusResponse,
   getVscodeStatusResponseSchema,

--- a/packages/api-schema/src/sub-agent/schema.ts
+++ b/packages/api-schema/src/sub-agent/schema.ts
@@ -1,0 +1,14 @@
+import {z} from 'zod';
+
+/** Discriminator for subagent implementations that can be dispatched/resumed. */
+export const SubAgentType = {
+  GENERAL: 'general',
+  EXPLORE: 'explore',
+} as const;
+
+export type SubAgentType = (typeof SubAgentType)[keyof typeof SubAgentType];
+
+export const subAgentTypeSchema = z.enum([
+  SubAgentType.GENERAL,
+  SubAgentType.EXPLORE,
+]);

--- a/packages/sse-events/src/schema.test.ts
+++ b/packages/sse-events/src/schema.test.ts
@@ -6,7 +6,9 @@ import {
   sseContextCompactionErrorEventSchema,
   sseContextCompactionStartEventSchema,
   sseEventSchema,
+  sseSubagentCompleteEventSchema,
   sseSubagentDispatchEventSchema,
+  sseSubagentOutputEventSchema,
 } from './schema.js';
 
 describe('context-compaction-start schema', () => {
@@ -81,6 +83,19 @@ describe('context-compaction-error schema', () => {
 });
 
 describe('subagent-dispatch schema', () => {
+  it('rejects a non-UUID agent id', () => {
+    expect(() =>
+      sseSubagentDispatchEventSchema.parse({
+        type: 'subagent-dispatch',
+        agentId: 'not-a-uuid',
+        task: 'Inspect the project',
+        agentType: 'general',
+        thinkingLevel: 'none',
+        workingDirectory: '/workspace/project',
+      }),
+    ).toThrow();
+  });
+
   it('rejects an unknown subagent type', () => {
     expect(() =>
       sseSubagentDispatchEventSchema.parse({
@@ -90,6 +105,30 @@ describe('subagent-dispatch schema', () => {
         agentType: 'unknown',
         thinkingLevel: 'none',
         workingDirectory: '/workspace/project',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('subagent-output schema', () => {
+  it('rejects a non-UUID agent id', () => {
+    expect(() =>
+      sseSubagentOutputEventSchema.parse({
+        type: 'subagent-output',
+        agentId: 'not-a-uuid',
+        event: {type: 'text-delta', content: 'Hello'},
+      }),
+    ).toThrow();
+  });
+});
+
+describe('subagent-complete schema', () => {
+  it('rejects a non-UUID agent id', () => {
+    expect(() =>
+      sseSubagentCompleteEventSchema.parse({
+        type: 'subagent-complete',
+        agentId: 'not-a-uuid',
+        status: 'success',
       }),
     ).toThrow();
   });

--- a/packages/sse-events/src/schema.test.ts
+++ b/packages/sse-events/src/schema.test.ts
@@ -6,6 +6,7 @@ import {
   sseContextCompactionErrorEventSchema,
   sseContextCompactionStartEventSchema,
   sseEventSchema,
+  sseSubagentDispatchEventSchema,
 } from './schema.js';
 
 describe('context-compaction-start schema', () => {
@@ -76,5 +77,20 @@ describe('context-compaction-error schema', () => {
     expect(sseContextCompactionErrorEventSchema.parse(event)).toEqual(event);
     expect(sseBaseEventSchema.parse(event)).toEqual(event);
     expect(sseEventSchema.parse(event)).toEqual(event);
+  });
+});
+
+describe('subagent-dispatch schema', () => {
+  it('rejects an unknown subagent type', () => {
+    expect(() =>
+      sseSubagentDispatchEventSchema.parse({
+        type: 'subagent-dispatch',
+        agentId: '11111111-1111-4111-8111-111111111111',
+        task: 'Inspect the project',
+        agentType: 'unknown',
+        thinkingLevel: 'none',
+        workingDirectory: '/workspace/project',
+      }),
+    ).toThrow();
   });
 });

--- a/packages/sse-events/src/schema.ts
+++ b/packages/sse-events/src/schema.ts
@@ -1,4 +1,4 @@
-import {thinkingLevelSchema} from '@omnicraft/api-schema';
+import {subAgentTypeSchema, thinkingLevelSchema} from '@omnicraft/api-schema';
 import {toolNameSchema, toolResultDataSchema} from '@omnicraft/tool-schemas';
 import {z} from 'zod';
 
@@ -224,9 +224,9 @@ export type SseBaseEvent = z.infer<typeof sseBaseEventSchema>;
 /** A subagent has been dispatched to handle a subtask. */
 export const sseSubagentDispatchEventSchema = z.object({
   type: z.literal('subagent-dispatch'),
-  agentId: z.string(),
+  agentId: z.uuid(),
   task: z.string(),
-  agentType: z.string(),
+  agentType: subAgentTypeSchema,
   thinkingLevel: thinkingLevelSchema,
   workingDirectory: z.string(),
 });
@@ -237,7 +237,7 @@ export type SseSubagentDispatchEvent = z.infer<
 /** A forwarded event from a running subagent. */
 export const sseSubagentOutputEventSchema = z.object({
   type: z.literal('subagent-output'),
-  agentId: z.string(),
+  agentId: z.uuid(),
   event: sseBaseEventSchema,
 });
 export type SseSubagentOutputEvent = z.infer<
@@ -247,7 +247,7 @@ export type SseSubagentOutputEvent = z.infer<
 /** A subagent has finished its work. */
 export const sseSubagentCompleteEventSchema = z.object({
   type: z.literal('subagent-complete'),
-  agentId: z.string(),
+  agentId: z.uuid(),
   status: z.enum(['success', 'failure']),
 });
 export type SseSubagentCompleteEvent = z.infer<


### PR DESCRIPTION
## Summary

Part of #200.

- Add a shared `SubAgentType` schema in `@omnicraft/api-schema`.
- Persist minimal parent-side subagent records in agent snapshots: `id` UUID plus `agentType`.
- Thread the subagent registry through tool execution context and register newly dispatched subagents.
- Tighten subagent SSE event `agentId` fields to UUID validation.

## Notes

This intentionally does not implement `resume_agent` yet. It only adds the registry foundation needed for the main agent to know which subagents exist after snapshot restore.

## Tests

- `bun run --filter '@omnicraft/api-schema' typecheck`\n- `bun run --filter '@omnicraft/api-schema' test`\n- `bun run --filter '@omnicraft/sse-events' typecheck`\n- `bun run --filter '@omnicraft/sse-events' test`\n- `bun run --filter '@omnicraft/backend' typecheck`\n- `bun run --filter '@omnicraft/backend' test`