### PR TITLE
[codex] Validate subagent SSE events

### DIFF
--- a/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts
+++ b/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts
@@ -18,6 +18,7 @@ import {createMockContext} from '@/agent-core/tool/testing.js';
 import type {ToolExecutionContext} from '@/agent-core/tool/types.js';
 
 import {
+  buildSubagentOutputEvent,
   createSubAgent,
   dispatchAgentTool,
   getSubagentSessionsDir,
@@ -267,6 +268,30 @@ describe('dispatchAgentTool', () => {
     expect(context.subagentRegistry.list()).toEqual([
       {id: subagent.id, agentType: SubAgentType.EXPLORE},
     ]);
+  });
+
+  describe('subagent output event wrapping', () => {
+    const agentId = '11111111-1111-4111-8111-111111111111';
+
+    it('wraps non-recursive agent events', () => {
+      const event = {type: 'session-title', title: 'Multiplication'} as const;
+
+      expect(buildSubagentOutputEvent(agentId, event)).toEqual({
+        type: 'subagent-output',
+        agentId,
+        event,
+      });
+    });
+
+    it('throws at the dispatch boundary for recursive subagent events', () => {
+      expect(() =>
+        buildSubagentOutputEvent(agentId, {
+          type: 'subagent-complete',
+          agentId,
+          status: 'success',
+        }),
+      ).toThrow();
+    });
   });
 
   describe('workingDirectory boundary check', () => {

--- a/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
+++ b/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
@@ -6,7 +6,11 @@ import {
   type ThinkingLevel,
   thinkingLevelSchema,
 } from '@omnicraft/api-schema';
-import type {SseBaseEvent} from '@omnicraft/sse-events';
+import {
+  sseBaseEventSchema,
+  type SseEvent,
+  type SseSubagentOutputEvent,
+} from '@omnicraft/sse-events';
 import {z} from 'zod';
 
 import {ExploreSubAgent, GeneralSubAgent} from '@/agent/agents/index.js';
@@ -96,6 +100,18 @@ export function registerSubAgent(
   agentType: SubAgentType,
 ): void {
   context.subagentRegistry.register({id: subagent.id, agentType});
+}
+
+export function buildSubagentOutputEvent(
+  agentId: string,
+  event: SseEvent,
+): SseSubagentOutputEvent {
+  const baseEvent = sseBaseEventSchema.parse(event);
+  return {
+    type: 'subagent-output',
+    agentId,
+    event: baseEvent,
+  };
 }
 
 const parameters = z.object({
@@ -212,27 +228,24 @@ export const dispatchAgentTool: ToolDefinition<
     try {
       let lastReplyText = '';
       let completed = false;
+      let failureMessage: string | null = null;
       const eventIter = subagent.subscribe({signal: context.signal});
 
       subagent.handleUserMessage(task);
 
       for await (const entry of eventIter) {
         const {event} = entry;
-        // Subagents cannot emit subagent events (no SubAgentToolRegistry),
-        // so all events are base events. Cast is safe by construction. The
-        // subagent cursor is only for resuming that internal log, so it is not
-        // forwarded through the parent session's SSE protocol.
-        context.onSubAgentEvent({
-          type: 'subagent-output',
-          agentId: subagent.id,
-          event: event as SseBaseEvent,
-        });
+        context.onSubAgentEvent(buildSubagentOutputEvent(subagent.id, event));
 
         if (event.type === 'message-start' && event.role === 'assistant') {
           lastReplyText = '';
         }
         if (event.type === 'text-delta') {
           lastReplyText += event.content;
+        }
+        if (event.type === 'error') {
+          failureMessage = event.message;
+          break;
         }
         // Subagent's sseLog is never sealed — break on done to end iteration.
         // If the parent aborts, the reader ends silently (no done seen).
@@ -256,6 +269,14 @@ export const dispatchAgentTool: ToolDefinition<
           data: {summary},
           content: summary,
           status: 'success',
+        };
+      }
+
+      if (failureMessage) {
+        return {
+          data: {message: `Subagent error: ${failureMessage}`},
+          content: `Subagent error: ${failureMessage}`,
+          status: 'failure',
         };
       }
 

--- a/apps/frontend/src/modules/chat-session/helpers/route-base-event-to-bus.test.ts
+++ b/apps/frontend/src/modules/chat-session/helpers/route-base-event-to-bus.test.ts
@@ -75,6 +75,41 @@ describe('routeBaseEventToBus', () => {
     expect(handler).toHaveBeenCalledWith(event);
   });
 
+  it('routes session-title to bus', () => {
+    const bus = createBus();
+    const handler = vi.fn();
+    bus.on('session-title', handler);
+
+    const event: SseBaseEvent = {
+      type: 'session-title',
+      title: 'Multiplication',
+    };
+    routeBaseEventToBus(event, bus);
+
+    expect(handler).toHaveBeenCalledWith(event);
+  });
+
+  it('routes todo-update to bus', () => {
+    const bus = createBus();
+    const handler = vi.fn();
+    bus.on('todo-update', handler);
+
+    const event: SseBaseEvent = {type: 'todo-update', items: []};
+    routeBaseEventToBus(event, bus);
+
+    expect(handler).toHaveBeenCalledWith(event);
+  });
+
+  it('routes error to stream-error', () => {
+    const bus = createBus();
+    const handler = vi.fn();
+    bus.on('stream-error', handler);
+
+    routeBaseEventToBus({type: 'error', message: 'failed'}, bus);
+
+    expect(handler).toHaveBeenCalledWith({message: 'failed'});
+  });
+
   it('routes all thinking events', () => {
     const bus = createBus();
     const startHandler = vi.fn();

--- a/apps/frontend/src/modules/chat-session/helpers/route-base-event-to-bus.ts
+++ b/apps/frontend/src/modules/chat-session/helpers/route-base-event-to-bus.ts
@@ -48,5 +48,14 @@ export function routeBaseEventToBus(
     case 'usage-update':
       bus.emit(event.type, event);
       break;
+    case 'session-title':
+      bus.emit(event.type, event);
+      break;
+    case 'todo-update':
+      bus.emit(event.type, event);
+      break;
+    case 'error':
+      bus.emit('stream-error', {message: event.message});
+      break;
   }
 }

--- a/packages/sse-events/src/schema.test.ts
+++ b/packages/sse-events/src/schema.test.ts
@@ -82,6 +82,60 @@ describe('context-compaction-error schema', () => {
   });
 });
 
+describe('base event schema', () => {
+  const agentId = '11111111-1111-4111-8111-111111111111';
+
+  it('accepts non-recursive agent events as subagent output payloads', () => {
+    const events = [
+      {type: 'session-title', title: 'Multiplication'},
+      {type: 'todo-update', items: []},
+      {type: 'error', message: 'Subagent failed'},
+    ];
+
+    for (const event of events) {
+      expect(sseBaseEventSchema.parse(event)).toEqual(event);
+      expect(sseEventSchema.parse(event)).toEqual(event);
+      expect(
+        sseSubagentOutputEventSchema.parse({
+          type: 'subagent-output',
+          agentId,
+          event,
+        }),
+      ).toEqual({type: 'subagent-output', agentId, event});
+    }
+  });
+
+  it('rejects recursive subagent events as subagent output payloads', () => {
+    const recursiveEvents = [
+      {
+        type: 'subagent-dispatch',
+        agentId,
+        task: 'Inspect the project',
+        agentType: 'general',
+        thinkingLevel: 'none',
+        workingDirectory: '/workspace/project',
+      },
+      {
+        type: 'subagent-output',
+        agentId,
+        event: {type: 'text-delta', content: 'nested'},
+      },
+      {type: 'subagent-complete', agentId, status: 'success'},
+    ];
+
+    for (const event of recursiveEvents) {
+      expect(() => sseBaseEventSchema.parse(event)).toThrow();
+      expect(() =>
+        sseSubagentOutputEventSchema.parse({
+          type: 'subagent-output',
+          agentId,
+          event,
+        }),
+      ).toThrow();
+    }
+  });
+});
+
 describe('subagent-dispatch schema', () => {
   it('rejects a non-UUID agent id', () => {
     expect(() =>

--- a/packages/sse-events/src/schema.ts
+++ b/packages/sse-events/src/schema.ts
@@ -195,12 +195,11 @@ export type SseContextCompactionEvent =
   | SseContextCompactionErrorEvent;
 
 // ---------------------------------------------------------------------------
-// Base event union (all events except error and subagent events).
+// Base event union (all non-recursive events).
 // Used as the inner event type for subagent-output to prevent recursion.
 // ---------------------------------------------------------------------------
 
-/** Union of base SSE events that can appear inside a subagent-output wrapper. */
-export const sseBaseEventSchema = z.discriminatedUnion('type', [
+const sseBaseEventSchemas = [
   sseMessageStartEventSchema,
   sseTextDeltaEventSchema,
   sseThinkingStartEventSchema,
@@ -210,11 +209,20 @@ export const sseBaseEventSchema = z.discriminatedUnion('type', [
   sseToolExecuteDeltaEventSchema,
   sseToolExecuteEndEventSchema,
   sseDoneEventSchema,
+  sseUsageUpdateEventSchema,
+  sseErrorEventSchema,
+  sseSessionTitleEventSchema,
+  sseTodoUpdateEventSchema,
   sseContextCompactionStartEventSchema,
   sseContextCompactionEndEventSchema,
   sseContextCompactionErrorEventSchema,
-  sseUsageUpdateEventSchema,
-]);
+] as const;
+
+/** Union of base SSE events that can appear inside a subagent-output wrapper. */
+export const sseBaseEventSchema = z.discriminatedUnion(
+  'type',
+  sseBaseEventSchemas,
+);
 export type SseBaseEvent = z.infer<typeof sseBaseEventSchema>;
 
 // ---------------------------------------------------------------------------
@@ -266,25 +274,10 @@ export type SseSubAgentEvent =
 
 /** Validates known SSE event types. Unknown types fail validation. */
 export const sseEventSchema = z.discriminatedUnion('type', [
-  sseMessageStartEventSchema,
-  sseTextDeltaEventSchema,
-  sseThinkingStartEventSchema,
-  sseThinkingDeltaEventSchema,
-  sseThinkingEndEventSchema,
-  sseToolExecuteStartEventSchema,
-  sseToolExecuteDeltaEventSchema,
-  sseToolExecuteEndEventSchema,
-  sseDoneEventSchema,
-  sseUsageUpdateEventSchema,
-  sseErrorEventSchema,
-  sseSessionTitleEventSchema,
+  ...sseBaseEventSchemas,
   sseSubagentDispatchEventSchema,
   sseSubagentOutputEventSchema,
   sseSubagentCompleteEventSchema,
-  sseTodoUpdateEventSchema,
-  sseContextCompactionStartEventSchema,
-  sseContextCompactionEndEventSchema,
-  sseContextCompactionErrorEventSchema,
 ]);
 
 /** Union of all known SSE events. */


### PR DESCRIPTION
## Summary

- Define SSE base events as the non-recursive event set and build the full SSE event schema by extending that base with subagent protocol events.
- Allow nested subagent output to carry non-recursive agent events such as session-title, todo-update, and stream-level error.
- Replace the dispatch_agent unsafe SseBaseEvent cast with schema parsing at the dispatch boundary, so recursive subagent events fail close to the source.
- Route the newly allowed base events through the frontend subagent event bus.

## Root Cause

Subagents are Agents and can emit normal non-recursive Agent events such as session-title. dispatch_agent wrapped every subagent log event with an unchecked cast, but subagent-output only accepted the narrower base schema, so valid subagent Agent events could crash later at the SSE writer.

## Validation

- bun run --filter '@omnicraft/sse-events' test -- src/schema.test.ts\n- bun run --filter '@omnicraft/backend' test -- src/agent/tools/sub-agent/dispatch-agent-tool.test.ts\n- bun run --filter '@omnicraft/frontend' test -- src/modules/chat-session/helpers/route-base-event-to-bus.test.ts\n- bun run --filter '@omnicraft/sse-events' typecheck\n- bun run --filter '@omnicraft/backend' typecheck\n- bun run --filter '@omnicraft/backend' lint\n- bun run --filter '@omnicraft/frontend' lint\n- bun run --filter '@omnicraft/frontend' build\n- bun run format:check