### PR TITLE
chore(backend): sync known model capacities with Copilot API

### DIFF
--- a/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
+++ b/apps/backend/src/agent-core/model-capacity/claude-capacity.ts
@@ -19,19 +19,11 @@ const DEFAULT_MAX_CONTEXT_WINDOW_TOKENS = 200_000;
  */
 const KNOWN_MODELS = new Map<string, CachedCapacity>([
   [
-    'claude-opus-4.6-1m',
+    'claude-opus-4.8',
     {
       maxContextWindowTokens: 1_000_000,
       maxPromptTokens: 936_000,
       maxOutputTokens: 64_000,
-    },
-  ],
-  [
-    'claude-opus-4.6',
-    {
-      maxContextWindowTokens: 200_000,
-      maxPromptTokens: 168_000,
-      maxOutputTokens: 32_000,
     },
   ],
   [
@@ -45,9 +37,9 @@ const KNOWN_MODELS = new Map<string, CachedCapacity>([
   [
     'claude-opus-4.7',
     {
-      maxContextWindowTokens: 200_000,
-      maxPromptTokens: 168_000,
-      maxOutputTokens: 32_000,
+      maxContextWindowTokens: 1_000_000,
+      maxPromptTokens: 936_000,
+      maxOutputTokens: 64_000,
     },
   ],
   [
@@ -55,11 +47,35 @@ const KNOWN_MODELS = new Map<string, CachedCapacity>([
     {
       maxContextWindowTokens: 200_000,
       maxPromptTokens: 168_000,
-      maxOutputTokens: 32_000,
+      maxOutputTokens: 64_000,
     },
   ],
   [
     'claude-opus-4.7-xhigh',
+    {
+      maxContextWindowTokens: 200_000,
+      maxPromptTokens: 168_000,
+      maxOutputTokens: 64_000,
+    },
+  ],
+  [
+    'claude-opus-4.6-1m',
+    {
+      maxContextWindowTokens: 1_000_000,
+      maxPromptTokens: 936_000,
+      maxOutputTokens: 64_000,
+    },
+  ],
+  [
+    'claude-opus-4.6',
+    {
+      maxContextWindowTokens: 1_000_000,
+      maxPromptTokens: 936_000,
+      maxOutputTokens: 64_000,
+    },
+  ],
+  [
+    'claude-opus-4.5',
     {
       maxContextWindowTokens: 200_000,
       maxPromptTokens: 168_000,
@@ -69,29 +85,13 @@ const KNOWN_MODELS = new Map<string, CachedCapacity>([
   [
     'claude-sonnet-4.6',
     {
-      maxContextWindowTokens: 200_000,
-      maxPromptTokens: 168_000,
-      maxOutputTokens: 32_000,
-    },
-  ],
-  [
-    'claude-sonnet-4',
-    {
-      maxContextWindowTokens: 216_000,
-      maxPromptTokens: 200_000,
-      maxOutputTokens: 16_000,
+      maxContextWindowTokens: 1_000_000,
+      maxPromptTokens: 936_000,
+      maxOutputTokens: 64_000,
     },
   ],
   [
     'claude-sonnet-4.5',
-    {
-      maxContextWindowTokens: 200_000,
-      maxPromptTokens: 168_000,
-      maxOutputTokens: 32_000,
-    },
-  ],
-  [
-    'claude-opus-4.5',
     {
       maxContextWindowTokens: 200_000,
       maxPromptTokens: 168_000,

--- a/apps/backend/src/agent-core/model-capacity/model-capacity.test.ts
+++ b/apps/backend/src/agent-core/model-capacity/model-capacity.test.ts
@@ -43,16 +43,16 @@ describe('modelCapacity', () => {
         model: 'gpt-5.5',
       });
       expect(await modelCapacity.getMaxOutputTokens(config)).toBe(128_000);
-      expect(await modelCapacity.getMaxPromptTokens(config)).toBe(272_000);
+      expect(await modelCapacity.getMaxPromptTokens(config)).toBe(922_000);
       expect(await modelCapacity.getMaxContextWindowTokens(config)).toBe(
-        400_000,
+        1_050_000,
       );
     });
 
     it('returns known output limit via openai-responses format', async () => {
       const config = makeConfig({
         apiFormat: 'openai-responses',
-        model: 'gpt-5.2-codex',
+        model: 'gpt-5.3-codex',
       });
       expect(await modelCapacity.getMaxOutputTokens(config)).toBe(128_000);
     });
@@ -88,10 +88,10 @@ describe('modelCapacity', () => {
         apiFormat: 'claude',
         model: 'claude-opus-4.7',
       });
-      expect(await modelCapacity.getMaxOutputTokens(config)).toBe(32_000);
-      expect(await modelCapacity.getMaxPromptTokens(config)).toBe(168_000);
+      expect(await modelCapacity.getMaxOutputTokens(config)).toBe(64_000);
+      expect(await modelCapacity.getMaxPromptTokens(config)).toBe(936_000);
       expect(await modelCapacity.getMaxContextWindowTokens(config)).toBe(
-        200_000,
+        1_000_000,
       );
       expect(mockRetrieve).not.toHaveBeenCalled();
     });

--- a/apps/backend/src/agent-core/model-capacity/openai-capacity.ts
+++ b/apps/backend/src/agent-core/model-capacity/openai-capacity.ts
@@ -22,51 +22,11 @@ interface KnownCapacity {
  */
 const KNOWN_MODELS = new Map<string, KnownCapacity>([
   [
-    'gpt-4o',
-    {
-      maxContextWindowTokens: 128_000,
-      maxPromptTokens: 64_000,
-      maxOutputTokens: 4_096,
-    },
-  ],
-  [
-    'gpt-4.1',
-    {
-      maxContextWindowTokens: 128_000,
-      maxPromptTokens: 128_000,
-      maxOutputTokens: 16_384,
-    },
-  ],
-  [
     'gpt-5-mini',
     {
       maxContextWindowTokens: 264_000,
       maxPromptTokens: 128_000,
       maxOutputTokens: 64_000,
-    },
-  ],
-  [
-    'gpt-5.1',
-    {
-      maxContextWindowTokens: 264_000,
-      maxPromptTokens: 128_000,
-      maxOutputTokens: 64_000,
-    },
-  ],
-  [
-    'gpt-5.2',
-    {
-      maxContextWindowTokens: 400_000,
-      maxPromptTokens: 272_000,
-      maxOutputTokens: 128_000,
-    },
-  ],
-  [
-    'gpt-5.2-codex',
-    {
-      maxContextWindowTokens: 400_000,
-      maxPromptTokens: 272_000,
-      maxOutputTokens: 128_000,
     },
   ],
   [
@@ -88,16 +48,24 @@ const KNOWN_MODELS = new Map<string, KnownCapacity>([
   [
     'gpt-5.4',
     {
-      maxContextWindowTokens: 400_000,
-      maxPromptTokens: 272_000,
+      maxContextWindowTokens: 1_050_000,
+      maxPromptTokens: 922_000,
       maxOutputTokens: 128_000,
     },
   ],
   [
     'gpt-5.5',
     {
-      maxContextWindowTokens: 400_000,
-      maxPromptTokens: 272_000,
+      maxContextWindowTokens: 1_050_000,
+      maxPromptTokens: 922_000,
+      maxOutputTokens: 128_000,
+    },
+  ],
+  [
+    'mai-code-1-flash-internal',
+    {
+      maxContextWindowTokens: 256_000,
+      maxPromptTokens: 128_000,
       maxOutputTokens: 128_000,
     },
   ],
@@ -118,10 +86,18 @@ const KNOWN_MODELS = new Map<string, KnownCapacity>([
     },
   ],
   [
+    'gemini-3.5-flash',
+    {
+      maxContextWindowTokens: 1_000_000,
+      maxPromptTokens: 936_000,
+      maxOutputTokens: 64_000,
+    },
+  ],
+  [
     'gemini-3.1-pro-preview',
     {
-      maxContextWindowTokens: 200_000,
-      maxPromptTokens: 136_000,
+      maxContextWindowTokens: 1_000_000,
+      maxPromptTokens: 936_000,
       maxOutputTokens: 64_000,
     },
   ],


### PR DESCRIPTION
## Summary
- Synced the static `KNOWN_MODELS` capacity tables against the live `/v1/models` endpoint (`http://copilot-api-server.local:4141`).
- **Claude** (`claude-capacity.ts`): bumped `claude-opus-4.6`, `claude-opus-4.7`, and `claude-sonnet-4.6` to 1M context / 936k prompt / 64k output; bumped `claude-opus-4.7-high`/`-xhigh` output to 64k; added `claude-opus-4.8`; removed `claude-sonnet-4` (no longer offered).
- **OpenAI/Gemini** (`openai-capacity.ts`): updated `gpt-5.4`/`gpt-5.5` to 1.05M / 922k / 128k; updated `gemini-3.1-pro-preview` to 1M / 936k / 64k; added `gemini-3.5-flash` and `mai-code-1-flash-internal`; removed `gpt-4o`, `gpt-4.1`, `gpt-5.1`, `gpt-5.2`, `gpt-5.2-codex` (no longer offered).
- Updated `model-capacity.test.ts` to match the new authoritative values and drop the reference to the removed `gpt-5.2-codex`.

## Notes
- The API model IDs carry a `[1m]` suffix (e.g. `claude-opus-4.8[1m]`) while these tables key by the bare `version` string. Kept the existing keying convention.

## Test plan
- [x] `bunx vitest run src/agent-core/model-capacity/` — 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)