### PR TITLE
[codex] Add list_agents subagent tool

### DIFF
--- a/apps/backend/src/agent/tools/sub-agent/list-agents-tool.test.ts
+++ b/apps/backend/src/agent/tools/sub-agent/list-agents-tool.test.ts
@@ -3,11 +3,11 @@ import os from 'node:os';
 import path from 'node:path';
 
 import {SubAgentType} from '@omnicraft/api-schema';
-import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
-import {Agent} from '@/agent-core/agent/index.js';
 import {createMockContext} from '@/agent-core/tool/testing.js';
 import type {ToolExecutionContext} from '@/agent-core/tool/types.js';
+import {logger} from '@/logger.js';
 
 import {listAgentsTool} from './list-agents-tool.js';
 import {SubAgentToolRegistry} from './sub-agent-tool-registry.js';
@@ -85,6 +85,7 @@ describe('listAgentsTool', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await fs.rm(tmpDir, {recursive: true, force: true});
   });
 
@@ -185,7 +186,8 @@ describe('listAgentsTool', () => {
     });
   });
 
-  it('uses the default title when persisted title cannot be read', async () => {
+  it('omits records whose persisted title cannot be read', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
     context.subagentRegistry.register({
       id: child1Id,
       agentType: SubAgentType.GENERAL,
@@ -195,19 +197,16 @@ describe('listAgentsTool', () => {
 
     expect(result).toMatchObject({
       status: 'success',
-      data: {
-        agents: [
-          {
-            id: child1Id,
-            agentType: SubAgentType.GENERAL,
-            title: Agent.DEFAULT_TITLE,
-          },
-        ],
-      },
+      data: {agents: []},
     });
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({agentId: child1Id}),
+      'Skipping subagent with unreadable persisted title',
+    );
   });
 
-  it('uses the default title for in-memory parent sessions', async () => {
+  it('omits records for in-memory parent sessions', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
     const memoryContext = createMockContext({sessionsDir: null});
     memoryContext.subagentRegistry.register({
       id: child1Id,
@@ -218,15 +217,11 @@ describe('listAgentsTool', () => {
 
     expect(result).toMatchObject({
       status: 'success',
-      data: {
-        agents: [
-          {
-            id: child1Id,
-            agentType: SubAgentType.GENERAL,
-            title: Agent.DEFAULT_TITLE,
-          },
-        ],
-      },
+      data: {agents: []},
     });
+    expect(warn).toHaveBeenCalledWith(
+      {agentId: child1Id},
+      'Skipping subagent without persistence directory',
+    );
   });
 });

--- a/apps/backend/src/agent/tools/sub-agent/list-agents-tool.test.ts
+++ b/apps/backend/src/agent/tools/sub-agent/list-agents-tool.test.ts
@@ -1,0 +1,232 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {SubAgentType} from '@omnicraft/api-schema';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+import {Agent} from '@/agent-core/agent/index.js';
+import {createMockContext} from '@/agent-core/tool/testing.js';
+import type {ToolExecutionContext} from '@/agent-core/tool/types.js';
+
+import {listAgentsTool} from './list-agents-tool.js';
+import {SubAgentToolRegistry} from './sub-agent-tool-registry.js';
+
+const parentId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const child1Id = '11111111-1111-4111-8111-111111111111';
+const child2Id = '22222222-2222-4222-8222-222222222222';
+const unregisteredChildId = '33333333-3333-4333-8333-333333333333';
+
+function emptyUsage() {
+  return {
+    currentContextInputTokens: 0,
+    latestCallOutputTokens: 0,
+    sessionInputTokens: 0,
+    sessionOutputTokens: 0,
+    sessionCacheReadInputTokens: 0,
+  };
+}
+
+async function writeSubagentMetadata(
+  rootDir: string,
+  id: string,
+  title: string,
+): Promise<void> {
+  const dir = path.join(rootDir, id);
+  await fs.mkdir(dir, {recursive: true});
+  await fs.writeFile(
+    path.join(dir, 'metadata.json'),
+    JSON.stringify({id, title, workingDirectory: '/workspace/project'}),
+  );
+}
+
+async function writeSubagentSnapshot(
+  rootDir: string,
+  id: string,
+  title: string,
+): Promise<void> {
+  const dir = path.join(rootDir, id);
+  await fs.mkdir(dir, {recursive: true});
+  await fs.writeFile(
+    path.join(dir, 'snapshot.json'),
+    JSON.stringify({
+      id,
+      title,
+      sseEventCount: 0,
+      llmSession: {
+        id: 'llm-session-id',
+        messages: [],
+        compactions: [],
+        latestUsageInputMessageCount: null,
+        usage: emptyUsage(),
+      },
+      options: {
+        workingDirectory: '/workspace/project',
+        thinkingLevel: 'none',
+      },
+      subagents: [],
+    }),
+  );
+}
+
+describe('listAgentsTool', () => {
+  let tmpDir: string;
+  let context: ToolExecutionContext;
+  let subagentSessionsDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'list-agents-test-'));
+    context = createMockContext({
+      agentId: parentId,
+      sessionsDir: tmpDir,
+      workingDirectory: '/workspace/project',
+    });
+    subagentSessionsDir = path.join(tmpDir, parentId, 'subagents');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, {recursive: true, force: true});
+  });
+
+  it('has the correct name', () => {
+    expect(listAgentsTool.name).toBe('list_agents');
+  });
+
+  it('is registered by the subagent tool registry', () => {
+    SubAgentToolRegistry.resetInstance();
+    try {
+      const registry = SubAgentToolRegistry.create();
+
+      expect(registry.get('list_agents')).toBe(listAgentsTool);
+    } finally {
+      SubAgentToolRegistry.resetInstance();
+    }
+  });
+
+  it('returns an empty list when no subagents are registered', async () => {
+    const result = await listAgentsTool.execute({}, context);
+
+    expect(result).toMatchObject({
+      status: 'success',
+      data: {agents: []},
+    });
+    expect(result.content).toContain('No subagents');
+  });
+
+  it('lists registered subagents with titles from metadata', async () => {
+    context.subagentRegistry.register({
+      id: child1Id,
+      agentType: SubAgentType.GENERAL,
+    });
+    context.subagentRegistry.register({
+      id: child2Id,
+      agentType: SubAgentType.EXPLORE,
+    });
+    await writeSubagentMetadata(subagentSessionsDir, child1Id, 'Build Summary');
+    await writeSubagentMetadata(
+      subagentSessionsDir,
+      child2Id,
+      'Explore Report',
+    );
+    await writeSubagentMetadata(
+      subagentSessionsDir,
+      unregisteredChildId,
+      'Not Owned By Registry',
+    );
+
+    const result = await listAgentsTool.execute({}, context);
+
+    expect(result).toMatchObject({
+      status: 'success',
+      data: {
+        agents: [
+          {
+            id: child1Id,
+            agentType: SubAgentType.GENERAL,
+            title: 'Build Summary',
+          },
+          {
+            id: child2Id,
+            agentType: SubAgentType.EXPLORE,
+            title: 'Explore Report',
+          },
+        ],
+      },
+    });
+    expect(result.content).toContain(child1Id);
+    expect(result.content).toContain('Build Summary');
+    expect(result.content).not.toContain(unregisteredChildId);
+  });
+
+  it('falls back to snapshot title when metadata is missing', async () => {
+    context.subagentRegistry.register({
+      id: child1Id,
+      agentType: SubAgentType.GENERAL,
+    });
+    await writeSubagentSnapshot(
+      subagentSessionsDir,
+      child1Id,
+      'Snapshot Title',
+    );
+
+    const result = await listAgentsTool.execute({}, context);
+
+    expect(result).toMatchObject({
+      status: 'success',
+      data: {
+        agents: [
+          {
+            id: child1Id,
+            agentType: SubAgentType.GENERAL,
+            title: 'Snapshot Title',
+          },
+        ],
+      },
+    });
+  });
+
+  it('uses the default title when persisted title cannot be read', async () => {
+    context.subagentRegistry.register({
+      id: child1Id,
+      agentType: SubAgentType.GENERAL,
+    });
+
+    const result = await listAgentsTool.execute({}, context);
+
+    expect(result).toMatchObject({
+      status: 'success',
+      data: {
+        agents: [
+          {
+            id: child1Id,
+            agentType: SubAgentType.GENERAL,
+            title: Agent.DEFAULT_TITLE,
+          },
+        ],
+      },
+    });
+  });
+
+  it('uses the default title for in-memory parent sessions', async () => {
+    const memoryContext = createMockContext({sessionsDir: null});
+    memoryContext.subagentRegistry.register({
+      id: child1Id,
+      agentType: SubAgentType.GENERAL,
+    });
+
+    const result = await listAgentsTool.execute({}, memoryContext);
+
+    expect(result).toMatchObject({
+      status: 'success',
+      data: {
+        agents: [
+          {
+            id: child1Id,
+            agentType: SubAgentType.GENERAL,
+            title: Agent.DEFAULT_TITLE,
+          },
+        ],
+      },
+    });
+  });
+});

--- a/apps/backend/src/agent/tools/sub-agent/list-agents-tool.test.ts
+++ b/apps/backend/src/agent/tools/sub-agent/list-agents-tool.test.ts
@@ -197,6 +197,34 @@ describe('listAgentsTool', () => {
     });
   });
 
+  it('lists an empty persisted title without falling back or omitting the record', async () => {
+    context.subagentRegistry.register({
+      id: child1Id,
+      agentType: SubAgentType.GENERAL,
+    });
+    await writeSubagentMetadata(subagentSessionsDir, child1Id, '');
+    await writeSubagentSnapshot(
+      subagentSessionsDir,
+      child1Id,
+      'Snapshot Title',
+    );
+
+    const result = await listAgentsTool.execute({}, context);
+
+    expect(result).toMatchObject({
+      status: 'success',
+      data: {
+        agents: [
+          {
+            id: child1Id,
+            agentType: SubAgentType.GENERAL,
+            title: '',
+          },
+        ],
+      },
+    });
+  });
+
   it('omits records whose persisted title cannot be read', async () => {
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
     context.subagentRegistry.register({

--- a/apps/backend/src/agent/tools/sub-agent/list-agents-tool.test.ts
+++ b/apps/backend/src/agent/tools/sub-agent/list-agents-tool.test.ts
@@ -69,6 +69,17 @@ async function writeSubagentSnapshot(
   );
 }
 
+async function writeRawSubagentFile(
+  rootDir: string,
+  id: string,
+  fileName: string,
+  content: string,
+): Promise<void> {
+  const dir = path.join(rootDir, id);
+  await fs.mkdir(dir, {recursive: true});
+  await fs.writeFile(path.join(dir, fileName), content);
+}
+
 describe('listAgentsTool', () => {
   let tmpDir: string;
   let context: ToolExecutionContext;
@@ -199,6 +210,79 @@ describe('listAgentsTool', () => {
       status: 'success',
       data: {agents: []},
     });
+    expect(result.content).toContain('could not be listed');
+    expect(result.content).not.toContain('No subagents');
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({agentId: child1Id}),
+      'Skipping subagent with unreadable persisted title',
+    );
+  });
+
+  it('logs unreadable metadata and falls back to the snapshot title', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    context.subagentRegistry.register({
+      id: child1Id,
+      agentType: SubAgentType.GENERAL,
+    });
+    await writeRawSubagentFile(
+      subagentSessionsDir,
+      child1Id,
+      'metadata.json',
+      'not valid json{{{',
+    );
+    await writeSubagentSnapshot(
+      subagentSessionsDir,
+      child1Id,
+      'Snapshot Title',
+    );
+
+    const result = await listAgentsTool.execute({}, context);
+
+    expect(result).toMatchObject({
+      status: 'success',
+      data: {
+        agents: [
+          {
+            id: child1Id,
+            agentType: SubAgentType.GENERAL,
+            title: 'Snapshot Title',
+          },
+        ],
+      },
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({agentId: child1Id}),
+      'Failed to read subagent metadata title',
+    );
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'Skipping subagent with unreadable persisted title',
+    );
+  });
+
+  it('logs unreadable snapshot before omitting the record', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    context.subagentRegistry.register({
+      id: child1Id,
+      agentType: SubAgentType.GENERAL,
+    });
+    await writeRawSubagentFile(
+      subagentSessionsDir,
+      child1Id,
+      'snapshot.json',
+      'not valid json{{{',
+    );
+
+    const result = await listAgentsTool.execute({}, context);
+
+    expect(result).toMatchObject({
+      status: 'success',
+      data: {agents: []},
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({agentId: child1Id}),
+      'Failed to read subagent snapshot title',
+    );
     expect(warn).toHaveBeenCalledWith(
       expect.objectContaining({agentId: child1Id}),
       'Skipping subagent with unreadable persisted title',

--- a/apps/backend/src/agent/tools/sub-agent/list-agents-tool.ts
+++ b/apps/backend/src/agent/tools/sub-agent/list-agents-tool.ts
@@ -53,30 +53,13 @@ async function readTitleFromSnapshot(
 }
 
 async function readSubagentTitle(
-  context: ToolExecutionContext,
+  subagentSessionsDir: string,
   id: string,
 ): Promise<string | null> {
-  const subagentSessionsDir = getSubagentSessionsDir(context);
-  if (!subagentSessionsDir) {
-    logger.warn(
-      {agentId: id},
-      'Skipping subagent without persistence directory',
-    );
-    return null;
-  }
-
-  const title =
+  return (
     (await readTitleFromMetadata(subagentSessionsDir, id)) ??
-    (await readTitleFromSnapshot(subagentSessionsDir, id));
-
-  if (!title) {
-    logger.warn(
-      {agentId: id},
-      'Skipping subagent with unreadable persisted title',
-    );
-  }
-
-  return title;
+    (await readTitleFromSnapshot(subagentSessionsDir, id))
+  );
 }
 
 function formatListAgentsContent(agents: readonly ListedAgent[]): string {
@@ -106,10 +89,26 @@ export const listAgentsTool: ToolDefinition<
     context: ToolExecutionContext,
   ): Promise<ToolExecuteResult<ListAgentsResult>> {
     const records = context.subagentRegistry.list();
+    const subagentSessionsDir = getSubagentSessionsDir(context);
     const agentsOrNull = await Promise.all(
       records.map(async (record): Promise<ListedAgent | null> => {
-        const title = await readSubagentTitle(context, record.id);
-        if (!title) return null;
+        if (!subagentSessionsDir) {
+          logger.warn(
+            {agentId: record.id},
+            'Skipping subagent without persistence directory',
+          );
+          return null;
+        }
+
+        const title = await readSubagentTitle(subagentSessionsDir, record.id);
+        if (!title) {
+          logger.warn(
+            {agentId: record.id},
+            'Skipping subagent with unreadable persisted title',
+          );
+          return null;
+        }
+
         return {id: record.id, agentType: record.agentType, title};
       }),
     );

--- a/apps/backend/src/agent/tools/sub-agent/list-agents-tool.ts
+++ b/apps/backend/src/agent/tools/sub-agent/list-agents-tool.ts
@@ -9,6 +9,7 @@ import type {
   ToolExecuteResult,
   ToolExecutionContext,
 } from '@/agent-core/tool/index.js';
+import {isFileNotFoundError} from '@/helpers/fs.js';
 import {logger} from '@/logger.js';
 
 import {getSubagentSessionsDir} from './dispatch-agent-tool.js';
@@ -36,7 +37,10 @@ async function readTitleFromMetadata(
     );
     const parsed: unknown = JSON.parse(content);
     return sessionMetadataSchema.parse(parsed).title;
-  } catch {
+  } catch (err) {
+    if (!isFileNotFoundError(err)) {
+      logger.warn({agentId: id, err}, 'Failed to read subagent metadata title');
+    }
     return null;
   }
 }
@@ -47,7 +51,10 @@ async function readTitleFromSnapshot(
 ): Promise<string | null> {
   try {
     return (await agentPersistence.loadSnapshot(subagentSessionsDir, id)).title;
-  } catch {
+  } catch (err) {
+    if (!isFileNotFoundError(err)) {
+      logger.warn({agentId: id, err}, 'Failed to read subagent snapshot title');
+    }
     return null;
   }
 }
@@ -62,8 +69,17 @@ async function readSubagentTitle(
   );
 }
 
-function formatListAgentsContent(agents: readonly ListedAgent[]): string {
-  if (agents.length === 0) return 'No subagents have been dispatched.';
+function formatListAgentsContent(
+  agents: readonly ListedAgent[],
+  registeredCount: number,
+): string {
+  if (agents.length === 0) {
+    if (registeredCount > 0) {
+      return 'Subagents are registered, but they could not be listed because their persisted state is unavailable or unreadable.';
+    }
+
+    return 'No subagents have been dispatched.';
+  }
 
   return agents
     .map((agent) => `- ${agent.title} (${agent.agentType})\n  id: ${agent.id}`)
@@ -118,7 +134,7 @@ export const listAgentsTool: ToolDefinition<
 
     return {
       data: {agents},
-      content: formatListAgentsContent(agents),
+      content: formatListAgentsContent(agents, records.length),
       status: 'success',
     };
   },

--- a/apps/backend/src/agent/tools/sub-agent/list-agents-tool.ts
+++ b/apps/backend/src/agent/tools/sub-agent/list-agents-tool.ts
@@ -1,0 +1,111 @@
+import {readFile} from 'node:fs/promises';
+
+import {sessionMetadataSchema, type SubAgentType} from '@omnicraft/api-schema';
+import {z} from 'zod';
+
+import {Agent, agentPersistence} from '@/agent-core/agent/index.js';
+import type {
+  ToolDefinition,
+  ToolExecuteResult,
+  ToolExecutionContext,
+} from '@/agent-core/tool/index.js';
+
+import {getSubagentSessionsDir} from './dispatch-agent-tool.js';
+
+interface ListedAgent {
+  id: string;
+  agentType: SubAgentType;
+  title: string;
+}
+
+interface ListAgentsResult {
+  agents: ListedAgent[];
+}
+
+const parameters = z.object({});
+
+async function readTitleFromMetadata(
+  subagentSessionsDir: string,
+  id: string,
+): Promise<string | null> {
+  try {
+    const content = await readFile(
+      agentPersistence.metadataPath(subagentSessionsDir, id),
+      'utf-8',
+    );
+    const parsed: unknown = JSON.parse(content);
+    return sessionMetadataSchema.parse(parsed).title;
+  } catch {
+    return null;
+  }
+}
+
+async function readTitleFromSnapshot(
+  subagentSessionsDir: string,
+  id: string,
+): Promise<string | null> {
+  try {
+    return (await agentPersistence.loadSnapshot(subagentSessionsDir, id)).title;
+  } catch {
+    return null;
+  }
+}
+
+async function readSubagentTitle(
+  context: ToolExecutionContext,
+  id: string,
+): Promise<string> {
+  const subagentSessionsDir = getSubagentSessionsDir(context);
+  if (!subagentSessionsDir) return Agent.DEFAULT_TITLE;
+
+  return (
+    (await readTitleFromMetadata(subagentSessionsDir, id)) ??
+    (await readTitleFromSnapshot(subagentSessionsDir, id)) ??
+    Agent.DEFAULT_TITLE
+  );
+}
+
+function formatListAgentsContent(agents: readonly ListedAgent[]): string {
+  if (agents.length === 0) return 'No subagents have been dispatched.';
+
+  return agents
+    .map((agent) => `- ${agent.title} (${agent.agentType})\n  id: ${agent.id}`)
+    .join('\n');
+}
+
+export const listAgentsTool: ToolDefinition<
+  typeof parameters,
+  ListAgentsResult
+> = {
+  name: 'list_agents',
+  displayName: 'List Agents',
+  description:
+    'Lists subagents dispatched by the current agent. ' +
+    'Use this when you need to identify an existing subagent by id.',
+  parameters,
+  suppressToolEvents: true,
+  compactResult({content}) {
+    return content.trim() || null;
+  },
+  async execute(
+    _args: z.infer<typeof parameters>,
+    context: ToolExecutionContext,
+  ): Promise<ToolExecuteResult<ListAgentsResult>> {
+    const records = context.subagentRegistry.list();
+    const agents = await Promise.all(
+      records.map(
+        async (record): Promise<ListedAgent> => ({
+          id: record.id,
+          agentType: record.agentType,
+          title: await readSubagentTitle(context, record.id),
+        }),
+      ),
+    );
+
+    return {
+      data: {agents},
+      content: formatListAgentsContent(agents),
+      status: 'success',
+    };
+  },
+};

--- a/apps/backend/src/agent/tools/sub-agent/list-agents-tool.ts
+++ b/apps/backend/src/agent/tools/sub-agent/list-agents-tool.ts
@@ -3,12 +3,13 @@ import {readFile} from 'node:fs/promises';
 import {sessionMetadataSchema, type SubAgentType} from '@omnicraft/api-schema';
 import {z} from 'zod';
 
-import {Agent, agentPersistence} from '@/agent-core/agent/index.js';
+import {agentPersistence} from '@/agent-core/agent/index.js';
 import type {
   ToolDefinition,
   ToolExecuteResult,
   ToolExecutionContext,
 } from '@/agent-core/tool/index.js';
+import {logger} from '@/logger.js';
 
 import {getSubagentSessionsDir} from './dispatch-agent-tool.js';
 
@@ -54,15 +55,28 @@ async function readTitleFromSnapshot(
 async function readSubagentTitle(
   context: ToolExecutionContext,
   id: string,
-): Promise<string> {
+): Promise<string | null> {
   const subagentSessionsDir = getSubagentSessionsDir(context);
-  if (!subagentSessionsDir) return Agent.DEFAULT_TITLE;
+  if (!subagentSessionsDir) {
+    logger.warn(
+      {agentId: id},
+      'Skipping subagent without persistence directory',
+    );
+    return null;
+  }
 
-  return (
+  const title =
     (await readTitleFromMetadata(subagentSessionsDir, id)) ??
-    (await readTitleFromSnapshot(subagentSessionsDir, id)) ??
-    Agent.DEFAULT_TITLE
-  );
+    (await readTitleFromSnapshot(subagentSessionsDir, id));
+
+  if (!title) {
+    logger.warn(
+      {agentId: id},
+      'Skipping subagent with unreadable persisted title',
+    );
+  }
+
+  return title;
 }
 
 function formatListAgentsContent(agents: readonly ListedAgent[]): string {
@@ -92,14 +106,15 @@ export const listAgentsTool: ToolDefinition<
     context: ToolExecutionContext,
   ): Promise<ToolExecuteResult<ListAgentsResult>> {
     const records = context.subagentRegistry.list();
-    const agents = await Promise.all(
-      records.map(
-        async (record): Promise<ListedAgent> => ({
-          id: record.id,
-          agentType: record.agentType,
-          title: await readSubagentTitle(context, record.id),
-        }),
-      ),
+    const agentsOrNull = await Promise.all(
+      records.map(async (record): Promise<ListedAgent | null> => {
+        const title = await readSubagentTitle(context, record.id);
+        if (!title) return null;
+        return {id: record.id, agentType: record.agentType, title};
+      }),
+    );
+    const agents = agentsOrNull.filter(
+      (agent): agent is ListedAgent => agent !== null,
     );
 
     return {

--- a/apps/backend/src/agent/tools/sub-agent/list-agents-tool.ts
+++ b/apps/backend/src/agent/tools/sub-agent/list-agents-tool.ts
@@ -117,7 +117,7 @@ export const listAgentsTool: ToolDefinition<
         }
 
         const title = await readSubagentTitle(subagentSessionsDir, record.id);
-        if (!title) {
+        if (title === null) {
           logger.warn(
             {agentId: record.id},
             'Skipping subagent with unreadable persisted title',

--- a/apps/backend/src/agent/tools/sub-agent/sub-agent-tool-registry.ts
+++ b/apps/backend/src/agent/tools/sub-agent/sub-agent-tool-registry.ts
@@ -1,12 +1,14 @@
 import {ToolRegistry} from '@/agent-core/tool/index.js';
 
 import {dispatchAgentTool} from './dispatch-agent-tool.js';
+import {listAgentsTool} from './list-agents-tool.js';
 
 /** Registry for subagent-related tools. */
 export class SubAgentToolRegistry extends ToolRegistry {
   /** Creates the singleton and registers all subagent tools. */
   static override create(): SubAgentToolRegistry {
     const instance = super.create() as SubAgentToolRegistry;
+    instance.register(listAgentsTool);
     instance.register(dispatchAgentTool);
     return instance;
   }


### PR DESCRIPTION
## Summary

- Add a `list_agents` tool for subagent discovery before resume flows.
- Use the parent `SubagentRegistry` as the only source of listed subagents.
- Return each subagent `id`, `agentType`, and `title`, reading title from child metadata first and snapshot fallback second.
- Register `list_agents` in `SubAgentToolRegistry` alongside `dispatch_agent`.

## Notes

This does not implement `resume_agent` yet. It adds the minimal discovery tool needed for an agent to identify a resumable subagent by id.

## Tests

- `bun run --filter '@omnicraft/backend' typecheck`\n- `bun run --filter '@omnicraft/backend' lint`\n- `bun run --filter '@omnicraft/backend' test`