### PR TITLE
feat(backend): return subagent id from dispatch_agent and resume_agent results

### DIFF
--- a/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts
+++ b/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts
@@ -220,6 +220,10 @@ describe('dispatchAgentTool', () => {
     );
   });
 
+  it('documents that the result includes the subagent id', () => {
+    expect(dispatchAgentTool.description).toContain('includes the subagent id');
+  });
+
   it('documents explore-specific research use cases', () => {
     expect(dispatchAgentTool.description).toContain(
       `- ${SubAgentType.EXPLORE} (Explore):`,

--- a/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts
+++ b/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts
@@ -441,8 +441,8 @@ describe('dispatchAgentTool', () => {
 
     expect(result).toMatchObject({
       status: 'success',
-      data: {summary: 'done'},
-      content: 'done',
+      data: {summary: 'done', agentId: subagent.id},
+      content: `<subagent_id>${subagent.id}</subagent_id>\n\ndone`,
     });
     expect(subagent.handledMessages).toEqual(['Inspect the code']);
     expect(order).toEqual(['handleUserMessage', 'onTurnStarted']);
@@ -484,8 +484,8 @@ describe('dispatchAgentTool', () => {
 
     expect(result).toMatchObject({
       status: 'success',
-      data: {summary: 'new summary'},
-      content: 'new summary',
+      data: {summary: 'new summary', agentId: subagent.id},
+      content: `<subagent_id>${subagent.id}</subagent_id>\n\nnew summary`,
     });
     expect(subagent.handledMessages).toEqual(['Continue the work']);
     expect(subagent.subscribedStartIndexes).toEqual([3]);

--- a/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
+++ b/apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts
@@ -53,7 +53,9 @@ function buildToolDescription(): string {
     'without blocking your immediate next local action. ' +
     'Keep very small local lookups local when dispatch overhead is not worth it. ' +
     'After the subagent returns, synthesize the subagent result for the user ' +
-    'or use it to guide implementation.';
+    'or use it to guide implementation. ' +
+    'The result includes the subagent id so it can be sent follow-up work ' +
+    'later without a separate lookup.';
 
   const typeDescriptions = Object.entries(subAgentInfos)
     .map(([key, info]) => `- ${key} (${info.name}): ${info.description}`)

--- a/apps/backend/src/agent/tools/sub-agent/resume-agent-tool.test.ts
+++ b/apps/backend/src/agent/tools/sub-agent/resume-agent-tool.test.ts
@@ -82,6 +82,10 @@ describe('resumeAgentTool', () => {
     expect(resumeAgentTool.name).toBe('resume_agent');
   });
 
+  it('documents that the result includes the subagent id', () => {
+    expect(resumeAgentTool.description).toContain('includes the subagent id');
+  });
+
   it('is registered by the subagent tool registry', () => {
     SubAgentToolRegistry.resetInstance();
     try {

--- a/apps/backend/src/agent/tools/sub-agent/resume-agent-tool.test.ts
+++ b/apps/backend/src/agent/tools/sub-agent/resume-agent-tool.test.ts
@@ -144,8 +144,8 @@ describe('resumeAgentTool', () => {
 
     expect(result).toMatchObject({
       status: 'success',
-      data: {summary: 'follow-up result'},
-      content: 'follow-up result',
+      data: {summary: 'follow-up result', agentId: subagent.id},
+      content: `<subagent_id>${subagent.id}</subagent_id>\n\nfollow-up result`,
     });
     expect(subagent.handledMessages).toEqual(['Continue analysis']);
     expect(context.events).toEqual([

--- a/apps/backend/src/agent/tools/sub-agent/resume-agent-tool.ts
+++ b/apps/backend/src/agent/tools/sub-agent/resume-agent-tool.ts
@@ -49,7 +49,10 @@ export const resumeAgentTool: ToolDefinition<
 > = {
   name: 'resume_agent',
   displayName: 'Resume Agent',
-  description: 'Resumes a subagent by sending it a follow-up task.',
+  description:
+    'Resumes a subagent by sending it a follow-up task. ' +
+    'The result includes the subagent id so it can be sent further work ' +
+    'later without a separate lookup.',
   parameters,
   suppressToolEvents: true,
   compactResult({content}) {

--- a/apps/backend/src/agent/tools/sub-agent/subagent-turn-runner.ts
+++ b/apps/backend/src/agent/tools/sub-agent/subagent-turn-runner.ts
@@ -14,6 +14,7 @@ import type {
 
 export interface SubagentTurnResult {
   summary: string;
+  agentId: string;
 }
 
 export interface RunSubagentTurnInput {
@@ -109,7 +110,12 @@ export async function runSubagentTurn({
       const summary =
         lastReplyText ||
         'Subagent completed the task but produced no text summary.';
-      return {data: {summary}, content: summary, status: 'success'};
+      const content = `<subagent_id>${subagent.id}</subagent_id>\n\n${summary}`;
+      return {
+        data: {summary, agentId: subagent.id},
+        content,
+        status: 'success',
+      };
     }
 
     if (failureMessage) {

--- a/docs/superpowers/plans/2026-06-07-subagent-dispatch-id-return.md
+++ b/docs/superpowers/plans/2026-06-07-subagent-dispatch-id-return.md
@@ -1,0 +1,285 @@
+# Return Subagent ID from dispatch_agent and resume_agent — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface the subagent id to the main agent (the LLM) in the success result of both `dispatch_agent` and `resume_agent`, so a subagent can be resumed without a separate lookup.
+
+**Architecture:** Both tools share the `runSubagentTurn` helper. The success branch there will add `agentId` to the structured `SubagentTurnResult` and wrap the returned `content` with a `<subagent_id>…</subagent_id>` header above the summary. Failure/abort/error paths are untouched. Tool descriptions get one generic sentence each.
+
+**Tech Stack:** TypeScript (NodeNext ESM), Bun (package manager/runtime), Vitest, ESLint, Prettier.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-subagent-dispatch-id-return-design.md`
+
+---
+
+## File Structure
+
+- Modify: `apps/backend/src/agent/tools/sub-agent/subagent-turn-runner.ts`
+  - `SubagentTurnResult` gains `agentId`; success branch wraps `content` and returns `agentId`.
+- Modify: `apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts`
+  - Append one generic sentence to the tool description.
+- Modify: `apps/backend/src/agent/tools/sub-agent/resume-agent-tool.ts`
+  - Append one generic sentence to the tool description.
+- Test: `apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts`
+  - Update two success assertions; add a description assertion.
+- Test: `apps/backend/src/agent/tools/sub-agent/resume-agent-tool.test.ts`
+  - Update one success assertion; add a description assertion.
+
+Both mock subagents in these tests use the id `11111111-1111-4111-8111-111111111111`.
+
+---
+
+## Task 1: Surface `agentId` in the shared `runSubagentTurn` result
+
+**Files:**
+
+- Modify: `apps/backend/src/agent/tools/sub-agent/subagent-turn-runner.ts:15-17` (interface) and `:108-113` (success branch)
+- Test: `apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts:442-446` and `:485-489`
+- Test: `apps/backend/src/agent/tools/sub-agent/resume-agent-tool.test.ts:145-149`
+
+Both test files exercise `runSubagentTurn`, so both must be updated before the implementation lands or the suite goes red.
+
+- [ ] **Step 1: Update the failing success assertions**
+
+In `dispatch-agent-tool.test.ts`, replace the assertion in the test `forwards dispatched subagent events and registers after the turn starts` (currently):
+
+```ts
+expect(result).toMatchObject({
+  status: 'success',
+  data: {summary: 'done'},
+  content: 'done',
+});
+```
+
+with:
+
+```ts
+expect(result).toMatchObject({
+  status: 'success',
+  data: {summary: 'done', agentId: subagent.id},
+  content: `<subagent_id>${subagent.id}</subagent_id>\n\ndone`,
+});
+```
+
+In the same file, replace the assertion in the test `streams a resumed turn from the current subagent log end` (currently):
+
+```ts
+expect(result).toMatchObject({
+  status: 'success',
+  data: {summary: 'new summary'},
+  content: 'new summary',
+});
+```
+
+with:
+
+```ts
+expect(result).toMatchObject({
+  status: 'success',
+  data: {summary: 'new summary', agentId: subagent.id},
+  content: `<subagent_id>${subagent.id}</subagent_id>\n\nnew summary`,
+});
+```
+
+In `resume-agent-tool.test.ts`, replace the assertion in the test `runs a follow-up turn on a registered idle subagent` (currently):
+
+```ts
+expect(result).toMatchObject({
+  status: 'success',
+  data: {summary: 'follow-up result'},
+  content: 'follow-up result',
+});
+```
+
+with:
+
+```ts
+expect(result).toMatchObject({
+  status: 'success',
+  data: {summary: 'follow-up result', agentId: subagent.id},
+  content: `<subagent_id>${subagent.id}</subagent_id>\n\nfollow-up result`,
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/backend && bun run test src/agent/tools/sub-agent`
+Expected: FAIL — the three updated assertions report a `content`/`data` mismatch (received plain summary, expected the `<subagent_id>` wrapper and `agentId`).
+
+- [ ] **Step 3: Add `agentId` to `SubagentTurnResult`**
+
+In `subagent-turn-runner.ts`, change the interface (currently):
+
+```ts
+export interface SubagentTurnResult {
+  summary: string;
+}
+```
+
+to:
+
+```ts
+export interface SubagentTurnResult {
+  summary: string;
+  agentId: string;
+}
+```
+
+- [ ] **Step 4: Wrap the success content and return `agentId`**
+
+In `subagent-turn-runner.ts`, change the success branch (currently):
+
+```ts
+if (completed) {
+  const summary =
+    lastReplyText ||
+    'Subagent completed the task but produced no text summary.';
+  return {data: {summary}, content: summary, status: 'success'};
+}
+```
+
+to:
+
+```ts
+if (completed) {
+  const summary =
+    lastReplyText ||
+    'Subagent completed the task but produced no text summary.';
+  const content = `<subagent_id>${subagent.id}</subagent_id>\n\n${summary}`;
+  return {
+    data: {summary, agentId: subagent.id},
+    content,
+    status: 'success',
+  };
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd apps/backend && bun run test src/agent/tools/sub-agent`
+Expected: PASS — all dispatch and resume sub-agent tests green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/backend/src/agent/tools/sub-agent/subagent-turn-runner.ts \
+  apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts \
+  apps/backend/src/agent/tools/sub-agent/resume-agent-tool.test.ts
+git commit -m "feat(backend): return subagent id from dispatch and resume results
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 2: Document the returned id in the tool descriptions
+
+**Files:**
+
+- Modify: `apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts:48-63` (`buildToolDescription` header)
+- Modify: `apps/backend/src/agent/tools/sub-agent/resume-agent-tool.ts:52` (`description`)
+- Test: `apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts`
+- Test: `apps/backend/src/agent/tools/sub-agent/resume-agent-tool.test.ts`
+
+Wording stays generic and must not name other tools, per `apps/backend/src/agent/tools/CLAUDE.md`. The phrase "subagent id" avoids an apostrophe so it fits the single-quoted string concatenation already used in these files.
+
+- [ ] **Step 1: Add failing description assertions**
+
+In `dispatch-agent-tool.test.ts`, add this test inside the `describe('dispatchAgentTool', …)` block, right after the existing `it('documents when dispatching a subagent is useful', …)` test:
+
+```ts
+it('documents that the result includes the subagent id', () => {
+  expect(dispatchAgentTool.description).toContain('includes the subagent id');
+});
+```
+
+In `resume-agent-tool.test.ts`, add this test inside the `describe('resumeAgentTool', …)` block, right after the existing `it('has the correct name', …)` test:
+
+```ts
+it('documents that the result includes the subagent id', () => {
+  expect(resumeAgentTool.description).toContain('includes the subagent id');
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd apps/backend && bun run test src/agent/tools/sub-agent`
+Expected: FAIL — both new tests fail because the descriptions do not yet contain `includes the subagent id`.
+
+- [ ] **Step 3: Update the `dispatch_agent` description**
+
+In `dispatch-agent-tool.ts`, change the end of the `header` string in `buildToolDescription` (currently):
+
+```ts
+'After the subagent returns, synthesize the subagent result for the user ' +
+  'or use it to guide implementation.';
+```
+
+to:
+
+```ts
+'After the subagent returns, synthesize the subagent result for the user ' +
+  'or use it to guide implementation. ' +
+  'The result includes the subagent id so it can be sent follow-up work ' +
+  'later without a separate lookup.';
+```
+
+- [ ] **Step 4: Update the `resume_agent` description**
+
+In `resume-agent-tool.ts`, change the `description` field (currently):
+
+```ts
+  description: 'Resumes a subagent by sending it a follow-up task.',
+```
+
+to:
+
+```ts
+  description:
+    'Resumes a subagent by sending it a follow-up task. ' +
+    'The result includes the subagent id so it can be sent further work ' +
+    'later without a separate lookup.',
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd apps/backend && bun run test src/agent/tools/sub-agent`
+Expected: PASS — all sub-agent tests, including the two new description tests, are green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.ts \
+  apps/backend/src/agent/tools/sub-agent/resume-agent-tool.ts \
+  apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts \
+  apps/backend/src/agent/tools/sub-agent/resume-agent-tool.test.ts
+git commit -m "feat(backend): note returned subagent id in dispatch and resume descriptions
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+## Task 3: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Typecheck the backend**
+
+Run: `cd apps/backend && bun run typecheck`
+Expected: PASS — no type errors (confirms `SubagentTurnResult` consumers still compile).
+
+- [ ] **Step 2: Lint the backend**
+
+Run: `cd apps/backend && bun run lint`
+Expected: PASS — no ESLint errors.
+
+- [ ] **Step 3: Run the full backend test suite**
+
+Run: `cd apps/backend && bun run test`
+Expected: PASS — entire backend suite green, confirming no other consumer relied on the old plain-summary `content`.
+
+- [ ] **Step 4: Confirm there is nothing left to commit**
+
+Run: `git status --short`
+Expected: empty output (Task 1 and Task 2 already committed all changes; any formatting from the pre-commit hook is already included).

--- a/docs/superpowers/specs/2026-06-07-subagent-dispatch-id-return-design.md
+++ b/docs/superpowers/specs/2026-06-07-subagent-dispatch-id-return-design.md
@@ -1,0 +1,115 @@
+# Return Subagent ID from dispatch_agent and resume_agent
+
+## Problem
+
+After `dispatch_agent` runs, the main agent (the LLM) never learns the
+dispatched subagent's id. The tool result that reaches the LLM is only the
+subagent's summary text (`agent-turn-runner.ts` forwards `result.content` as the
+tool result message). The id (`agentId`) is emitted solely through SSE events
+(`subagent-dispatch`, `subagent-output`, `subagent-complete`) that reach the
+frontend, never the LLM.
+
+Consequently, to send follow-up work the main agent must always call
+`list_resumable_agents` first to discover the id before calling `resume_agent`.
+That listing tool was meant as a fallback for when the agent is unsure which
+subagent to resume — not a mandatory step on every resume.
+
+## Goal
+
+Surface the subagent id to the LLM in the result of both `dispatch_agent` and
+`resume_agent`, so the agent can resume a subagent directly without an extra
+lookup. The listing tool remains available as a fallback.
+
+## Design
+
+### Where
+
+The change lives in the shared `runSubagentTurn` helper
+(`apps/backend/src/agent/tools/sub-agent/subagent-turn-runner.ts`), which both
+tools call. Centralizing here makes both tools return the id consistently with
+no per-tool special-casing.
+
+### Result shape
+
+`SubagentTurnResult` gains an `agentId` field:
+
+```ts
+export interface SubagentTurnResult {
+  summary: string;
+  agentId: string;
+}
+```
+
+Only the success path carries the id. Failure, abort, and error paths keep
+returning the existing `ToolExecuteFailureResult` (`{ message }`) unchanged —
+error content is not annotated with the id, to avoid cluttering error messages
+for a subagent that may be in a bad state.
+
+### Content format (what the LLM sees)
+
+On success, `content` wraps the id in a labeled block above the summary:
+
+```
+<subagent_id>{agentId}</subagent_id>
+
+{summary}
+```
+
+- The id is delimited so it is unambiguous and not confused with the subagent's
+  own output.
+- Placing it at the top guarantees it survives compaction head/tail truncation.
+- `data` carries the structured `{ summary, agentId }`.
+
+The success branch currently returns:
+
+```ts
+return {data: {summary}, content: summary, status: 'success'};
+```
+
+It becomes:
+
+```ts
+const content = `<subagent_id>${subagent.id}</subagent_id>\n\n${summary}`;
+return {data: {summary, agentId: subagent.id}, content, status: 'success'};
+```
+
+### compactResult
+
+`dispatch_agent` and `resume_agent` both define
+`compactResult({content}) => content.trim() || null`. Because the id is part of
+`content`, it is preserved through compaction with no change to these hooks.
+
+### Tool descriptions
+
+Add one generic sentence to the `dispatch_agent` and `resume_agent`
+descriptions: the result includes the subagent's id, which can later be used to
+send the subagent follow-up work without a separate discovery step. Wording
+stays generic and does not name other tools, per
+`apps/backend/src/agent/tools/CLAUDE.md`.
+
+### Frontend / SSE
+
+No change. The frontend already receives `agentId` via `subagent-dispatch`,
+`subagent-resume`, `subagent-output`, and `subagent-complete` events.
+
+## Testing
+
+- `apps/backend/src/agent/tools/sub-agent/dispatch-agent-tool.test.ts`:
+  - Update the two `runSubagentTurn` success assertions (currently
+    `data: {summary: 'done'}, content: 'done'` and
+    `data: {summary: 'new summary'}, content: 'new summary'`) to expect
+    `agentId` in `data` and the `<subagent_id>…</subagent_id>` wrapper in
+    `content`.
+  - Add an assertion that `content` contains the subagent id.
+  - Leave the failure-path (aborted) assertions unchanged.
+- `apps/backend/src/agent/tools/sub-agent/resume-agent-tool.test.ts`:
+  - Update the success assertion (currently
+    `data: {summary: 'follow-up result'}, content: 'follow-up result'`) the same
+    way.
+
+## Out of Scope
+
+- No change to the `SubagentRegistry`, eviction, or resume-claim logic.
+- No change to SSE event schemas.
+- `list_resumable_agents` keeps its current behavior and remains the fallback
+  discovery path.


### PR DESCRIPTION
## Summary
- `dispatch_agent` and `resume_agent` now surface the subagent's id to the main agent (the LLM) in their **success** result: `content` is wrapped with a `<subagent_id>…</subagent_id>` header above the summary, and `data` gains `agentId`.
- Previously the id only reached the frontend via SSE events, never the LLM — so resuming a subagent always required a separate `list_resumable_agents` lookup. That listing tool is now only a fallback.
- The change is centralized in the shared `runSubagentTurn` helper, so both tools behave identically; failure/abort/error paths are unchanged.
- Both tool descriptions document the returned id (generic wording, no other tool named, per `apps/backend/src/agent/tools/CLAUDE.md`).
- Includes the design spec and implementation plan under `docs/superpowers/`.

## Test Plan
- [x] `cd apps/backend && bun run typecheck` — clean
- [x] `cd apps/backend && bun run lint` — clean
- [x] `cd apps/backend && bun run test` — 646 tests pass (incl. updated dispatch/resume assertions + new description tests)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>